### PR TITLE
feat: add LIN frame types and ASC/BLF parsing support

### DIFF
--- a/src/main/ipc/uds.ts
+++ b/src/main/ipc/uds.ts
@@ -1619,24 +1619,27 @@ ipcMain.handle(
     const frames: TraceFileFrame[] = []
     const channelSet = new Set<number>()
 
-    let frame = await reader.readFrame()
-    while (frame) {
-      channelSet.add(frame.channel)
-      frames.push({
-        channel: frame.channel,
-        ts: frame.ts,
-        id: frame.id,
-        dir: frame.dir,
-        msgType: {
-          idType: frame.msgType.idType,
-          brs: frame.msgType.brs,
-          canfd: frame.msgType.canfd,
-          remote: frame.msgType.remote
-        },
-        data: Array.from(frame.data),
-        isError: frame.isError
-      })
-      frame = await reader.readFrame()
+    let replayFrame = await reader.readFrame()
+    while (replayFrame) {
+      if (replayFrame.type === 'can') {
+        const f = replayFrame.frame
+        channelSet.add(f.channel)
+        frames.push({
+          channel: f.channel,
+          ts: f.ts,
+          id: f.id,
+          dir: f.dir,
+          msgType: {
+            idType: f.msgType.idType,
+            brs: f.msgType.brs,
+            canfd: f.msgType.canfd,
+            remote: f.msgType.remote
+          },
+          data: Array.from(f.data),
+          isError: f.isError
+        })
+      }
+      replayFrame = await reader.readFrame()
     }
 
     const measurementStartTimeMs = reader.measurementStartTimeMs ?? 0

--- a/src/main/replay/ascReader.ts
+++ b/src/main/replay/ascReader.ts
@@ -1,7 +1,8 @@
-import { ReplayCanFrame, ReplayReader } from '.'
+import { ReplayCanFrame, ReplayFrame, ReplayLinFrame, ReplayReader } from '.'
 import fs from 'fs'
 import { Transform, TransformCallback } from 'stream'
 import { CAN_ID_TYPE } from '../share/can'
+import { LinChecksumType } from '../share/lin'
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -49,14 +50,14 @@ export class AscTransform extends Transform {
     this.startTime += ms
   }
 
-  private async applyTimeBackpressure(frame: ReplayCanFrame): Promise<void> {
+  private async applyTimeBackpressure(ts: number): Promise<void> {
     if (this.speedFactor <= 0) return
     if (this.firstFrameTs < 0) {
-      this.firstFrameTs = frame.ts
+      this.firstFrameTs = ts
       this.startTime = Date.now()
       return
     }
-    const frameOffsetUs = frame.ts - this.firstFrameTs
+    const frameOffsetUs = ts - this.firstFrameTs
     const expectedElapsedMs = frameOffsetUs / 1000 / this.speedFactor
     const actualElapsedMs = Date.now() - this.startTime
     const delayMs = expectedElapsedMs - actualElapsedMs
@@ -68,9 +69,10 @@ export class AscTransform extends Transform {
   /**
    * Apply time backpressure, then push frame.
    */
-  private async pushFrame(frame: ReplayCanFrame): Promise<void> {
-    await this.applyTimeBackpressure(frame)
-    this.push(frame)
+  private async pushFrame(result: ReplayFrame): Promise<void> {
+    const ts = result.type === 'can' ? result.frame.ts : result.frame.ts
+    await this.applyTimeBackpressure(ts)
+    this.push(result)
   }
 
   _transform(chunk: Buffer, _encoding: string, callback: TransformCallback): void {
@@ -82,9 +84,9 @@ export class AscTransform extends Transform {
       for (const line of lines) {
         // Approximate bytes consumed for this line (+ newline) for progress tracking
         this.bytesRead += Buffer.byteLength(line, 'utf8') + 1
-        const frame = this.parseLine(line)
-        if (frame) {
-          await this.pushFrame(frame)
+        const result = this.parseLine(line)
+        if (result) {
+          await this.pushFrame(result)
         }
       }
       callback()
@@ -99,9 +101,9 @@ export class AscTransform extends Transform {
       if (trimmed) {
         // Count remaining buffered line bytes towards progress
         this.bytesRead += Buffer.byteLength(lineText, 'utf8')
-        const frame = this.parseLine(trimmed)
-        if (frame) {
-          await this.pushFrame(frame)
+        const result = this.parseLine(trimmed)
+        if (result) {
+          await this.pushFrame(result)
         }
       }
       callback()
@@ -109,7 +111,7 @@ export class AscTransform extends Transform {
     run().catch((err) => callback(err))
   }
 
-  private parseLine(line: string): ReplayCanFrame | null {
+  private parseLine(line: string): ReplayFrame | null {
     const trimmed = line.trim()
     if (!trimmed || trimmed.startsWith('base')) {
       return null
@@ -133,36 +135,55 @@ export class AscTransform extends Transform {
 
     this.lineCount++
 
+    // Try LIN message match first (channel is "Li" or "L<n>")
+    const linMatch = trimmed.match(
+      /^\s*([\d.]+)\s+(Li|L\d+)\s+([0-9a-f]{1,2})\s+(Tx|Rx)\s+(\d+)\s+((?:[0-9a-f]{2}\s*)*)\s*checksum\s*=\s*([0-9a-f]{2})\s*(?:CSM\s*=\s*(enhanced|standard))?/i
+    )
+    if (linMatch) {
+      return { type: 'lin', frame: this.parseLinLine(linMatch) }
+    }
+
+    // Try LIN error match
+    const linErrorMatch = trimmed.match(
+      /^\s*([\d.]+)\s+(Li|L\d+)\s+([0-9a-f]{1,2})\s+(CSErr|TransmErr|SyncError|RcvError)/i
+    )
+    if (linErrorMatch) {
+      return { type: 'lin', frame: this.parseLinErrorLine(linErrorMatch) }
+    }
+
     const canFdMatch = trimmed.match(
       /^\s*([\d.]+)\s+CANFD\s+(\d+)\s+(Rx|Tx)\s+([0-9A-Fa-fx]+)\s+.*?\s+([01])\s+([01])\s+([0-9a-f])\s+(\d+)\s+((?:[0-9A-Fa-f]{2}\s*)*)/i
     )
     if (canFdMatch) {
-      return this.parseCanFdLine(canFdMatch)
+      return { type: 'can', frame: this.parseCanFdLine(canFdMatch) }
     }
 
     const canMatch = trimmed.match(
       /^\s*([\d.]+)\s+(\d+)\s+([0-9A-Fa-fx]+)\s+(Rx|Tx)\s+([dr])\s+([0-9a-f])\s*((?:[0-9A-Fa-f]{2}\s*)*)/i
     )
     if (canMatch) {
-      return this.parseCanLine(canMatch)
+      return { type: 'can', frame: this.parseCanLine(canMatch) }
     }
 
     if (trimmed.includes('ErrorFrame')) {
       const errorMatch = trimmed.match(/^\s*([\d.]+)\s+(\d+)\s+ErrorFrame/i)
       if (errorMatch) {
         return {
-          channel: parseInt(errorMatch[2]),
-          ts: Math.round(parseFloat(errorMatch[1]) * 1_000_000),
-          id: 0,
-          dir: 'IN',
-          msgType: {
-            idType: CAN_ID_TYPE.STANDARD,
-            brs: false,
-            canfd: false,
-            remote: false
-          },
-          data: Buffer.alloc(0),
-          isError: true
+          type: 'can',
+          frame: {
+            channel: parseInt(errorMatch[2]),
+            ts: Math.round(parseFloat(errorMatch[1]) * 1_000_000),
+            id: 0,
+            dir: 'IN',
+            msgType: {
+              idType: CAN_ID_TYPE.STANDARD,
+              brs: false,
+              canfd: false,
+              remote: false
+            },
+            data: Buffer.alloc(0),
+            isError: true
+          }
         }
       }
     }
@@ -234,6 +255,62 @@ export class AscTransform extends Transform {
       data
     }
   }
+
+  /** Parse LIN channel string (Li -> 101, L2 -> 102, etc.) */
+  private parseLinChannel(channelStr: string): number {
+    if (channelStr.toLowerCase() === 'li') return 101
+    const num = parseInt(channelStr.substring(1))
+    return 100 + (isNaN(num) ? 1 : num)
+  }
+
+  private parseLinLine(match: RegExpMatchArray): ReplayLinFrame {
+    const timestamp = parseFloat(match[1])
+    const channelStr = match[2]
+    const frameId = parseInt(match[3], 16)
+    const dir = match[4] as 'Tx' | 'Rx'
+    const dlc = parseInt(match[5])
+    const dataStr = match[6]?.trim() || ''
+    const checksum = parseInt(match[7], 16)
+    const csmStr = match[8]?.toLowerCase()
+
+    let data = Buffer.alloc(0)
+    if (dataStr) {
+      const bytes = dataStr.split(/\s+/).filter((b) => b.length > 0)
+      data = Buffer.from(bytes.map((b) => parseInt(b, 16)))
+    }
+
+    const checksumType = csmStr === 'standard' ? LinChecksumType.CLASSIC : LinChecksumType.ENHANCED
+
+    return {
+      ts: Math.round(timestamp * 1_000_000),
+      channel: this.parseLinChannel(channelStr),
+      frameId,
+      dir,
+      data,
+      dlc,
+      checksumType,
+      checksum
+    }
+  }
+
+  private parseLinErrorLine(match: RegExpMatchArray): ReplayLinFrame {
+    const timestamp = parseFloat(match[1])
+    const channelStr = match[2]
+    const frameId = parseInt(match[3], 16)
+    const errorType = match[4]
+
+    return {
+      ts: Math.round(timestamp * 1_000_000),
+      channel: this.parseLinChannel(channelStr),
+      frameId,
+      dir: 'Rx',
+      data: Buffer.alloc(0),
+      dlc: 0,
+      checksumType: LinChecksumType.ENHANCED,
+      isError: true,
+      errorType
+    }
+  }
 }
 
 /**
@@ -245,7 +322,7 @@ export class AscReader implements ReplayReader {
   private _closed = false
   private readStream: fs.ReadStream | null = null
   private transform: AscTransform | null = null
-  private frameIterator: AsyncIterator<ReplayCanFrame> | null = null
+  private frameIterator: AsyncIterator<ReplayFrame> | null = null
 
   private _paused = false
   private pauseStartTime = 0
@@ -296,7 +373,7 @@ export class AscReader implements ReplayReader {
     }
   }
 
-  async readFrame(): Promise<ReplayCanFrame | null> {
+  async readFrame(): Promise<ReplayFrame | null> {
     if (this._closed || !this.frameIterator) {
       return null
     }
@@ -310,7 +387,7 @@ export class AscReader implements ReplayReader {
         }
         return null
       }
-      return result.value as ReplayCanFrame
+      return result.value as ReplayFrame
     } catch {
       return null
     }

--- a/src/main/replay/blfReader.ts
+++ b/src/main/replay/blfReader.ts
@@ -1,8 +1,9 @@
-import { ReplayCanFrame, ReplayReader } from '.'
+import { ReplayCanFrame, ReplayFrame, ReplayLinFrame, ReplayReader } from '.'
 import fs from 'fs'
 import zlib from 'zlib'
 import { Transform, TransformCallback } from 'stream'
 import { CAN_ID_TYPE } from '../share/can'
+import { LinChecksumType } from '../share/lin'
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -20,6 +21,14 @@ const CAN_ERROR_EXT = 73
 const CAN_MESSAGE2 = 86
 const CAN_FD_MESSAGE = 100
 const CAN_FD_MESSAGE_64 = 101
+
+// LIN Object Types (per Vector binlog_objects.h)
+const LIN_MESSAGE = 11
+const LIN_CRC_ERROR = 12
+const LIN_DLC_INFO = 13
+const LIN_RCV_ERROR = 14
+const LIN_SND_ERROR = 15
+const LIN_MESSAGE2 = 57
 
 const ZLIB_DEFLATE = 2
 
@@ -184,6 +193,92 @@ function parseCanFdMessage64(payload: Buffer, timestampUs: number): ReplayCanFra
 }
 
 /**
+ * Parse a LIN_MESSAGE (type 11) object payload into a ReplayLinFrame.
+ * Layout per VBLLINMessage:
+ *   channel(H:2) + id(B:1) + dlc(B:1) + data[8](8) + FSMId(B:1) + FSMState(B:1) +
+ *   headerTime(B:1) + fullTime(B:1) + CRC(H:2) + dir(B:1) + reserved(B:1) = 20 bytes
+ */
+function parseLinMessage(payload: Buffer, timestampUs: number): ReplayLinFrame | null {
+  if (payload.length < 20) return null
+  const channel = payload.readUInt16LE(0)
+  const frameId = payload.readUInt8(2) & 0x3f
+  const dlc = payload.readUInt8(3)
+  const dataLen = Math.min(dlc, 8)
+  const data = Buffer.from(payload.subarray(4, 4 + dataLen))
+  // offset 16: CRC (WORD LE)
+  const checksum = payload.readUInt16LE(16) & 0xff
+  // offset 18: dir
+  const dir = (payload.readUInt8(18) & 0x1) !== 0 ? 'Tx' : 'Rx'
+
+  return {
+    ts: timestampUs,
+    channel: 100 + channel,
+    frameId,
+    dir,
+    data,
+    dlc,
+    checksumType: LinChecksumType.ENHANCED,
+    checksum
+  }
+}
+
+/**
+ * Parse a LIN_MESSAGE2 (type 57) object payload into a ReplayLinFrame.
+ * Nested structure (after VBLObjectHeader):
+ *   VBLLINDatabyteTimestampEvent (112 bytes):
+ *     VBLLINMessageDescriptor (40):
+ *       VBLLINSynchFieldEvent (32):
+ *         VBLLINBusEvent (16): SOF(Q:8) + baudrate(D:4) + channel(H:2) + reserved(2)
+ *         synchBreakLen(Q:8) + synchDelLen(Q:8)
+ *       supplierID(H:2) + messageID(H:2) + NAD(B:1) + ID(B:1) + DLC(B:1) + checksumModel(B:1)
+ *     databyteTimestamps[9](Q*9:72)
+ *   data[8](8) + CRC(H:2) + dir(B:1) + ...
+ */
+function parseLinMessage2(payload: Buffer, timestampUs: number): ReplayLinFrame | null {
+  if (payload.length < 123) return null
+  const channel = payload.readUInt16LE(12)
+  const frameId = payload.readUInt8(37) & 0x3f
+  const dlc = payload.readUInt8(38)
+  const checksumModel = payload.readUInt8(39)
+  const dataLen = Math.min(dlc, 8)
+  const data = Buffer.from(payload.subarray(112, 112 + dataLen))
+  const checksum = payload.readUInt16LE(120) & 0xff
+  const dir = (payload.readUInt8(122) & 0x1) !== 0 ? 'Tx' : 'Rx'
+
+  return {
+    ts: timestampUs,
+    channel: 100 + channel,
+    frameId,
+    dir,
+    data,
+    dlc,
+    checksumType: checksumModel === 0 ? LinChecksumType.CLASSIC : LinChecksumType.ENHANCED,
+    checksum
+  }
+}
+
+/**
+ * Parse a LIN error (type 13 DLC_INFO / type 14 RCV_ERROR) payload into a ReplayLinFrame.
+ */
+function parseLinError(payload: Buffer, timestampUs: number): ReplayLinFrame | null {
+  if (payload.length < 4) return null
+  const channel = payload.readUInt16LE(0)
+  const frameId = payload.readUInt8(2) & 0x3f
+
+  return {
+    ts: timestampUs,
+    channel: 100 + channel,
+    frameId,
+    dir: 'Rx',
+    data: Buffer.alloc(0),
+    dlc: 0,
+    checksumType: LinChecksumType.ENHANCED,
+    isError: true,
+    errorType: 'BLF_LIN_ERROR'
+  }
+}
+
+/**
  * Extract inner LOBJ objects from (decompressed) container data.
  * Handles cross-container reassembly via the carryover buffer.
  */
@@ -284,14 +379,14 @@ export class BlfTransform extends Transform {
     this.startTime += ms
   }
 
-  private async applyTimeBackpressure(frame: ReplayCanFrame): Promise<void> {
+  private async applyTimeBackpressure(ts: number): Promise<void> {
     if (this.speedFactor <= 0) return
     if (this.firstFrameTs < 0) {
-      this.firstFrameTs = frame.ts
+      this.firstFrameTs = ts
       this.startTime = Date.now()
       return
     }
-    const frameOffsetUs = frame.ts - this.firstFrameTs
+    const frameOffsetUs = ts - this.firstFrameTs
     const expectedElapsedMs = frameOffsetUs / 1000 / this.speedFactor
     const actualElapsedMs = Date.now() - this.startTime
     const delayMs = expectedElapsedMs - actualElapsedMs
@@ -300,9 +395,10 @@ export class BlfTransform extends Transform {
     }
   }
 
-  private async pushFrame(frame: ReplayCanFrame): Promise<void> {
-    await this.applyTimeBackpressure(frame)
-    this.push(frame)
+  private async pushFrame(result: ReplayFrame): Promise<void> {
+    const ts = result.type === 'can' ? result.frame.ts : result.frame.ts
+    await this.applyTimeBackpressure(ts)
+    this.push(result)
   }
 
   _transform(chunk: Buffer, _encoding: string, callback: TransformCallback): void {
@@ -473,17 +569,44 @@ export class BlfTransform extends Transform {
     }
   }
 
-  private parseFrame(objType: number, payload: Buffer, timestampUs: number): ReplayCanFrame | null {
+  private parseFrame(objType: number, payload: Buffer, timestampUs: number): ReplayFrame | null {
     switch (objType) {
       case CAN_MESSAGE:
-      case CAN_MESSAGE2:
-        return parseCanMessage(payload, timestampUs)
-      case CAN_FD_MESSAGE:
-        return parseCanFdMessage(payload, timestampUs)
-      case CAN_FD_MESSAGE_64:
-        return parseCanFdMessage64(payload, timestampUs)
-      case CAN_ERROR_EXT:
-        return parseCanErrorExt(payload, timestampUs)
+      case CAN_MESSAGE2: {
+        const frame = parseCanMessage(payload, timestampUs)
+        return frame ? { type: 'can', frame } : null
+      }
+      case CAN_FD_MESSAGE: {
+        const frame = parseCanFdMessage(payload, timestampUs)
+        return frame ? { type: 'can', frame } : null
+      }
+      case CAN_FD_MESSAGE_64: {
+        const frame = parseCanFdMessage64(payload, timestampUs)
+        return frame ? { type: 'can', frame } : null
+      }
+      case CAN_ERROR_EXT: {
+        const frame = parseCanErrorExt(payload, timestampUs)
+        return frame ? { type: 'can', frame } : null
+      }
+      case LIN_MESSAGE:
+      case LIN_SND_ERROR:
+      case LIN_CRC_ERROR: {
+        const frame = parseLinMessage(payload, timestampUs)
+        if (frame && (objType === LIN_SND_ERROR || objType === LIN_CRC_ERROR)) {
+          frame.isError = true
+          frame.errorType = objType === LIN_SND_ERROR ? 'SndError' : 'CRCError'
+        }
+        return frame ? { type: 'lin', frame } : null
+      }
+      case LIN_MESSAGE2: {
+        const frame = parseLinMessage2(payload, timestampUs)
+        return frame ? { type: 'lin', frame } : null
+      }
+      case LIN_DLC_INFO:
+      case LIN_RCV_ERROR: {
+        const frame = parseLinError(payload, timestampUs)
+        return frame ? { type: 'lin', frame } : null
+      }
       default:
         return null
     }
@@ -499,7 +622,7 @@ export class BlfReader implements ReplayReader {
   private _closed = false
   private readStream: fs.ReadStream | null = null
   private transform: BlfTransform | null = null
-  private frameIterator: AsyncIterator<ReplayCanFrame> | null = null
+  private frameIterator: AsyncIterator<ReplayFrame> | null = null
   private _paused = false
   private pauseStartTime = 0
 
@@ -544,7 +667,7 @@ export class BlfReader implements ReplayReader {
     }
   }
 
-  async readFrame(): Promise<ReplayCanFrame | null> {
+  async readFrame(): Promise<ReplayFrame | null> {
     if (this._closed || !this.frameIterator) return null
 
     try {
@@ -555,7 +678,7 @@ export class BlfReader implements ReplayReader {
         }
         return null
       }
-      return result.value as ReplayCanFrame
+      return result.value as ReplayFrame
     } catch {
       return null
     }

--- a/src/main/replay/index.ts
+++ b/src/main/replay/index.ts
@@ -1,7 +1,6 @@
-import fs from 'fs'
 import path from 'path'
-import zlib from 'zlib'
 import { CAN_ID_TYPE, CanMessage, getTsUs } from '../share/can'
+import { LinChecksumType, LinDirection, LinMsg } from '../share/lin'
 import { ReplayLOG } from '../log'
 import type { ReplayItem, ReplayFileFormat, ReplayChannelMap } from 'src/preload/data'
 import { AscReader } from './ascReader'
@@ -13,34 +12,6 @@ import { EthBaseInfo } from '../share/doip'
 import { PwmBase } from '../pwm'
 import { VSomeIP_Client } from '../vsomeip'
 import i18next from 'i18next'
-
-// ---- BLF Constants (layout matches src/main/transport/blf.ts writer) ----
-const FILE_HEADER_SIZE = 144
-const OBJ_HEADER_BASE_SIZE = 16
-const OBJ_HEADER_V1_SIZE = 16
-const LOG_CONTAINER_HEADER_SIZE = 16
-
-const CAN_MESSAGE = 1
-const LOG_CONTAINER = 10
-const CAN_ERROR_EXT = 73
-const CAN_MESSAGE2 = 86
-const CAN_FD_MESSAGE = 100
-
-const NO_COMPRESSION = 0
-const ZLIB_DEFLATE = 2
-
-const CAN_MSG_EXT = 0x80000000
-const REMOTE_FLAG = 0x80
-const DIR_FLAG = 0x1
-const EDL_FLAG = 0x1
-const BRS_FLAG = 0x2
-const TIME_ONE_NANS = 0x00000002
-
-/** Object payload padding to 4-byte boundary (same as writer padData) */
-function blfPadSize(len: number): number {
-  const mod = len % 4
-  return mod === 0 ? 0 : 4 - mod
-}
 
 /**
  * Parsed CAN frame from replay file
@@ -54,6 +25,39 @@ export type ReplayCanFrame = Omit<CanMessage, 'ts'> & {
   /** Is error frame */
   isError?: boolean
 }
+
+/**
+ * Parsed LIN frame from replay file
+ */
+export type ReplayLinFrame = {
+  /** Timestamp in microseconds */
+  ts: number
+  /** Channel number from log file (LIN channels use offset 100+) */
+  channel: number
+  /** LIN Frame ID (0-63) */
+  frameId: number
+  /** Direction */
+  dir: 'Tx' | 'Rx'
+  /** Frame data */
+  data: Buffer
+  /** Data length */
+  dlc: number
+  /** Checksum type */
+  checksumType: LinChecksumType
+  /** Checksum value */
+  checksum?: number
+  /** Is error frame */
+  isError?: boolean
+  /** Error type description */
+  errorType?: string
+}
+
+/**
+ * Discriminated union for replay frames
+ */
+export type ReplayFrame =
+  | { type: 'can'; frame: ReplayCanFrame }
+  | { type: 'lin'; frame: ReplayLinFrame }
 
 /**
  * Sleep for specified milliseconds
@@ -71,7 +75,7 @@ export interface ReplayReader {
    * Read next frame with time-based backpressure
    * The reader will delay based on frame timestamps to simulate real-time playback
    */
-  readFrame(): Promise<ReplayCanFrame | null>
+  readFrame(): Promise<ReplayFrame | null>
   getProgress(): { current: number; total: number; percent: number }
   /** Set playback speed factor (1.0 = normal, 2.0 = 2x, 0 = as fast as possible) */
   setSpeedFactor(factor: number): void
@@ -206,9 +210,9 @@ export class Replay {
     while (this.state === 'running' && this.reader) {
       try {
         // Reader handles time-based backpressure internally
-        const frame = await this.reader.readFrame()
+        const result = await this.reader.readFrame()
 
-        if (frame === null) {
+        if (result === null) {
           // End of file
           await this.handleStreamEnd()
           if (this.state !== 'running') {
@@ -216,7 +220,7 @@ export class Replay {
           }
           continue
         }
-        this.processReplayFrame(frame)
+        this.processReplayFrame(result)
       } catch (error: any) {
         this.log.error(error.message)
         this.stop()
@@ -225,8 +229,8 @@ export class Replay {
     }
   }
 
-  private processReplayFrame(frame: ReplayCanFrame): void {
-    // Lazily capture measurement start time after header is parsed
+  private processReplayFrame(result: ReplayFrame): void {
+    // Common progress tracking
     if (this.measurementStartTimeMs === 0 && this.reader?.measurementStartTimeMs) {
       this.measurementStartTimeMs = this.reader.measurementStartTimeMs
     }
@@ -238,6 +242,15 @@ export class Replay {
         this.log.progress(progress.current, progress.total, intPercent, this.currentRepeat)
       }
     }
+
+    if (result.type === 'can') {
+      this.processCanFrame(result.frame)
+    } else if (result.type === 'lin') {
+      this.processLinFrame(result.frame)
+    }
+  }
+
+  private processCanFrame(frame: ReplayCanFrame): void {
     const channelMap = this.findChannelMap(frame.channel)
     if (channelMap) {
       for (const deviceId of channelMap.deviceIds) {
@@ -270,6 +283,138 @@ export class Replay {
         }
       }
     }
+  }
+
+  private processLinFrame(frame: ReplayLinFrame): void {
+    const channelMap = this.findChannelMap(frame.channel)
+    if (!channelMap) return
+
+    for (const deviceId of channelMap.deviceIds) {
+      const base = this.linBaseMap.get(deviceId)
+      if (!base) continue
+
+      const linMsg: LinMsg = {
+        frameId: frame.frameId,
+        data: frame.data,
+        direction: frame.dir === 'Tx' ? LinDirection.SEND : LinDirection.RECV,
+        checksumType: frame.checksumType,
+        checksum: frame.checksum,
+        ts: frame.ts + this.tsOffset
+      }
+
+      // Enrich with LDF database info (frame name + signal values)
+      if (base.info.database) {
+        this.enrichLinMsg(linMsg, base.info.database)
+      }
+
+      if (this.config.mode === 'offline') {
+        base.log.linBase(linMsg)
+      } else {
+        // Online mode: send via hardware (only works for Master mode)
+        base.write(linMsg).catch((e: any) => this.log.error(e.message))
+      }
+    }
+  }
+
+  /**
+   * Enrich a LinMsg with frame name and decoded signal values from LDF database.
+   */
+  private enrichLinMsg(msg: LinMsg, databaseId: string): void {
+    const cacheKey = `lin|${databaseId}|${msg.frameId}`
+    let cachedFrame = this.frameDbInfoCache.get(cacheKey)
+    if (cachedFrame === undefined) {
+      const db = global.dataSet?.database?.lin?.[databaseId]
+      if (db && db.frames) {
+        const ldfFrame = Object.values(db.frames).find((f: any) => f.id === msg.frameId) as
+          | { name: string; id: number; signals: { name: string; offset: number }[] }
+          | undefined
+        cachedFrame = ldfFrame ? { database: databaseId, name: ldfFrame.name } : null
+      } else {
+        cachedFrame = null
+      }
+      this.frameDbInfoCache.set(cacheKey, cachedFrame)
+    }
+    if (!cachedFrame) return
+
+    msg.name = cachedFrame.name
+    msg.database = cachedFrame.database
+
+    // Decode signals
+    const db = global.dataSet?.database?.lin?.[databaseId]
+    if (!db) return
+
+    const ldfFrame = Object.values(db.frames).find((f: any) => f.id === msg.frameId) as
+      | { name: string; signals: { name: string; offset: number }[] }
+      | undefined
+    if (!ldfFrame || !ldfFrame.signals) return
+
+    // Build reverse map: signalName → encodingTypeName
+    const sigToEncoding: Record<string, string> = {}
+    if (db.signalRep) {
+      for (const [encName, sigNames] of Object.entries(db.signalRep)) {
+        for (const sn of sigNames as string[]) {
+          sigToEncoding[sn] = encName
+        }
+      }
+    }
+
+    const signals: Record<string, any> = {}
+    for (const sigRef of ldfFrame.signals) {
+      const sigDef = db.signals[sigRef.name]
+      if (!sigDef) continue
+
+      const bitOffset = sigRef.offset
+      const bitLength = sigDef.signalSizeBits
+      // Read raw value (LIN is always little-endian)
+      let rawValue = 0
+      let startByte = Math.floor(bitOffset / 8)
+      let startBitInByte = bitOffset % 8
+      let remaining = bitLength
+      let valueIndex = 0
+      while (remaining > 0 && startByte < msg.data.length) {
+        const bits = Math.min(8 - startBitInByte, remaining)
+        const mask = (1 << bits) - 1
+        const v = (msg.data[startByte] >> startBitInByte) & mask
+        rawValue |= v << valueIndex
+        remaining -= bits
+        valueIndex += bits
+        startByte++
+        startBitInByte = 0
+      }
+
+      // Apply encoding type for physical value
+      let physValue: number | string = rawValue
+      let physValueEnum: string | undefined
+      const encName = sigToEncoding[sigRef.name]
+      if (encName && db.signalEncodeTypes?.[encName]) {
+        const enc = db.signalEncodeTypes[encName]
+        for (const et of enc.encodingTypes) {
+          if (et.type === 'physicalValue' && et.physicalValue) {
+            const pv = et.physicalValue
+            if (rawValue >= pv.minValue && rawValue <= pv.maxValue) {
+              physValue = rawValue * pv.scale + pv.offset
+              break
+            }
+          } else if (et.type === 'logicalValue' && et.logicalValue) {
+            if (rawValue === et.logicalValue.signalValue) {
+              physValueEnum = et.logicalValue.textInfo || ''
+              physValue = physValueEnum || rawValue
+              break
+            }
+          }
+        }
+      }
+
+      signals[sigRef.name] = {
+        signalName: sigRef.name,
+        signalSizeBits: bitLength,
+        initValue: sigDef.initValue,
+        value: rawValue,
+        physValue,
+        physValueEnum
+      }
+    }
+    msg.signals = signals
   }
 
   private async handleStreamEnd(): Promise<void> {

--- a/src/preload/data.d.ts
+++ b/src/preload/data.d.ts
@@ -223,6 +223,8 @@ export type ReplayChannelMap = {
   logChannel: number
   /** Device IDs to replay to (supports multiple targets) */
   deviceIds: string[]
+  /** Bus type for this channel mapping (default: 'can') */
+  busType?: 'can' | 'lin'
 }
 
 export type ReplayItem = {

--- a/test/replay/replay.spec.ts
+++ b/test/replay/replay.spec.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { ReplayCanFrame } from '../../src/main/replay/index'
+import { ReplayCanFrame, ReplayFrame, ReplayReader } from '../../src/main/replay/index'
 import path from 'path'
 import { AscReader } from 'src/main/replay/ascReader'
 import { BlfReader } from 'src/main/replay/blfReader'
+
+/** Helper: read all CAN frames from a reader, unwrapping the tagged union */
+async function readAllCanFrames(reader: ReplayReader): Promise<ReplayCanFrame[]> {
+  const frames: ReplayCanFrame[] = []
+  let rf: ReplayFrame | null
+  while ((rf = await reader.readFrame()) !== null) {
+    if (rf.type === 'can') frames.push(rf.frame)
+  }
+  return frames
+}
 
 describe('Replay', () => {
   const blfFilePath = path.resolve(__dirname, './Logging.blf')
@@ -24,13 +34,7 @@ describe('Replay', () => {
       const reader = new AscReader(ascFilePath, 10) // 0 = as fast as possible (no time-based delay)
       reader.init()
 
-      const frames: ReplayCanFrame[] = []
-      let frame: ReplayCanFrame | null
-
-      // Read all frames
-      while ((frame = await reader.readFrame()) !== null) {
-        frames.push(frame)
-      }
+      const frames = await readAllCanFrames(reader)
 
       expect(frames.length).toBeGreaterThan(0)
       console.log(`Read ${frames.length} CAN frames from ASC file`)
@@ -61,18 +65,14 @@ describe('Replay', () => {
       const reader = new AscReader(ascFilePath, 0)
       await reader.init()
 
+      const frames = await readAllCanFrames(reader)
       let lastTs = -1
-      let frame: ReplayCanFrame | null
-      let count = 0
-
-      while ((frame = await reader.readFrame()) !== null) {
-        // Timestamps should be non-decreasing
+      for (const frame of frames) {
         expect(frame.ts).toBeGreaterThanOrEqual(lastTs)
         lastTs = frame.ts
-        count++
       }
 
-      console.log(`Verified ${count} frames have increasing timestamps`)
+      console.log(`Verified ${frames.length} frames have increasing timestamps`)
       reader.close()
     })
 
@@ -80,10 +80,10 @@ describe('Replay', () => {
       const reader = new AscReader(ascFilePath, 0)
       const { total } = await reader.init()
 
-      let frame: ReplayCanFrame | null
+      let rf: ReplayFrame | null
       let lastProgress = 0
 
-      while ((frame = await reader.readFrame()) !== null) {
+      while ((rf = await reader.readFrame()) !== null) {
         const progress = reader.getProgress()
         expect(progress.current).toBeLessThanOrEqual(progress.total)
         expect(progress.percent).toBeGreaterThanOrEqual(lastProgress)
@@ -104,12 +104,7 @@ describe('Replay', () => {
       const reader = new AscReader(ascFilePath, 0)
       await reader.init()
 
-      const frames: ReplayCanFrame[] = []
-      let frame: ReplayCanFrame | null
-
-      while ((frame = await reader.readFrame()) !== null) {
-        frames.push(frame)
-      }
+      const frames = await readAllCanFrames(reader)
 
       // Total frames in ASC file: 37 (lines 4-40)
       expect(frames.length).toBe(36)
@@ -180,12 +175,7 @@ describe('Replay', () => {
       const reader = new BlfReader(blfFilePath, 0)
       reader.init()
 
-      const frames: ReplayCanFrame[] = []
-      let frame: ReplayCanFrame | null
-
-      while ((frame = await reader.readFrame()) !== null) {
-        frames.push(frame)
-      }
+      const frames = await readAllCanFrames(reader)
 
       expect(frames.length).toBeGreaterThan(0)
       console.log(`Read ${frames.length} CAN frames from BLF file`)
@@ -216,18 +206,15 @@ describe('Replay', () => {
       const reader = new BlfReader(blfFilePath, 0)
       await reader.init()
 
+      const frames = await readAllCanFrames(reader)
       let lastTs = -1
-      let frame: ReplayCanFrame | null
-      let count = 0
-
-      while ((frame = await reader.readFrame()) !== null) {
+      for (const frame of frames) {
         expect(frame.ts).toBeGreaterThanOrEqual(lastTs)
         lastTs = frame.ts
-        count++
       }
 
-      expect(count).toBeGreaterThan(0)
-      console.log(`Verified ${count} frames have increasing timestamps`)
+      expect(frames.length).toBeGreaterThan(0)
+      console.log(`Verified ${frames.length} frames have increasing timestamps`)
       reader.close()
     })
 
@@ -235,9 +222,9 @@ describe('Replay', () => {
       const reader = new BlfReader(blfFilePath, 0)
       await reader.init()
 
-      let frame: ReplayCanFrame | null
+      let rf: ReplayFrame | null
 
-      while ((frame = await reader.readFrame()) !== null) {
+      while ((rf = await reader.readFrame()) !== null) {
         const progress = reader.getProgress()
         expect(progress.current).toBeLessThanOrEqual(progress.total)
       }


### PR DESCRIPTION
Add LIN frame type definitions and parsing support for ASC/BLF file readers.

- Define LIN-specific frame structures in trace file parser
- Extend ASC reader to parse LIN frames
- Extend BLF reader to parse LIN frames  
- LIN frames use channel offset +100 to distinguish from CAN channels

**Stack:** 1/4 — base PR