### PR TITLE
Build and upload RPM package in CI workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -37,5 +37,9 @@ jobs:
         run: npm run build:linux
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact
+          name: artifact-deb
           path: dist/*.deb
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-rpm
+          path: dist/*.rpm

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,7 +41,9 @@ nsis:
   guid: 98123fde-012f-5ff3-8b50-881449dac91a
   include: build/installer.nsh
 linux:
-  target: deb
+  target:
+    - target: deb
+    - target: rpm
   icon: ./build/icon.icns
   executableName: ecubuspro
   description: EcuBus-Pro


### PR DESCRIPTION
Builds a Linux RPM package alongside the existing DEB package in the `build-linux` CI workflow. This makes it easy for users running a Linux distro that uses RPM packages (Fedora, RHEL, OpenSESE, etc.) to install and use EcuBus-Pro releases.