### PR TITLE
fix: remove redundant scrollbar in trace window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,10 @@ Tests live under `test/` and run with Vitest.
 
 i18next-based. App translations in `resources/locales/<lang>/translation.json`. Plugin translations loaded from `locales/<lang>/translation.json` and merged via IPC.
 
+## Git Commit Rules
+
+- Do NOT add `Co-authored-by` trailers to commit messages.
+
 ## MCP Servers
 
 Workspace MCP config in `.vscode/mcp.json`. The `playwright` server (`npx -y @playwright/mcp@latest`) is useful for browser-based UI exploration when dev server is running.

--- a/src/renderer/src/views/uds/trace.vue
+++ b/src/renderer/src/views/uds/trace.vue
@@ -1196,7 +1196,7 @@ const detailPanelMinHeight = 120
 const detailPanelDefaultHeight = 200
 
 const tableHeight = computed(() => {
-  return props.height - 30 - detailPanelHeight.value - (detailPanelHeight.value > 0 ? 4 : 0)
+  return props.height - 30 - detailPanelHeight.value - (detailPanelHeight.value > 0 ? 8 : 0)
 })
 const tableWidth = computed(() => {
   return props.width


### PR DESCRIPTION
Add overflow: hidden and height: 100% to trace component root div to prevent the parent container's overflow: auto from showing a duplicate vertical scrollbar alongside EVirtTable's own scrollbar.