### PR TITLE
fix(cdd): resolve Python imports when parsing CDD as a subprocess

### DIFF
--- a/resources/cdd/cddparse.py
+++ b/resources/cdd/cddparse.py
@@ -1,10 +1,15 @@
 import json
 import sys
+from pathlib import Path
 
-try:
-    from .cdd_tester_parser import CddParse
-except ImportError:
-    from cdd_tester_parser import CddParse
+# When launched as `python cddparse.py`, this file is not part of a package, so
+# relative imports fail and sibling modules are not on sys.path. Ensure the
+# directory containing the CDD Python sources is importable.
+_cdd_dir = str(Path(__file__).resolve().parent)
+if _cdd_dir not in sys.path:
+    sys.path.insert(0, _cdd_dir)
+
+from cdd_tester_parser import CddParse
 
 
 def parseTesterInfo(file_path):

--- a/src/main/ipc/cdd.ts
+++ b/src/main/ipc/cdd.ts
@@ -21,7 +21,9 @@ async function runCddParse(
     args.push('--parseResp')
   }
 
-  const result = await execBinary(pythonPath, args)
+  const result = await execBinary(pythonPath, args, {
+    cwd: path.dirname(cddPyFile)
+  })
 
   try {
     if (result.success) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CDD parsing failed on Windows when Electron invoked `cddparse.py` as a standalone script: relative imports raised `ImportError`, and the fallback `from cdd_tester_parser import ...` failed because `resources/cdd` was not on `sys.path`.

## Changes

- **`resources/cdd/cddparse.py`**: Insert the directory containing the CDD Python sources at the front of `sys.path` before importing `cdd_tester_parser`, so sibling modules (`cdd_parser_base`, `cdd_shared`, etc.) always resolve when the script is run via `python /path/to/cddparse.py`.
- **`src/main/ipc/cdd.ts`**: Run the Python subprocess with `cwd` set to the CDD resources folder for consistent behavior with any relative paths.

## Verification

- Ran `python3 /workspace/resources/cdd/cddparse.py parseTesterInfo ...` from a different working directory; imports succeed (parser runs until the expected file error for a missing CDD).
- `npm run typecheck` passes locally after installing dependencies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-352d33e9-4db8-46e6-a688-e1d21aa65d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-352d33e9-4db8-46e6-a688-e1d21aa65d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

