### PR TITLE
[fix]: add missing 'src' path alias for renderer imports

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
   renderer: {
     resolve: {
       alias: {
+        src: resolve(__dirname, 'src'),
         '@r': resolve('src/renderer/src'),
         nodeCan: resolve(__dirname, 'src/main/share')
       }


### PR DESCRIPTION
## Problem

PR #347 introduced `src/preload/data` and `src/preload/plugin` import paths in renderer code (22 files) but missed adding the corresponding Vite alias configuration.

This causes build failures:
```
Error: The following dependencies are imported but could not be resolved:
  src/preload/data
  src/preload/plugin
```

## Fix

Add `src` path alias to `electron.vite.config.ts` renderer resolve config, mapping `src` to the project root `src/` directory.