### PR TITLE
Fix github issue 234

### DIFF
--- a/src/main/docan/zlg/index.ts
+++ b/src/main/docan/zlg/index.ts
@@ -383,6 +383,89 @@ export class ZLG_CAN extends CanBase {
           label: 'ZCAN_USBCAN_E_MINI_INDEX_1_CHANNEL_0',
           id: 'ZCAN_USBCAN_E_MINI_INDEX_1_CHANNEL_0',
           handle: `${ZLG.ZCAN_USBCAN_E_U}_1_0`
+        },
+        //USBCAN2 (USBCAN-II)
+        {
+          label: 'ZCAN_USBCAN2_INDEX_0_CHANNEL_0',
+          id: 'ZCAN_USBCAN2_INDEX_0_CHANNEL_0',
+          handle: `${ZLG.ZCAN_USBCAN2}_0_0`
+        },
+        {
+          label: 'ZCAN_USBCAN2_INDEX_0_CHANNEL_1',
+          id: 'ZCAN_USBCAN2_INDEX_0_CHANNEL_1',
+          handle: `${ZLG.ZCAN_USBCAN2}_0_1`
+        },
+        {
+          label: 'ZCAN_USBCAN2_INDEX_1_CHANNEL_0',
+          id: 'ZCAN_USBCAN2_INDEX_1_CHANNEL_0',
+          handle: `${ZLG.ZCAN_USBCAN2}_1_0`
+        },
+        {
+          label: 'ZCAN_USBCAN2_INDEX_1_CHANNEL_1',
+          id: 'ZCAN_USBCAN2_INDEX_1_CHANNEL_1',
+          handle: `${ZLG.ZCAN_USBCAN2}_1_1`
+        },
+        //USBCAN-2E-U
+        {
+          label: 'ZCAN_USBCAN_2E_U_INDEX_0_CHANNEL_0',
+          id: 'ZCAN_USBCAN_2E_U_INDEX_0_CHANNEL_0',
+          handle: `${ZLG.ZCAN_USBCAN_2E_U}_0_0`
+        },
+        {
+          label: 'ZCAN_USBCAN_2E_U_INDEX_0_CHANNEL_1',
+          id: 'ZCAN_USBCAN_2E_U_INDEX_0_CHANNEL_1',
+          handle: `${ZLG.ZCAN_USBCAN_2E_U}_0_1`
+        },
+        {
+          label: 'ZCAN_USBCAN_2E_U_INDEX_1_CHANNEL_0',
+          id: 'ZCAN_USBCAN_2E_U_INDEX_1_CHANNEL_0',
+          handle: `${ZLG.ZCAN_USBCAN_2E_U}_1_0`
+        },
+        {
+          label: 'ZCAN_USBCAN_2E_U_INDEX_1_CHANNEL_1',
+          id: 'ZCAN_USBCAN_2E_U_INDEX_1_CHANNEL_1',
+          handle: `${ZLG.ZCAN_USBCAN_2E_U}_1_1`
+        },
+        //USBCANFD-400U
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_0',
+          id: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_0',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_0_0`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_1',
+          id: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_1',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_0_1`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_2',
+          id: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_2',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_0_2`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_3',
+          id: 'ZCAN_USBCANFD_400U_INDEX_0_CHANNEL_3',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_0_3`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_0',
+          id: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_0',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_1_0`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_1',
+          id: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_1',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_1_1`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_2',
+          id: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_2',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_1_2`
+        },
+        {
+          label: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_3',
+          id: 'ZCAN_USBCANFD_400U_INDEX_1_CHANNEL_3',
+          handle: `${ZLG.ZCAN_USBCANFD_400U}_1_3`
         }
       ]
       return zcanArray

--- a/test/docan/zlg.test.ts
+++ b/test/docan/zlg.test.ts
@@ -15,6 +15,29 @@ import { CanTp } from 'src/main/docan/cantp'
 const dllPath = path.join(__dirname, '../../resources/lib')
 ZLG_CAN.loadDllPath(dllPath)
 
+describe('zlg device availability test', () => {
+  test('should include USBCANFD-400U devices', () => {
+    const devices = ZLG_CAN.getValidDevices()
+    const usbcanfd400u = devices.filter((d) => d.label.includes('USBCANFD_400U'))
+    // USBCANFD-400U has 4 channels × 2 device indexes = 8 devices
+    equal(usbcanfd400u.length, 8, 'USBCANFD-400U should have 8 device entries (4 channels × 2 indexes)')
+  })
+
+  test('should include USBCAN2 (USBCAN-II) devices', () => {
+    const devices = ZLG_CAN.getValidDevices()
+    const usbcan2 = devices.filter((d) => d.label.includes('USBCAN2'))
+    // USBCAN2 has 2 channels × 2 device indexes = 4 devices
+    equal(usbcan2.length, 4, 'USBCAN2 should have 4 device entries (2 channels × 2 indexes)')
+  })
+
+  test('should include USBCAN-2E-U devices', () => {
+    const devices = ZLG_CAN.getValidDevices()
+    const usbcan2eu = devices.filter((d) => d.label.includes('USBCAN_2E_U'))
+    // USBCAN-2E-U has 2 channels × 2 device indexes = 4 devices
+    equal(usbcan2eu.length, 4, 'USBCAN-2E-U should have 4 device entries (2 channels × 2 indexes)')
+  })
+})
+
 describe('zlg test', () => {
   let client!: ZLG_CAN
   beforeAll(() => {


### PR DESCRIPTION
Add support for ZLG CAN adapters USBCANFD-400U, USBCAN-II, and USBCAN-2E-U to fix #234.

---
<a href="https://cursor.com/background-agent?bcId=bc-c98bc5ad-400e-4357-99f1-2b62424f3973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c98bc5ad-400e-4357-99f1-2b62424f3973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ZLG device definitions for USBCANFD-400U, USBCAN-II, and USBCAN-2E-U and tests validating their presence in device discovery.
> 
> - **ZLG device discovery (`src/main/docan/zlg/index.ts`)**:
>   - Extend `getValidDevices()` with entries for:
>     - `USBCANFD_400U` (indexes 0–1, channels 0–3).
>     - `USBCAN2` (indexes 0–1, channels 0–1).
>     - `USBCAN_2E_U` (indexes 0–1, channels 0–1).
> - **Tests (`test/docan/zlg.test.ts`)**:
>   - Add availability tests asserting counts for `USBCANFD_400U` (8), `USBCAN2` (4), and `USBCAN_2E_U` (4).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d4f2b1756048836899f38f427e58b831450a28d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->