### PR TITLE
feat: add LIN support to trace viewer and replay config UI

### DIFF
--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -2352,7 +2352,8 @@
         },
         "channelMap": {
           "hint": "Map log file channels to connected devices. One channel can send to multiple devices.",
-          "logChannel": "Log Channel",
+          "busType": "Bus",
+          "logChannel": "Channel",
           "channel": "Channel",
           "arrow": "",
           "targetDevice": "Target Device",

--- a/src/renderer/src/database/ldf/node.vue
+++ b/src/renderer/src/database/ldf/node.vue
@@ -163,15 +163,14 @@ const rules: FormRules<NodeAttrDef> = {
   ],
   initial_NAD: [
     {
-      required: true,
+      required: false,
       type: 'number',
       validator: (rule: any, value: number | undefined, callback: any) => {
-        if (typeof value === 'string') {
-          //报错
-          callback(new Error(i18next.t('database.ldf.node.validation.pleaseEnterInitialNad')))
+        if (value === undefined) {
+          callback()
           return
         }
-        if (value === undefined) {
+        if (typeof value === 'string') {
           callback(new Error(i18next.t('database.ldf.node.validation.pleaseEnterInitialNad')))
           return
         }

--- a/src/renderer/src/database/ldfParse.ts
+++ b/src/renderer/src/database/ldfParse.ts
@@ -1167,7 +1167,7 @@ class LdfParser extends CstParser {
     this.SUBRULE(this.version)
     this.SUBRULE(this.llversion)
     this.SUBRULE(this.speed)
-    this.OPTION(this.channel)
+    this.OPTION(() => this.SUBRULE(this.channel))
     this.MANY({
       DEF: () => {
         this.OR([

--- a/src/renderer/src/views/uds/network/replayConfig.vue
+++ b/src/renderer/src/views/uds/network/replayConfig.vue
@@ -160,25 +160,42 @@
 
           <el-table :data="channelMapData" size="small" style="width: 100%">
             <el-table-column
+              prop="busType"
+              :label="i18next.t('uds.network.replayConfig.channelMap.busType')"
+              width="90"
+            >
+              <template #default="{ row, $index }">
+                <el-select
+                  v-model="row.busType"
+                  size="small"
+                  :disabled="globalStart"
+                  @change="onBusTypeChange($index, row)"
+                >
+                  <el-option label="CAN" value="can" />
+                  <el-option label="LIN" value="lin" />
+                </el-select>
+              </template>
+            </el-table-column>
+            <el-table-column
               prop="logChannel"
               :label="i18next.t('uds.network.replayConfig.channelMap.logChannel')"
-              width="140"
+              width="120"
             >
               <template #default="{ row, $index }">
                 <el-input-number
-                  v-model="row.logChannel"
+                  v-model="row.displayChannel"
                   :min="1"
                   :controls="true"
                   :disabled="globalStart"
                   size="small"
                   style="width: 100%"
-                  @change="onLogChannelChange($index, row)"
+                  @change="onDisplayChannelChange($index, row)"
                 />
               </template>
             </el-table-column>
             <el-table-column
               :label="i18next.t('uds.network.replayConfig.channelMap.arrow')"
-              width="60"
+              width="50"
               align="center"
             >
               <template #default>
@@ -198,10 +215,10 @@
                   :disabled="globalStart"
                   collapse-tags
                   collapse-tags-tooltip
-                  @change="updateChannelMap($index, row.logChannel, $event)"
+                  @change="updateChannelMap($index, row)"
                 >
                   <el-option
-                    v-for="device in assignedDevices"
+                    v-for="device in getDevicesForBusType(row.busType)"
                     :key="device.key"
                     :label="device.label"
                     :value="device.key"
@@ -397,7 +414,25 @@ const allDevices = computed(() => {
   return dd
 })
 
-// Channel mapping - only show assigned devices
+// Channel mapping - show devices filtered by bus type
+const getDevicesForBusType = (busType: 'can' | 'lin') => {
+  const dd: Option[] = []
+  for (const deviceId of formData.value.channel) {
+    if (allDevices.value[deviceId]) {
+      const deviceType = dataBase.devices[deviceId]?.type
+      if (deviceType === busType) {
+        dd.push({
+          key: deviceId,
+          label: allDevices.value[deviceId].name,
+          disabled: false
+        })
+      }
+    }
+  }
+  return dd
+}
+
+// Also keep assignedDevices for backward compatibility
 const assignedDevices = computed(() => {
   const dd: Option[] = []
   for (const deviceId of formData.value.channel) {
@@ -412,25 +447,50 @@ const assignedDevices = computed(() => {
   return dd
 })
 
+// Internal channel map row with display-friendly fields
+type ChannelMapRow = ReplayChannelMap & {
+  displayChannel: number
+}
+
 // Channel map data for the table
-const channelMapData = ref<ReplayChannelMap[]>([])
+const channelMapData = ref<ChannelMapRow[]>([])
+
+// Convert logChannel to display: LIN channels subtract 100
+function toDisplayChannel(logChannel: number, busType?: 'can' | 'lin'): number {
+  if (busType === 'lin') return logChannel - 100
+  if (!busType && logChannel >= 100) return logChannel - 100
+  return logChannel
+}
+
+// Convert display channel back to logChannel
+function toLogChannel(displayChannel: number, busType: 'can' | 'lin'): number {
+  return busType === 'lin' ? displayChannel + 100 : displayChannel
+}
 
 // Initialize channel map from formData
 if (formData.value.channelMap && formData.value.channelMap.length > 0) {
-  channelMapData.value = cloneDeep(formData.value.channelMap)
+  channelMapData.value = formData.value.channelMap.map((m) => ({
+    ...cloneDeep(m),
+    busType: m.busType || (m.logChannel >= 100 ? 'lin' : 'can'),
+    displayChannel: toDisplayChannel(m.logChannel, m.busType)
+  }))
 } else {
-  // Default: add channel 1 mapping (logChannel must start from 1)
-  channelMapData.value = [{ logChannel: 1, deviceIds: [] }]
+  channelMapData.value = [{ logChannel: 1, deviceIds: [], busType: 'can', displayChannel: 1 }]
 }
 
-// Add a new channel mapping row (logChannel starts from 1)
+// Add a new channel mapping row
 const addChannelMapping = () => {
   const existingChannels = channelMapData.value.map((m) => m.logChannel)
   let nextChannel = 1
   while (existingChannels.includes(nextChannel)) {
     nextChannel++
   }
-  channelMapData.value.push({ logChannel: nextChannel, deviceIds: [] })
+  channelMapData.value.push({
+    logChannel: nextChannel,
+    deviceIds: [],
+    busType: 'can',
+    displayChannel: nextChannel
+  })
 }
 
 // Remove a channel mapping row
@@ -438,13 +498,24 @@ const removeChannelMapping = (index: number) => {
   channelMapData.value.splice(index, 1)
 }
 
-// Update channel mapping
-const updateChannelMap = (index: number, logChannel: number, deviceIds: string[]) => {
-  channelMapData.value[index] = { logChannel, deviceIds }
+// When bus type changes, recalculate logChannel and clear incompatible devices
+const onBusTypeChange = (index: number, row: ChannelMapRow) => {
+  row.logChannel = toLogChannel(row.displayChannel, row.busType as 'can' | 'lin')
+  // Clear devices that don't match the new bus type
+  row.deviceIds = row.deviceIds.filter((id) => {
+    const deviceType = dataBase.devices[id]?.type
+    return deviceType === row.busType
+  })
 }
 
-const onLogChannelChange = (index: number, row: ReplayChannelMap) => {
-  updateChannelMap(index, row.logChannel, row.deviceIds)
+// When display channel changes
+const onDisplayChannelChange = (index: number, row: ChannelMapRow) => {
+  row.logChannel = toLogChannel(row.displayChannel, (row.busType || 'can') as 'can' | 'lin')
+}
+
+// Update channel mapping
+const updateChannelMap = (index: number, row: ChannelMapRow) => {
+  row.logChannel = toLogChannel(row.displayChannel, (row.busType || 'can') as 'can' | 'lin')
 }
 
 const ruleFormRef = ref<FormInstance>()
@@ -466,8 +537,10 @@ const handleConfirm = async () => {
 
   await ruleFormRef.value.validate((valid, fields) => {
     if (valid) {
-      // Save channel map (filter out empty device mappings)
-      formData.value.channelMap = channelMapData.value.filter((m) => m.deviceIds.length > 0)
+      // Save channel map (filter out empty device mappings, strip displayChannel)
+      formData.value.channelMap = channelMapData.value
+        .filter((m) => m.deviceIds.length > 0)
+        .map(({ displayChannel, ...rest }) => ({ ...rest }))
 
       dataBase.replays[editIndex.value] = cloneDeep(formData.value)
       const ceil = getReplayCeil()

--- a/src/renderer/src/views/uds/trace.vue
+++ b/src/renderer/src/views/uds/trace.vue
@@ -277,7 +277,7 @@
           v-model="traceFileJumpPage"
           size="small"
           :min="1"
-          :max="traceFileTotalPages"
+          :max="Math.max(1, traceFileTotalPages)"
           controls-position="right"
           style="width: 80px"
           @keyup.enter="traceFileGoJump"
@@ -371,7 +371,9 @@
     >
       <el-table :data="channelMapTemp" size="small" style="width: 100%">
         <el-table-column label="Log Channel" width="120" align="center">
-          <template #default="{ row }"> CH{{ row.logChannel }} </template>
+          <template #default="{ row }">
+            {{ row.logChannel >= 100 ? `Lin ${row.logChannel - 100}` : `CH${row.logChannel}` }}
+          </template>
         </el-table-column>
         <el-table-column label="→" width="50" align="center">
           <template #default>→</template>
@@ -386,7 +388,7 @@
               style="width: 100%"
             >
               <el-option
-                v-for="dev in canDeviceOptions"
+                v-for="dev in getDeviceOptionsForChannel(row.logChannel)"
                 :key="dev.key"
                 :label="dev.label"
                 :value="dev.key"
@@ -428,6 +430,7 @@ import {
   getDlcByLen
 } from 'nodeCan/can'
 import { writeMessageData } from '@r/database/dbc/calc'
+import type { LDF, Frame } from '@r/database/ldfParse'
 import { Icon } from '@iconify/vue'
 import circlePlusFilled from '@iconify/icons-material-symbols/scan-delete-outline'
 import email from '@iconify/icons-material-symbols/mark-email-unread-outline-rounded'
@@ -479,6 +482,7 @@ interface LogData {
   len?: number
   device: string
   channel: string
+  bus?: string
   msgType: string
   method: string
   name?: string
@@ -687,6 +691,9 @@ function data2str(data: Uint8Array) {
 }
 function CanMsgType2Str(msgType: CanMsgType) {
   let str = ''
+  if ((msgType.idType as string) === 'LIN') {
+    return 'LIN'
+  }
   if (msgType.canfd) {
     str += 'CANFD '
   }
@@ -882,6 +889,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
       continue
     if (val.message.method == 'canBase') {
       const canData = val.message.data
+      const canBusStr = devNameToBusStr.value.get(val.instance) || val.instance
       insertData({
         method: val.message.method,
         dir: canData.dir == 'OUT' ? 'Tx' : 'Rx',
@@ -892,6 +900,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
         len: canData.data.length,
         device: val.label,
         channel: val.instance,
+        bus: canBusStr,
         msgType: CanMsgType2Str(canData.msgType),
         name: canData.name,
         absTimeStr: canData.absTimeStr,
@@ -917,6 +926,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
         name: val.message.data.name
       })
     } else if (val.message.method == 'linBase') {
+      const linBusStr = devNameToBusStr.value.get(val.instance) || val.instance
       insertData({
         method: val.message.method,
         dir: val.message.data.direction == LinDirection.SEND ? 'Tx' : 'Rx',
@@ -926,6 +936,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
         len: val.message.data.data.length,
         device: val.label,
         channel: val.instance,
+        bus: linBusStr,
         msgType: `LIN ${val.message.data.checksumType}`,
         dlc: val.message.data.data.length,
         name: val.message.data.name,
@@ -998,6 +1009,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
         msgType: i18next.t('uds.trace.messageTypes.canError')
       })
     } else if (val.message.method == 'linError') {
+      const linBusStr = devNameToBusStr.value.get(val.instance) || val.instance
       if (val.message.data.data) {
         let method = 'linError'
         if (val.message.data.data?.isEvent || val.message.data.data?.frameId == 0x3d) {
@@ -1014,6 +1026,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
           dir: val.message.data.data.direction == LinDirection.SEND ? 'Tx' : 'Rx',
           device: val.label,
           channel: val.instance,
+          bus: linBusStr,
           msgType: i18next.t('uds.trace.messageTypes.linError')
         })
       } else {
@@ -1026,10 +1039,12 @@ function logDisplay({ values }: { values: LogItem[] }) {
           len: 0,
           device: val.label,
           channel: val.instance,
+          bus: linBusStr,
           msgType: i18next.t('uds.trace.messageTypes.linError')
         })
       }
     } else if (val.message.method == 'linEvent') {
+      const linBusStr = devNameToBusStr.value.get(val.instance) || val.instance
       insertData({
         method: val.message.method,
         name: '',
@@ -1039,6 +1054,7 @@ function logDisplay({ values }: { values: LogItem[] }) {
         len: 0,
         device: val.label,
         channel: val.instance,
+        bus: linBusStr,
         msgType: i18next.t('uds.trace.messageTypes.linEvent')
       })
     } else if (val.message.method == 'udsScript') {
@@ -1238,6 +1254,7 @@ function decodeSelectedRow(row: LogData) {
     { label: '#', value: String(row.seqIndex ?? '') },
     { label: 'Time(s)', value: (row.ts / 1000000).toFixed(6) },
     { label: 'Direction', value: row.dir ?? '--' },
+    { label: 'Bus', value: row.bus || '' },
     { label: 'Channel', value: row.channel },
     { label: 'Device', value: row.device },
     { label: 'ID', value: row.id },
@@ -1294,7 +1311,88 @@ function decodeSelectedRow(row: LogData) {
     }
   }
 
-  // Fallback: use live signal data from children if DBC decoding didn't produce signals
+  // Try LDF decoding for LIN frames
+  if (row.method === 'linBase' && channelDbcMapCache) {
+    const chNum = row.channel.startsWith('Lin ')
+      ? parseInt(row.channel.replace('Lin ', ''), 10) + 100
+      : parseInt(row.channel.replace('CH', ''), 10)
+    const chDbc = channelDbcMapCache.get(chNum)
+    if (chDbc && chDbc.db && chDbc.db.frames) {
+      const frameId = parseInt(row.id, 16)
+      const ldfDb = chDbc.db as LDF
+      const ldfFrame = Object.values(ldfDb.frames).find((f) => (f as Frame).id === frameId) as
+        | Frame
+        | undefined
+      if (ldfFrame) {
+        msgName = ldfFrame.name
+        // Build reverse map: signalName → encodingTypeName
+        const sigToEncoding: Record<string, string> = {}
+        if (ldfDb.signalRep) {
+          for (const [encName, sigNames] of Object.entries(ldfDb.signalRep)) {
+            for (const sn of sigNames) {
+              sigToEncoding[sn] = encName
+            }
+          }
+        }
+        for (const sigRef of ldfFrame.signals) {
+          const sigDef = ldfDb.signals[sigRef.name]
+          if (!sigDef) continue
+          const bitOffset = sigRef.offset
+          const bitLength = sigDef.signalSizeBits
+          // Read raw value (LIN is always little-endian)
+          let rawValue = 0
+          let startByte = Math.floor(bitOffset / 8)
+          let startBitInByte = bitOffset % 8
+          let remaining = bitLength
+          let valueIndex = 0
+          while (remaining > 0 && startByte < dataBytes.length) {
+            const bits = Math.min(8 - startBitInByte, remaining)
+            const mask = (1 << bits) - 1
+            const v = (dataBytes[startByte] >> startBitInByte) & mask
+            rawValue |= v << valueIndex
+            remaining -= bits
+            valueIndex += bits
+            startByte++
+            startBitInByte = 0
+          }
+          // Apply encoding type for physical value
+          let physValue: string | number = rawValue
+          let unit = ''
+          let enumLabel = ''
+          const encName = sigToEncoding[sigRef.name]
+          if (encName && ldfDb.signalEncodeTypes[encName]) {
+            const enc = ldfDb.signalEncodeTypes[encName]
+            for (const et of enc.encodingTypes) {
+              if (et.type === 'physicalValue' && et.physicalValue) {
+                const pv = et.physicalValue
+                if (rawValue >= pv.minValue && rawValue <= pv.maxValue) {
+                  physValue = rawValue * pv.scale + pv.offset
+                  unit = pv.textInfo || ''
+                  break
+                }
+              } else if (et.type === 'logicalValue' && et.logicalValue) {
+                if (rawValue === et.logicalValue.signalValue) {
+                  enumLabel = et.logicalValue.textInfo || ''
+                  physValue = enumLabel || rawValue
+                  break
+                }
+              }
+            }
+          }
+          signals.push({
+            name: sigRef.name,
+            value: rawValue,
+            physValue,
+            unit,
+            rawHex: '0x' + rawValue.toString(16).toUpperCase(),
+            bitPos: `[${bitOffset}|${bitLength}] LE`,
+            comment: '',
+            enumLabel
+          })
+        }
+      }
+    }
+  }
   if (signals.length === 0 && row.children && row.children.length > 0) {
     for (const child of row.children) {
       const match = child.data?.match(/PHY:(.*?)\s+RAW:(.*)/)
@@ -1610,16 +1708,77 @@ const canDeviceOptions = computed(() => {
   return opts
 })
 
+const linDeviceOptions = computed(() => {
+  const opts: { key: string; label: string }[] = []
+  for (const [id, dev] of Object.entries(database.devices)) {
+    if (dev.type === 'lin' && dev.linDevice) {
+      opts.push({ key: id, label: dev.linDevice.name })
+    }
+  }
+  return opts
+})
+
+const allDeviceOptions = computed(() => [...canDeviceOptions.value, ...linDeviceOptions.value])
+
+// Reverse lookup: device name → "Bus N" channel string (from replay config)
+const devNameToBusStr = computed(() => {
+  const map = new Map<string, string>()
+  for (const replay of Object.values(database.replays)) {
+    if (!replay.channelMap) continue
+    for (const cm of replay.channelMap) {
+      if (cm.deviceIds?.length > 0) {
+        for (const did of cm.deviceIds) {
+          const dev = database.devices[did]
+          if (dev?.type === 'lin' && dev.linDevice) {
+            map.set(
+              dev.linDevice.name,
+              `Lin ${cm.logChannel >= 100 ? cm.logChannel - 100 : cm.logChannel}`
+            )
+          } else if (dev?.type === 'can' && dev.canDevice) {
+            map.set(dev.canDevice.name, `CAN ${cm.logChannel}`)
+          }
+        }
+      }
+    }
+  }
+  return map
+})
+
+function getDeviceOptionsForChannel(logChannel: number) {
+  return logChannel >= 100 ? linDeviceOptions.value : canDeviceOptions.value
+}
+
 function showChannelMapDialog(channels: number[]): Promise<void> {
   const saved = trace.value.channelMap || []
+  // Build lookup from replay config channel maps for auto-matching
+  const replayLookup = new Map<number, string>()
+  for (const replay of Object.values(database.replays)) {
+    if (replay.channelMap) {
+      for (const cm of replay.channelMap) {
+        if (cm.deviceIds?.length > 0 && !replayLookup.has(cm.logChannel)) {
+          replayLookup.set(cm.logChannel, cm.deviceIds[0])
+        }
+      }
+    }
+  }
   channelMapTemp.value = channels.map((ch) => {
     const existing = saved.find((m) => m.logChannel === ch)
     if (existing) return { ...existing }
-    // Auto-match: channel N → Nth CAN device (by order)
-    const canDevKeys = Object.entries(database.devices)
-      .filter(([, d]) => d.type === 'can' && d.canDevice)
-      .map(([id]) => id)
-    const autoDeviceId = canDevKeys[ch - 1] || ''
+    // Auto-match from replay config first, then fall back to index-based
+    let autoDeviceId = replayLookup.get(ch) || ''
+    if (!autoDeviceId) {
+      if (ch >= 100) {
+        const linDevKeys = Object.entries(database.devices)
+          .filter(([, d]) => d.type === 'lin' && d.linDevice)
+          .map(([id]) => id)
+        autoDeviceId = linDevKeys[ch - 101] || ''
+      } else {
+        const canDevKeys = Object.entries(database.devices)
+          .filter(([, d]) => d.type === 'can' && d.canDevice)
+          .map(([id]) => id)
+        autoDeviceId = canDevKeys[ch - 1] || ''
+      }
+    }
     return { logChannel: ch, deviceId: autoDeviceId }
   })
   channelMapDialogVisible.value = true
@@ -1677,6 +1836,22 @@ function buildChannelDbcMap(): Map<number, { dbKey: string; db: any; deviceName:
             deviceName: canDev.name || `CH${entry.logChannel}`
           })
         }
+      } else if (dev && dev.type === 'lin' && dev.linDevice) {
+        const linDev = dev.linDevice
+        const linCh = entry.logChannel >= 100 ? entry.logChannel - 100 : entry.logChannel
+        if (linDev.database && database.database.lin[linDev.database]) {
+          map.set(entry.logChannel, {
+            dbKey: linDev.database,
+            db: database.database.lin[linDev.database],
+            deviceName: linDev.name || `Lin ${linCh}`
+          })
+        } else {
+          map.set(entry.logChannel, {
+            dbKey: '',
+            db: null,
+            deviceName: linDev.name || `Lin ${linCh}`
+          })
+        }
       }
     }
   }
@@ -1702,11 +1877,19 @@ function buildMsgNameCache(
 ): Map<number, Map<string, string>> {
   const cache = new Map<number, Map<string, string>>()
   for (const [ch, entry] of chDbcMap) {
-    if (!entry.db || !entry.db.messages) continue
+    if (!entry.db) continue
     const lookup = new Map<string, string>()
-    for (const m of entry.db.messages) {
-      const key = `${m.id}-${!!m.is_extended_frame}`
-      lookup.set(key, m.name)
+    if (entry.db.messages) {
+      // CAN DBC: messages is an array with id + is_extended_frame
+      for (const m of entry.db.messages) {
+        const key = `${m.id}-${!!m.is_extended_frame}`
+        lookup.set(key, m.name)
+      }
+    } else if (entry.db.frames) {
+      // LIN LDF: frames is Record<string, Frame> with id
+      for (const frame of Object.values(entry.db.frames) as { id: number; name: string }[]) {
+        lookup.set(`${frame.id}-false`, frame.name)
+      }
     }
     cache.set(ch, lookup)
   }
@@ -1765,22 +1948,26 @@ function framesToLogData(
       name = msgLookup.get(`${frame.id}-${isExtended}`)
     }
 
-    const deviceName = chDbc?.deviceName || `CH${frame.channel}`
+    const isLin = (msgType.idType as string) === 'LIN'
+    const deviceName =
+      chDbc?.deviceName || (isLin ? `Lin ${frame.channel - 100}` : `CH${frame.channel}`)
 
     const idStr = '0x' + frame.id.toString(16)
     const globalIndex = indexOffset + i + 1
     const deltaTs = prevLastTs >= 0 ? frame.ts - prevLastTs : undefined
     prevLastTs = frame.ts
+    const busStr = isLin ? `Lin ${frame.channel - 100}` : `CAN ${frame.channel}`
     result.push({
-      method: 'canBase',
+      method: isLin ? 'linBase' : 'canBase',
       dir: frame.dir === 'OUT' ? 'Tx' : 'Rx',
       data: data2str(dataArr),
       ts: frame.ts,
       id: idStr,
       dlc: getDlcByLen(dataArr.length, msgType.canfd),
       len: dataArr.length,
-      device: deviceName,
-      channel: `CH${frame.channel}`,
+      device: '',
+      channel: deviceName,
+      bus: busStr,
       msgType: CanMsgType2Str(msgType),
       name,
       seqIndex: globalIndex,
@@ -1902,7 +2089,7 @@ async function onDrop(e: DragEvent) {
     traceFileJumpPage.value = 1
 
     // Show channel map dialog if there are CAN devices configured
-    if (canDeviceOptions.value.length > 0 && channels.length > 0) {
+    if (allDeviceOptions.value.length > 0 && channels.length > 0) {
       loadingInstance.close()
       await showChannelMapDialog(channels)
     }
@@ -2045,6 +2232,7 @@ const allColumnDefs: { key: string; title: string; width: number; formatter?: an
   { key: 'dlc', title: i18next.t('uds.trace.columns.dlc'), width: 100 },
   { key: 'len', title: i18next.t('uds.trace.columns.len'), width: 100 },
   { key: 'msgType', title: i18next.t('uds.trace.columns.type'), width: 100 },
+  { key: 'bus', title: 'Bus', width: 100 },
   { key: 'channel', title: i18next.t('uds.trace.columns.channel'), width: 100 },
   { key: 'device', title: i18next.t('uds.trace.columns.device'), width: 200 }
 ]

--- a/src/renderer/src/views/uds/trace.vue
+++ b/src/renderer/src/views/uds/trace.vue
@@ -1381,8 +1381,8 @@ function decodeSelectedRow(row: LogData) {
           }
           signals.push({
             name: sigRef.name,
-            value: rawValue,
-            physValue,
+            value: String(rawValue),
+            physValue: String(physValue),
             unit,
             rawHex: '0x' + rawValue.toString(16).toUpperCase(),
             bitPos: `[${bitOffset}|${bitLength}] LE`,

--- a/src/renderer/src/views/uds/uds.vue
+++ b/src/renderer/src/views/uds/uds.vue
@@ -675,7 +675,7 @@ const fileExtMap = {
 const DatabaseDropdown = {
   setup() {
     return () =>
-      h(ElDropdownMenu, { size: 'small' }, () => [
+      h(ElDropdownMenu, { size: 'small', style: 'max-height: 60vh; overflow-y: auto' }, () => [
         h(ElDropdownItem, { icon: CirclePlusFilled, command: 'addLin' }, () =>
           i18next.t('database.addLin', {
             extensions: fileExtMap.lin.map((ext) => ext.toUpperCase()).join(', ')


### PR DESCRIPTION
## PR 3/4: 前端 LIN 支持

Trace 窗口和回放配置界面新增 LIN 支持。

### 变更
**Trace 窗口**
- 新增 **Bus 列**（CAN 1 / Lin 7）
- LIN 信号解码（详情面板，基于 LDF 数据库）
- 通道映射对话框支持 LIN 设备和 LDF 数据库
- 统一回放模式与文件模式的 Channel/Device 显示

**回放配置**
- 新增 Bus Type 列
- 设备下拉框按总线类型（CAN/LIN）过滤

**Bug 修复**
- 修复 LDF 解析器 Chevrotain OPTION/SUBRULE bug
- 修复 LDF node `initial_NAD` 校验问题
- 修复 DecodedSignal 类型不匹配
- 修复数据库下拉框溢出

**依赖**: PR #364（核心解析）

**系列 PR**: 1/4 核心解析 → 2/4 模拟硬件 → **3/4 前端 UI** → 4/4 文档