### PR TITLE
esbuild executable bin handling to OS

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,5 +1,16 @@
 import dllLib from '../../resources/lib/zlgcan.dll?asset&asarUnpack'
-import esbuildWin from '../../resources/bin/esbuild.exe?asset&asarUnpack'
+
+let esbuild_executable: any
+
+const loadEsbuild = async () => {
+  if (process.platform === 'win32') {
+    esbuild_executable = await import('../../../resources/bin/esbuild.exe?asset&asarUnpack')
+  } else {
+    esbuild_executable = await import('../../../resources/bin/esbuild?asset&asarUnpack')
+    //<-- May change fetch from node_modules esbuild_executable = await import('esbuild/bin/esbuild?asset&asarUnpack')
+  }
+}
+
 import path from 'path'
 import { DataSet } from 'src/preload/data'
 import { compileTsc, getBuildStatus } from 'src/main/docan/uds'
@@ -20,7 +31,7 @@ export async function build(
     projectName,
     data,
     entry,
-    esbuildWin,
+    esbuild_executable,
     path.join(libPath, 'js'),
     isTest
   )

--- a/src/main/ipc/uds.ts
+++ b/src/main/ipc/uds.ts
@@ -1,6 +1,17 @@
 import { BrowserWindow, ipcMain, shell } from 'electron'
 import scriptIndex from '../../../resources/docs/.gitkeep?asset&asarUnpack'
-import esbuildWin from '../../../resources/bin/esbuild.exe?asset&asarUnpack'
+
+let esbuild_executable: any
+
+const loadEsbuild = async () => {
+  if (process.platform === 'win32') {
+    esbuild_executable = await import('../../../resources/bin/esbuild.exe?asset&asarUnpack')
+  } else {
+    esbuild_executable = await import('../../../resources/bin/esbuild?asset&asarUnpack')
+    //<-- May change fetch from node_modules esbuild_executable = await import('esbuild/bin/esbuild?asset&asarUnpack')
+  }
+}
+
 import path from 'path'
 import {
   compileTsc,
@@ -88,7 +99,7 @@ ipcMain.handle('ipc-build-project', async (event, ...arg) => {
     projectName,
     data,
     entry,
-    esbuildWin,
+    esbuild_executable,
     path.join(libPath, 'js'),
     isTest
   )


### PR DESCRIPTION
### SUMMARY

- modified `build.ts` and `uds.ts` for MacOS

```
let esbuild_executable: any

const loadEsbuild = async () => {
  if (process.platform === 'win32') {
    esbuild_executable = await import('../../../resources/bin/esbuild.exe?asset&asarUnpack')
  } else {
    esbuild_executable = await import('../../../resources/bin/esbuild?asset&asarUnpack')
    //<-- May change fetch from node_modules esbuild_executable = await import('esbuild/bin/esbuild?asset&asarUnpack')
  }
}
```

- Added esbuild executable binary to resources


System Specs:

- npm -v 11.3.0
- node -v v24.1.0
- esbuild --version 0.25.1
- MacOS Sequonia 15.5 (24F74)
- Apple Silicon M4 Pro
