### PR TITLE
Fix RPM package path in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.build-windows.outputs.upload_url }}
-          asset_path: ./dist/ecubuspro-${{ env.VERSION }}_x86_64.rpm
+          asset_path: ./dist/ecubuspro-${{ env.VERSION }}.x86_64.rpm
           asset_name: EcuBus-Pro_${{ env.VERSION }}_x86_64.rpm
           asset_content_type: application/x-rpm


### PR DESCRIPTION
Fixes the path of the RPM package created in the `release` workflow in #252. I'm not able to test your exact release process on my fork but I believe this should now work.