### PR TITLE
Add DOIP tester-present support

### DIFF
--- a/src/main/ipc/uds.ts
+++ b/src/main/ipc/uds.ts
@@ -298,6 +298,62 @@ let cantps: {
   close: () => void
 }[] = []
 let doips: DOIP[] = []
+const doipTesterPresentMap = new Map<
+  string,
+  {
+    enable: boolean
+    timer?: NodeJS.Timeout
+    action: () => Promise<void>
+    schedule: () => void
+  }
+>()
+
+function getDoipTesterPresentKey(testerId: string, deviceId: string, addrIndex: number) {
+  return `${testerId}:${deviceId}:${addrIndex}`
+}
+
+function setupDoipTesterPresent(
+  doip: DOIP,
+  tester: TesterInfo,
+  addrIndex: number,
+  addr: EthAddr,
+  data: Buffer
+) {
+  const key = getDoipTesterPresentKey(tester.id, doip.base.id, addrIndex)
+  const old = doipTesterPresentMap.get(key)
+  if (old?.timer) {
+    clearTimeout(old.timer)
+  }
+  const item = {
+    enable: true,
+    timer: undefined as NodeJS.Timeout | undefined,
+    action: async () => {
+      const client = await doip.createClient(addr)
+      await doip.writeTpReq(client, data, addr.entity.logicalAddr)
+    },
+    schedule: () => {
+      const current = doipTesterPresentMap.get(key)
+      if (!current || !current.enable) {
+        return
+      }
+      current.timer = setTimeout(() => {
+        const latest = doipTesterPresentMap.get(key)
+        if (!latest || !latest.enable) {
+          return
+        }
+        latest.action()
+          .catch((err: any) => {
+            sysLog.warn(`doip tester present failed: ${err?.message || err?.toString?.() || err}`)
+          })
+          .finally(() => {
+            latest.schedule()
+          })
+      }, tester.udsTime.s3Time)
+    }
+  }
+  doipTesterPresentMap.set(key, item)
+  item.schedule()
+}
 
 function getDeviceSymbol(data: UdsDevice) {
   let vendor
@@ -546,6 +602,22 @@ async function globalStart(data: DataSet, projectInfo: { path: string; name: str
       for (const val of ethBaseMap.values()) {
         const doip = new DOIP(val, tester, projectInfo.path)
         doips.push(doip)
+        if (tester.udsTime.testerPresentEnable && tester.udsTime.testerPresentAddrIndex != undefined) {
+          const tpAddrIndex = tester.udsTime.testerPresentAddrIndex
+          const tpAddr = tester.address[tpAddrIndex]
+          if (tpAddr?.type == 'eth' && tpAddr.ethAddr) {
+            let tpData = Buffer.from([0x3e, 0x00])
+            if (tester.udsTime.testerPresentSpecialService) {
+              const service = tester.allServiceList['0x3E']?.find(
+                (e) => e.id == tester.udsTime.testerPresentSpecialService
+              )
+              if (service) {
+                tpData = getTxPdu(service)
+              }
+            }
+            setupDoipTesterPresent(doip, tester, tpAddrIndex, tpAddr.ethAddr, tpData)
+          }
+        }
 
         for (const addr of tester.address) {
           if (addr.type == 'eth' && addr.ethAddr) {
@@ -828,6 +900,35 @@ ipcMain.handle('ipc-switch-tester-present', async (event, ...arg) => {
           }
         }
       }
+    } else if (addr && addr.ethAddr) {
+      for (const doip of doips) {
+        if (doip.base.id == tester.targetDeviceId) {
+          const key = getDoipTesterPresentKey(
+            tester.id,
+            doip.base.id,
+            tester.udsTime.testerPresentAddrIndex
+          )
+          const item = doipTesterPresentMap.get(key)
+          if (item) {
+            item.enable = enable
+            if (item.timer) {
+              clearTimeout(item.timer)
+              item.timer = undefined
+            }
+            if (enable) {
+              item.action()
+                .catch((err: any) => {
+                  sysLog.warn(
+                    `doip tester present failed: ${err?.message || err?.toString?.() || err}`
+                  )
+                })
+                .finally(() => {
+                  item.schedule()
+                })
+            }
+          }
+        }
+      }
     }
   }
 })
@@ -947,6 +1048,12 @@ export function globalStop(emit = false) {
     value.close()
   })
   doips = []
+  doipTesterPresentMap.forEach((value) => {
+    if (value.timer) {
+      clearTimeout(value.timer)
+    }
+  })
+  doipTesterPresentMap.clear()
 
   someipMap.forEach((e) => {
     e.stop()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add DOIP tester-present scheduling/state management in `src/main/ipc/uds.ts`
- initialize DOIP tester-present when ETH testers start, reusing configured S3 interval and optional special 0x3E service payload
- support runtime toggle via `ipc-switch-tester-present` for DOIP testers, matching CAN behavior
- clean up all DOIP tester-present timers during global stop

## Notes
- no PR template file exists in this repository
- attempted `npm run typecheck`, but environment is missing `tsgo` (`sh: 1: tsgo: not found`), so full typecheck could not be completed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f501bcb-0d9e-4e9b-8af7-576dc4482059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f501bcb-0d9e-4e9b-8af7-576dc4482059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

