### PR TITLE
Fix github issue 236

### DIFF
--- a/src/renderer/src/stores/project.ts
+++ b/src/renderer/src/stores/project.ts
@@ -144,7 +144,7 @@ export const useProjectStore = defineStore('project', {
       {
         const r = await window.electron.ipcRenderer.invoke('ipc-show-open-dialog', {
           title: 'Open Project',
-          properties: ['openFile '],
+          properties: ['openFile'],
           filters: [{ name: 'EcuBus-Pro', extensions: ['ecb'] }]
         })
         const file = r.filePaths[0]

--- a/src/renderer/src/views/uds/uds.vue
+++ b/src/renderer/src/views/uds/uds.vue
@@ -1217,7 +1217,7 @@ async function openDatabase(testerIndex: string) {
     const type = testerIndex.split('add')[1].toLocaleLowerCase()
     const r = await window.electron.ipcRenderer.invoke('ipc-show-open-dialog', {
       title: 'Open Database File',
-      properties: ['openFile '],
+      properties: ['openFile'],
       filters: [{ name: `Database File`, extensions: [fileExtMap[type]] }]
     })
     const file = r.filePaths[0]


### PR DESCRIPTION
Fix file dialogs on MacOS by removing a trailing space from the `openFile` property.

The `showOpenDialog` function on MacOS failed to open file dialogs due to an invalid `'openFile '` property (with a trailing space), preventing users from selecting database and project files.

---
<a href="https://cursor.com/background-agent?bcId=bc-7132f86e-4000-4923-8f81-e5681057b219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7132f86e-4000-4923-8f81-e5681057b219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

