### PR TITLE
candle: fix SentCnt under-counting under high CPU load

### DIFF
--- a/src/main/docan/base.ts
+++ b/src/main/docan/base.ts
@@ -31,7 +31,7 @@ export abstract class CanBase {
   > = {}
   txPendingNode?: NodeClass
   // Bus loading statistics
-  private busLoadingStats = {
+  protected busLoadingStats = {
     startTime: 0,
     totalBits: 0,
     lastBits: 0,
@@ -140,10 +140,13 @@ export abstract class CanBase {
   protected busloadCb = this.updateBusLoadingWithFrame.bind(this)
   updateBusLoadingWithFrame(msg: CanMessage) {
     // 统计发送/接收帧
-    if (msg.dir === 'OUT') {
-      this.busLoadingStats.sentFrames++
-    } else if (msg.dir === 'IN') {
-      this.busLoadingStats.recvFrames++
+    // noCount=true 表示调用方已在发送时直接计数，此处跳过避免重复计数
+    if (!msg.noCount) {
+      if (msg.dir === 'OUT') {
+        this.busLoadingStats.sentFrames++
+      } else if (msg.dir === 'IN') {
+        this.busLoadingStats.recvFrames++
+      }
     }
 
     // 计算不同阶段的位数量

--- a/src/main/docan/candle/index.ts
+++ b/src/main/docan/candle/index.ts
@@ -357,6 +357,9 @@ export class Candle_CAN extends CanBase {
             this.pendingBaseCmds.delete(cmdId)
           }
 
+          // Log with firmware hardware timestamp.
+          // noCount=true: sentFrames was already counted in _writeBase at send time
+          // to avoid depending on TSFN callback reliability under high CPU load.
           const message: CanMessage = {
             device: this.info.name,
             dir: 'OUT',
@@ -365,7 +368,8 @@ export class Candle_CAN extends CanBase {
             ts: msg.TimeStamp,
             msgType: msgType,
             database: item.extra?.database,
-            name: item.extra?.name
+            name: item.extra?.name,
+            noCount: true
           }
           this.log.canBase(message)
           this.event.emit(cmdId, message)
@@ -677,6 +681,12 @@ export class Candle_CAN extends CanBase {
         frame.flags = falg
 
         Candle.SendCANMsg(this.id, this.channel, frame)
+        // Increment sentFrames immediately after USB write succeeds.
+        // Do NOT rely on echo callback — TSFN can drop/delay frames under
+        // high CPU load, causing SentCnt to under-count.
+        // The echo callback still calls log.canBase (with noCount:true)
+        // to write trace with firmware hardware timestamp.
+        this.busLoadingStats.sentFrames++
       } catch (err: any) {
         const items = this.pendingBaseCmds.get(cmdId)
         if (items && items.length > 0) {

--- a/src/main/share/can.ts
+++ b/src/main/share/can.ts
@@ -227,6 +227,12 @@ export type CanMessage<T = any> = {
   ts?: number
 
   /**
+   * If true, updateBusLoadingWithFrame will skip frame counting (sent/recv).
+   * Used to prevent double-counting when sentFrames is already counted at send time.
+   */
+  noCount?: boolean
+
+  /**
    * The identifier of the CAN message.
    */
   id: number


### PR DESCRIPTION
Under high CPU pressure the JS event loop may be backlogged, causing TSFN (ThreadSafeFunction) echo callbacks to be delayed or dropped silently. Because sentFrames++ previously lived inside the echo callback, SentCnt would be under-reported compared to what the firmware / PCAN actually sent.

Changes:
- candle/index.ts: move `sentFrames++` to immediately after `SendCANMsg` succeeds (synchronous USB write, always reliable); echo callback sets `noCount: true` so the trace log still carries the firmware HW timestamp without triggering a second count
- base.ts: add `noCount` guard in `updateBusLoadingWithFrame`; change `busLoadingStats` from `private` to `protected` so subclasses can access it
- can.ts: add optional `noCount?: boolean` field to `CanMessage` type