### PR TITLE
fix: resolve signal decoding in detail panel for BLF/ASC drag-drop trace

### DIFF
--- a/src/renderer/src/views/uds/trace.vue
+++ b/src/renderer/src/views/uds/trace.vue
@@ -1278,7 +1278,12 @@ function decodeSelectedRow(row: LogData) {
 
   // Try DBC decoding if channel map available
   if (row.method === 'canBase' && channelDbcMapCache) {
-    const chNum = parseInt(row.channel.replace('CH', ''), 10)
+    let chNum = parseInt(row.channel.replace('CH', ''), 10)
+    // For BLF/ASC loaded data, channel is device name; parse from bus field instead
+    if ((isNaN(chNum) || !channelDbcMapCache.has(chNum)) && row.bus) {
+      const busNum = parseInt(row.bus.replace('CAN ', ''), 10)
+      if (!isNaN(busNum)) chNum = busNum
+    }
     const chDbc = channelDbcMapCache.get(chNum)
     if (chDbc && chDbc.db) {
       const frameId = parseInt(row.id, 16)
@@ -1313,9 +1318,16 @@ function decodeSelectedRow(row: LogData) {
 
   // Try LDF decoding for LIN frames
   if (row.method === 'linBase' && channelDbcMapCache) {
-    const chNum = row.channel.startsWith('Lin ')
+    let chNum = row.channel.startsWith('Lin ')
       ? parseInt(row.channel.replace('Lin ', ''), 10) + 100
       : parseInt(row.channel.replace('CH', ''), 10)
+    // For BLF/ASC loaded data, channel is device name; parse from bus field instead
+    if ((isNaN(chNum) || !channelDbcMapCache.has(chNum)) && row.bus) {
+      const busNum = row.bus.startsWith('Lin ')
+        ? parseInt(row.bus.replace('Lin ', ''), 10) + 100
+        : parseInt(row.bus.replace('CAN ', ''), 10)
+      if (!isNaN(busNum)) chNum = busNum
+    }
     const chDbc = channelDbcMapCache.get(chNum)
     if (chDbc && chDbc.db && chDbc.db.frames) {
       const frameId = parseInt(row.id, 16)


### PR DESCRIPTION
Fix signal decoding failure when clicking trace rows after loading BLF/ASC files via drag-and-drop.

**Root cause:** `row.channel` contains device name (e.g. 'PEAK CAN-USB FD') for BLF-loaded data, not 'CH1' format. `parseInt(row.channel.replace('CH',''))` returns NaN, causing DBC cache lookup to silently fail.

**Fix:** Fallback to parsing `row.bus` field ('CAN 1'/'Lin 0') when `row.channel` cannot be resolved to a valid cache key. Applied to both CAN and LIN decode paths.

**Stack:** 4/4 — depends on #371