### PR TITLE
feat: add CAN-TP worker API and can_tp example

### DIFF
--- a/resources/examples/can_tp/can_tp.ecb
+++ b/resources/examples/can_tp/can_tp.ecb
@@ -1,0 +1,198 @@
+{
+  "data": {
+    "devices": {
+      "c07c3701-6a7a-4a23-9848-dd86bbc38061": {
+        "type": "can",
+        "canDevice": {
+          "id": "c07c3701-6a7a-4a23-9848-dd86bbc38061",
+          "name": "SIMULATE_0",
+          "handle": 0,
+          "vendor": "simulate",
+          "canfd": false,
+          "database": "",
+          "bitrate": {
+            "sjw": 1,
+            "timeSeg1": 13,
+            "timeSeg2": 2,
+            "preScaler": 10,
+            "freq": 500000,
+            "clock": "80",
+            "_X_ROW_KEY": "row_80"
+          }
+        }
+      }
+    },
+    "ia": {},
+    "tester": {},
+    "subFunction": {},
+    "nodes": {
+      "f67340dd-e027-454b-aaba-d0521350993c": {
+        "name": "Client",
+        "id": "f67340dd-e027-454b-aaba-d0521350993c",
+        "channel": [
+          "c07c3701-6a7a-4a23-9848-dd86bbc38061"
+        ],
+        "workNode": "",
+        "script": "tester.ts"
+      },
+      "99806fc5-64a9-4c84-9f83-710c938b28a9": {
+        "name": "Server",
+        "id": "99806fc5-64a9-4c84-9f83-710c938b28a9",
+        "channel": [
+          "c07c3701-6a7a-4a23-9848-dd86bbc38061"
+        ],
+        "script": "ecu.ts",
+        "workNode": ""
+      }
+    },
+    "database": {
+      "lin": {},
+      "can": {},
+      "orti": {}
+    },
+    "graphs": {},
+    "guages": {},
+    "vars": {},
+    "datas": {},
+    "panels": {},
+    "logs": {},
+    "traces": {
+      "trace": {
+        "id": "trace",
+        "name": "Trace",
+        "filter": [
+          "canBase",
+          "ipBase",
+          "linBase",
+          "uds",
+          "someipBase",
+          "osTrace"
+        ],
+        "filterDevice": [
+          "SIMULATE_0"
+        ],
+        "filterId": [],
+        "columnConfig": [
+          {
+            "key": "seqIndex",
+            "visible": true,
+            "width": 80
+          },
+          {
+            "key": "ts",
+            "visible": true,
+            "width": 200
+          },
+          {
+            "key": "deltaTs",
+            "visible": true,
+            "width": 120
+          },
+          {
+            "key": "absTimeStr",
+            "visible": true,
+            "width": 200
+          },
+          {
+            "key": "name",
+            "visible": true,
+            "width": 200
+          },
+          {
+            "key": "data",
+            "visible": true,
+            "width": 300
+          },
+          {
+            "key": "dir",
+            "visible": true,
+            "width": 50
+          },
+          {
+            "key": "id",
+            "visible": true,
+            "width": 100
+          },
+          {
+            "key": "dlc",
+            "visible": true,
+            "width": 100
+          },
+          {
+            "key": "len",
+            "visible": true,
+            "width": 100
+          },
+          {
+            "key": "msgType",
+            "visible": true,
+            "width": 100
+          },
+          {
+            "key": "channel",
+            "visible": true,
+            "width": 100
+          },
+          {
+            "key": "device",
+            "visible": true,
+            "width": 200
+          }
+        ]
+      }
+    },
+    "pluginData": {},
+    "replays": {}
+  },
+  "project": {
+    "wins": {
+      "message": {
+        "pos": {
+          "x": 383,
+          "y": 219,
+          "w": 1280,
+          "h": 200
+        },
+        "options": {
+          "params": {}
+        },
+        "title": "message",
+        "label": "Message",
+        "id": "message",
+        "layoutType": "bottom"
+      },
+      "network": {
+        "pos": {
+          "x": 1141,
+          "y": 0,
+          "w": 845,
+          "h": 559
+        },
+        "title": "network",
+        "label": "Network",
+        "id": "network",
+        "options": {}
+      },
+      "trace": {
+        "pos": {
+          "x": 8,
+          "y": 0,
+          "w": 1111,
+          "h": 952
+        },
+        "title": "trace",
+        "label": "Trace",
+        "id": "trace",
+        "options": {
+          "params": {
+            "edit-index": "trace"
+          },
+          "name": "Trace"
+        }
+      }
+    },
+    "example": {
+      "catalog": "CAN"
+    }
+  }
+}

--- a/resources/examples/can_tp/ecu.ts
+++ b/resources/examples/can_tp/ecu.ts
@@ -1,0 +1,97 @@
+/**
+ * Simulated ECU — receives CAN-TP requests and replies with a positive response.
+ *
+ * Uses Util.OnCan + output() to implement ISO 15765-2 without CanTpCreateConnection.
+ *
+ * RX = 0x7E0  (Tester → ECU)
+ * TX = 0x7E8  (ECU → Tester)
+ *
+ * Response rule: first byte = service_id + 0x40, remaining bytes echoed back.
+ */
+import { output, CAN_ID_TYPE } from 'ECB'
+import type { CanMessage } from 'ECB'
+
+const RX_ID = 0x7e0
+const TX_ID = 0x7e8
+
+let rxState: { totalLen: number; buf: number[]; expectedSN: number } | null = null
+let txState: { data: number[]; offset: number; sn: number } | null = null
+
+function sendRaw(bytes: number[]) {
+  const padded = [...bytes, ...Array(Math.max(0, 8 - bytes.length)).fill(0x00)].slice(0, 8)
+  output({
+    id: TX_ID,
+    data: Buffer.from(padded),
+    msgType: { idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: false }
+  } as CanMessage)
+}
+
+function respond(payload: number[]) {
+  const resp = [payload[0] + 0x40, ...payload.slice(1)]
+  const preview = resp
+    .slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ')
+  console.log(`[ECU] TX ${resp.length}B: ${preview}${resp.length > 8 ? ' ...' : ''}`)
+
+  if (resp.length <= 7) {
+    sendRaw([resp.length, ...resp])
+  } else {
+    txState = { data: resp, offset: 6, sn: 1 }
+    sendRaw([0x10 | ((resp.length >> 8) & 0x0f), resp.length & 0xff, ...resp.slice(0, 6)])
+  }
+}
+
+Util.OnCan(RX_ID, (msg) => {
+  const d = Array.from(msg.data)
+  if (!d.length) return
+  const frameType = (d[0] >> 4) & 0x0f
+
+  if (frameType === 0) {
+    // Single Frame
+    const len = d[0] & 0x0f
+    if (len < 1 || len > d.length - 1) return
+    rxState = null
+    respond(d.slice(1, 1 + len))
+  } else if (frameType === 1) {
+    // First Frame — send FC immediately
+    const totalLen = ((d[0] & 0x0f) << 8) | d[1]
+    if (totalLen < 8) return
+    rxState = { totalLen, buf: [...d.slice(2)], expectedSN: 1 }
+    sendRaw([0x30, 0x00, 0x00]) // FC: ContinueToSend, BS=0, STmin=0
+  } else if (frameType === 2) {
+    // Consecutive Frame
+    if (!rxState) return
+    const sn = d[0] & 0x0f
+    if (sn !== rxState.expectedSN % 16) {
+      rxState = null
+      return
+    }
+    rxState.expectedSN++
+    rxState.buf.push(...d.slice(1))
+    if (rxState.buf.length >= rxState.totalLen) {
+      const payload = rxState.buf.slice(0, rxState.totalLen)
+      rxState = null
+      const preview = payload
+        .slice(0, 8)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(' ')
+      console.log(`[ECU] RX ${payload.length}B: ${preview}${payload.length > 8 ? ' ...' : ''}`)
+      respond(payload)
+    }
+  } else if (frameType === 3) {
+    // Flow Control (tester acking ECU's FF)
+    if (!txState || (d[0] & 0x0f) !== 0) return
+    while (txState.offset < txState.data.length) {
+      const chunk = txState.data.slice(txState.offset, txState.offset + 7)
+      sendRaw([0x20 | (txState.sn & 0x0f), ...chunk])
+      txState.sn++
+      txState.offset += 7
+    }
+    txState = null
+  }
+})
+
+Util.Init(() => {
+  console.log('[ECU] Ready  RX=0x7E0  TX=0x7E8')
+})

--- a/resources/examples/can_tp/readme.md
+++ b/resources/examples/can_tp/readme.md
@@ -1,0 +1,120 @@
+# CAN-TP Example
+
+Demonstrates the `CanTpCreateConnection` / `CanTpSendData` / `CanTpRecvData` worker API for ISO 15765-2 (CAN Transport Protocol) communication. No hardware required — both nodes run on a single virtual CAN bus.
+
+## Overview
+
+- **Node 1 (tester.ts)**: Uses the `CanTp*` API to send requests and receive responses. Runs four tests on startup covering single-frame and multi-frame scenarios up to 500 bytes.
+- **Node 2 (ecu.ts)**: Simulated ECU implemented with `Util.OnCan` + `output()`. Handles ISO 15765-2 SF / FF / CF / FC frames manually and echoes back a positive response (`service_id + 0x40`).
+- **Device**: SIMULATE_0 (virtual CAN bus — no hardware needed)
+
+## Addressing
+
+| Parameter | Tester | ECU |
+|-----------|--------|-----|
+| TX ID | `0x7E0` | `0x7E8` |
+| RX ID | `0x7E8` | `0x7E0` |
+| Addressing | Normal | Normal |
+
+## Tests
+
+| # | Payload | Frame type | Pass condition |
+|---|---------|-----------|----------------|
+| 1 | 2 B | SF TX → SF RX | `resp[0] == 0x50`, `resp.length == 2` |
+| 2 | 8 B | MF TX → MF RX | `resp[0] == 0x62`, `resp.length == 8` |
+| 3 | 20 B | MF TX → MF RX | `resp[0] == 0x76`, `resp.length == 20` |
+| 4 | 500 B | MF TX → MF RX | `resp[0] == 0x76`, `resp.length == 500` |
+
+## How to Run
+
+1. Open `can_tp.ecb` in EcuBus-Pro
+2. Start the project — both nodes launch automatically
+3. Check the Tester log for pass / fail results
+
+Expected tester output:
+
+```
+[Tester] Connection ready
+
+=== Test 1: SF  2B ===
+  TX 2B: 10 01
+  RX 2B: 50 01
+  PASS ✓
+
+=== Test 2: MF  8B ===
+  TX 8B: 22 f1 80 01 02 03 04 05
+  RX 8B: 62 f1 80 01 02 03 04 05
+  PASS ✓
+
+=== Test 3: MF 20B ===
+  TX 20B: 36 01 02 03 04 05 06 07 ...
+  RX 20B: 76 01 02 03 04 05 06 07 ...
+  PASS ✓
+
+=== Test 4: MF 500B ===
+  TX 500B: 36 00 01 02 03 04 05 06 ...
+  RX 500B: 76 00 01 02 03 04 05 06 ...
+  PASS ✓
+
+[Tester] Done  4/4 passed
+```
+
+## Code Highlights
+
+### Tester — create connection and send/receive
+
+```typescript
+import { CanTpCreateConnection, CanTpSendData, CanTpRecvData, CanTpCloseConnection } from 'ECB'
+import type { CanTpAddr } from 'ECB'
+
+const addr: CanTpAddr = {
+  name: 'tester',
+  idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: false,
+  canIdTx: '0x7E0', canIdRx: '0x7E8',
+  addrFormat: CAN_ADDR_FORMAT.NORMAL, addrType: CAN_ADDR_TYPE.PHYSICAL,
+  SA: '0xF1', TA: '0x01', AE: '0x00',
+  nAs: 1000, nAr: 1000, nBs: 1000, nCr: 1500,
+  stMin: 0, bs: 0, maxWTF: 0, dlc: 8, padding: false, paddingValue: '0x00'
+}
+
+const handle = await CanTpCreateConnection(addr)
+await CanTpSendData(handle, [0x10, 0x01])
+const { data } = await CanTpRecvData(handle, 2000)
+await CanTpCloseConnection(handle)
+```
+
+### ECU — raw frame handler with Util.OnCan
+
+```typescript
+Util.OnCan(0x7E0, (msg) => {
+  const d = Array.from(msg.data)
+  const frameType = (d[0] >> 4) & 0x0f
+
+  if (frameType === 0) {           // SF — respond immediately
+    respond(d.slice(1, 1 + (d[0] & 0x0f)))
+  } else if (frameType === 1) {    // FF — send FC
+    rxState = { totalLen: ((d[0] & 0xf) << 8) | d[1], buf: [...d.slice(2)], expectedSN: 1 }
+    sendRaw([0x30, 0x00, 0x00])
+  } else if (frameType === 2) {    // CF — accumulate, respond when complete
+    rxState!.buf.push(...d.slice(1))
+    if (rxState!.buf.length >= rxState!.totalLen) respond(rxState!.buf)
+  } else if (frameType === 3) {    // FC — send remaining CFs
+    while (txState!.offset < txState!.data.length) { ... }
+  }
+})
+```
+
+## File Structure
+
+```
+can_tp/
+├── can_tp.ecb    # Project config (SIMULATE_0, two nodes)
+├── tester.ts     # Node 1 — CanTp* API demo
+├── ecu.ts        # Node 2 — Util.OnCan + output() ECU simulator
+├── readme.md
+└── readme.zh.md
+```
+
+## Real Hardware
+
+Replace `SIMULATE_0` with a real CAN device. For a two-node setup on the same physical bus, both channels must be able to ACK each other (separate channels connected back-to-back, or a real ECU on the bus). See the [EcuBus-Pro documentation](https://ecubus.org) for hardware configuration.

--- a/resources/examples/can_tp/readme.zh.md
+++ b/resources/examples/can_tp/readme.zh.md
@@ -1,0 +1,120 @@
+# CAN-TP 示例
+
+演示 ISO 15765-2（CAN 传输层协议）的 Worker API：`CanTpCreateConnection` / `CanTpSendData` / `CanTpRecvData`。无需真实硬件——两个节点运行在同一个虚拟 CAN 总线上即可。
+
+## 概述
+
+- **节点 1 (tester.ts)**：使用 `CanTp*` API 发送请求、接收响应。启动时自动执行四个测试，覆盖单帧和多帧场景，最大 500 字节。
+- **节点 2 (ecu.ts)**：用 `Util.OnCan` + `output()` 实现的模拟 ECU，手动处理 ISO 15765-2 的 SF / FF / CF / FC 帧，返回正响应（`service_id + 0x40`，其余字节原样）。
+- **设备**：SIMULATE_0（虚拟 CAN 总线，无需硬件）
+
+## 地址配置
+
+| 参数 | Tester | ECU |
+|------|--------|-----|
+| TX ID | `0x7E0` | `0x7E8` |
+| RX ID | `0x7E8` | `0x7E0` |
+| 寻址模式 | Normal | Normal |
+
+## 测试项
+
+| # | 数据长度 | 帧类型 | 通过条件 |
+|---|---------|--------|---------|
+| 1 | 2 B | SF TX → SF RX | `resp[0] == 0x50`，`resp.length == 2` |
+| 2 | 8 B | MF TX → MF RX | `resp[0] == 0x62`，`resp.length == 8` |
+| 3 | 20 B | MF TX → MF RX | `resp[0] == 0x76`，`resp.length == 20` |
+| 4 | 500 B | MF TX → MF RX | `resp[0] == 0x76`，`resp.length == 500` |
+
+## 如何运行
+
+1. 在 EcuBus-Pro 中打开 `can_tp.ecb`
+2. 启动工程，两个节点自动运行
+3. 查看 Tester 节点日志
+
+预期 Tester 输出：
+
+```
+[Tester] Connection ready
+
+=== Test 1: SF  2B ===
+  TX 2B: 10 01
+  RX 2B: 50 01
+  PASS ✓
+
+=== Test 2: MF  8B ===
+  TX 8B: 22 f1 80 01 02 03 04 05
+  RX 8B: 62 f1 80 01 02 03 04 05
+  PASS ✓
+
+=== Test 3: MF 20B ===
+  TX 20B: 36 01 02 03 04 05 06 07 ...
+  RX 20B: 76 01 02 03 04 05 06 07 ...
+  PASS ✓
+
+=== Test 4: MF 500B ===
+  TX 500B: 36 00 01 02 03 04 05 06 ...
+  RX 500B: 76 00 01 02 03 04 05 06 ...
+  PASS ✓
+
+[Tester] Done  4/4 passed
+```
+
+## 代码要点
+
+### Tester — 创建连接并收发数据
+
+```typescript
+import { CanTpCreateConnection, CanTpSendData, CanTpRecvData, CanTpCloseConnection } from 'ECB'
+import type { CanTpAddr } from 'ECB'
+
+const addr: CanTpAddr = {
+  name: 'tester',
+  idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: false,
+  canIdTx: '0x7E0', canIdRx: '0x7E8',
+  addrFormat: CAN_ADDR_FORMAT.NORMAL, addrType: CAN_ADDR_TYPE.PHYSICAL,
+  SA: '0xF1', TA: '0x01', AE: '0x00',
+  nAs: 1000, nAr: 1000, nBs: 1000, nCr: 1500,
+  stMin: 0, bs: 0, maxWTF: 0, dlc: 8, padding: false, paddingValue: '0x00'
+}
+
+const handle = await CanTpCreateConnection(addr)
+await CanTpSendData(handle, [0x10, 0x01])
+const { data } = await CanTpRecvData(handle, 2000)
+await CanTpCloseConnection(handle)
+```
+
+### ECU — 用 Util.OnCan 处理原始帧
+
+```typescript
+Util.OnCan(0x7E0, (msg) => {
+  const d = Array.from(msg.data)
+  const frameType = (d[0] >> 4) & 0x0f
+
+  if (frameType === 0) {           // SF — 直接回复
+    respond(d.slice(1, 1 + (d[0] & 0x0f)))
+  } else if (frameType === 1) {    // FF — 发 FC
+    rxState = { totalLen: ((d[0] & 0xf) << 8) | d[1], buf: [...d.slice(2)], expectedSN: 1 }
+    sendRaw([0x30, 0x00, 0x00])
+  } else if (frameType === 2) {    // CF — 累积，完整后回复
+    rxState!.buf.push(...d.slice(1))
+    if (rxState!.buf.length >= rxState!.totalLen) respond(rxState!.buf)
+  } else if (frameType === 3) {    // FC — 发送剩余 CF
+    while (txState!.offset < txState!.data.length) { ... }
+  }
+})
+```
+
+## 文件结构
+
+```
+can_tp/
+├── can_tp.ecb    # 工程配置（SIMULATE_0，两个节点）
+├── tester.ts     # 节点 1 — CanTp* API 演示
+├── ecu.ts        # 节点 2 — Util.OnCan + output() 模拟 ECU
+├── readme.md
+└── readme.zh.md
+```
+
+## 真实硬件
+
+将 SIMULATE_0 替换为真实 CAN 设备。双节点在同一物理总线上通信时，两个通道必须能互相 ACK（背靠背连接的两个通道，或总线上接有真实 ECU）。详见 [EcuBus-Pro 文档](https://ecubus.org)。

--- a/resources/examples/can_tp/tester.ts
+++ b/resources/examples/can_tp/tester.ts
@@ -1,0 +1,108 @@
+/**
+ * CAN-TP tester — demonstrates CanTpCreateConnection / CanTpSendData / CanTpRecvData.
+ *
+ * TX = 0x7E0  (Tester → ECU)
+ * RX = 0x7E8  (ECU → Tester)
+ *
+ * Runs four tests automatically on startup:
+ *   Test 1 — Single Frame  TX → Single Frame  RX   (2 bytes)
+ *   Test 2 — Multi  Frame  TX → Multi  Frame  RX   (8 bytes)
+ *   Test 3 — Multi  Frame  TX → Multi  Frame  RX   (20 bytes)
+ *   Test 4 — Multi  Frame  TX → Multi  Frame  RX   (500 bytes)
+ */
+import {
+  CanTpCreateConnection,
+  CanTpSendData,
+  CanTpRecvData,
+  CanTpCloseConnection,
+  CAN_ADDR_FORMAT,
+  CAN_ADDR_TYPE,
+  CAN_ID_TYPE
+} from 'ECB'
+import type { CanTpAddr } from 'ECB'
+
+const addr: CanTpAddr = {
+  name: 'tester',
+  idType: CAN_ID_TYPE.STANDARD,
+  brs: false,
+  canfd: false,
+  remote: false,
+  canIdTx: '0x7E0',
+  canIdRx: '0x7E8',
+  addrFormat: CAN_ADDR_FORMAT.NORMAL,
+  addrType: CAN_ADDR_TYPE.PHYSICAL,
+  SA: '0xF1',
+  TA: '0x01',
+  AE: '0x00',
+  nAs: 1000,
+  nAr: 1000,
+  nBs: 1000,
+  nCr: 1500,
+  stMin: 0,
+  bs: 0,
+  maxWTF: 0,
+  dlc: 8,
+  padding: false,
+  paddingValue: '0x00'
+}
+
+function preview(bytes: number[], maxBytes = 8): string {
+  const hex = bytes
+    .slice(0, maxBytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ')
+  return bytes.length > maxBytes ? `${hex} ...` : hex
+}
+
+async function runTest(
+  handle: string,
+  label: string,
+  request: number[],
+  expectedFirstByte: number
+): Promise<boolean> {
+  console.log(`=== ${label} ===`)
+  console.log(`  TX ${request.length}B: ${preview(request)}`)
+  try {
+    await CanTpSendData(handle, request)
+    const { data } = await CanTpRecvData(handle, 3000)
+    console.log(`  RX ${data.length}B: ${preview(data)}`)
+    const pass = data[0] === expectedFirstByte && data.length === request.length
+    console.log(`  ${pass ? 'PASS ✓' : 'FAIL ✗'}\n`)
+    return pass
+  } catch (e: any) {
+    console.error(`  Error: ${e.message}\n`)
+    return false
+  }
+}
+
+Util.OnKey('c', async () => {
+  // Give the ECU node a moment to register its OnCan listener
+  await new Promise((r) => setTimeout(r, 200))
+
+  const handle = await CanTpCreateConnection(addr)
+  console.log('[Tester] Connection ready\n')
+
+  let passed = 0
+  const total = 4
+
+  // Test 1 — Single Frame (2 bytes)
+  if (await runTest(handle, 'Test 1: SF  2B', [0x10, 0x01], 0x50)) passed++
+
+  // Test 2 — Multi Frame (8 bytes)
+  if (
+    await runTest(handle, 'Test 2: MF  8B', [0x22, 0xf1, 0x80, 0x01, 0x02, 0x03, 0x04, 0x05], 0x62)
+  )
+    passed++
+
+  // Test 3 — Multi Frame (20 bytes)
+  const req20 = [0x36, ...Array.from({ length: 19 }, (_, i) => (i + 1) & 0xff)]
+  if (await runTest(handle, 'Test 3: MF 20B', req20, 0x76)) passed++
+
+  // Test 4 — Multi Frame (500 bytes)
+  // First byte = service 0x36 (TransferData), rest filled with a repeating pattern 0x00..0xFE
+  const req500 = [0x36, ...Array.from({ length: 499 }, (_, i) => i & 0xff)]
+  if (await runTest(handle, 'Test 4: MF 500B', req500, 0x76)) passed++
+
+  await CanTpCloseConnection(handle)
+  console.log(`[Tester] Done  ${passed}/${total} passed`)
+})

--- a/src/main/nodeItem.ts
+++ b/src/main/nodeItem.ts
@@ -12,7 +12,7 @@ import UdsTester, {
   SerialPortApi,
   SomeipApiCall
 } from './workerClient'
-import { CAN_TP, TpError as CanTpError } from './docan/cantp'
+import { CAN_TP, CAN_TP_SOCKET, TpError as CanTpError } from './docan/cantp'
 import { UdsLOG, VarLOG } from './log'
 import { applyBuffer, getRxPdu, getTxPdu, PwmBaseInfo, ServiceItem, UdsDevice } from './share/uds'
 import { findService, UDSTesterMain } from './docan/uds'
@@ -80,6 +80,7 @@ export class NodeClass {
   pool?: UdsTester
   private cantp: CAN_TP[] = []
   private lintp: LIN_TP[] = []
+  private cantpSocketMap: Map<string, { tp: CAN_TP; socket: CAN_TP_SOCKET }> = new Map()
   private linBaseId: string[] = []
   private canBaseId: string[] = []
   private ethBaseId: string[] = []
@@ -944,7 +945,58 @@ export class NodeClass {
       }
     }
   }
-  async canApi(data: any) {}
+  async canApi(data: any): Promise<any> {
+    const { op } = data
+
+    const findCanBase = (device?: string) => {
+      if (device != undefined) {
+        for (const channelId of this.canBaseId) {
+          const item = this.canBaseMap.get(channelId)
+          if (item && item.info.name == device) return item
+        }
+        throw new Error(`CAN device '${device}' not found`)
+      }
+      if (this.canBaseId.length > 0) {
+        const item = this.canBaseMap.get(this.canBaseId[0])
+        if (item) return item
+      }
+      throw new Error('no CAN device attached to this node')
+    }
+
+    if (op === 'createConnection') {
+      const base = findCanBase(data.device)
+      const tp = new CAN_TP(base)
+      const socket = new CAN_TP_SOCKET(tp, data.addr)
+      const handle = `cantp-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      this.cantpSocketMap.set(handle, { tp, socket })
+      return handle
+    }
+
+    if (op === 'closeConnection') {
+      const entry = this.cantpSocketMap.get(data.handle)
+      if (!entry) throw new Error(`CAN-TP handle '${data.handle}' not found`)
+      entry.socket.close()
+      entry.tp.close(false)
+      this.cantpSocketMap.delete(data.handle)
+      return
+    }
+
+    if (op === 'sendData') {
+      const entry = this.cantpSocketMap.get(data.handle)
+      if (!entry) throw new Error(`CAN-TP handle '${data.handle}' not found`)
+      const ts = await entry.socket.write(Buffer.from(data.data))
+      return ts
+    }
+
+    if (op === 'recvData') {
+      const entry = this.cantpSocketMap.get(data.handle)
+      if (!entry) throw new Error(`CAN-TP handle '${data.handle}' not found`)
+      const result = await entry.socket.read(data.timeout ?? 5000)
+      return { data: Array.from(result.data), ts: result.ts }
+    }
+
+    throw new Error(`unknown canApi op: ${op}`)
+  }
 
   private resolveSomeipClient(channel?: string): VSomeIP_Client {
     if (channel) {
@@ -1447,6 +1499,11 @@ export class NodeClass {
     this.cantp.forEach((tp) => {
       tp.close(false)
     })
+    for (const { socket, tp } of this.cantpSocketMap.values()) {
+      socket.close()
+      tp.close(false)
+    }
+    this.cantpSocketMap.clear()
     this.lintp.forEach((tp) => {
       tp.close(false)
     })

--- a/src/main/worker/cantp.ts
+++ b/src/main/worker/cantp.ts
@@ -1,0 +1,143 @@
+/**
+ * CAN-TP (ISO 15765-2) worker API — send and receive multi-frame CAN data via the transport layer.
+ *
+ * @remarks
+ * All functions bridge to the main process via `emitWorkerEventWithReply('canApi', ...)`.
+ * Use {@link CanTpCreateConnection} to obtain a handle, then pass that handle to the
+ * send / recv helpers. Always call {@link CanTpCloseConnection} when done.
+ *
+ * @module cantp
+ * @category CAN-TP
+ *
+ * @example
+ * ```ts
+ * import { CanTpCreateConnection, CanTpSendData, CanTpRecvData, CanTpCloseConnection } from 'ecubus-worker'
+ * import { CAN_ADDR_FORMAT, CAN_ADDR_TYPE, CAN_ID_TYPE } from 'ecubus-worker'
+ *
+ * Util.Init(async () => {
+ *   const addr: CanTpAddr = {
+ *     name: 'myConn',
+ *     idType: CAN_ID_TYPE.STANDARD,
+ *     brs: false,
+ *     canfd: false,
+ *     remote: false,
+ *     canIdTx: '0x7E0',
+ *     canIdRx: '0x7E8',
+ *     addrFormat: CAN_ADDR_FORMAT.NORMAL,
+ *     addrType: CAN_ADDR_TYPE.PHYSICAL,
+ *     SA: '0xF1',
+ *     TA: '0x01',
+ *     AE: '0x00',
+ *     nAs: 1000, nAr: 1000, nBs: 1000, nCr: 1000,
+ *     stMin: 0, bs: 0, maxWTF: 0,
+ *     dlc: 8, padding: false, paddingValue: '0x00'
+ *   }
+ *
+ *   const handle = await CanTpCreateConnection(addr)
+ *   await CanTpSendData(handle, [0x10, 0x01])
+ *   const { data, ts } = await CanTpRecvData(handle, 5000)
+ *   console.log('received:', data)
+ *   await CanTpCloseConnection(handle)
+ * })
+ * ```
+ */
+
+import { emitWorkerEventWithReply } from './uds'
+import type { CanAddr } from '../share/can'
+
+/**
+ * CAN-TP addressing configuration passed to {@link CanTpCreateConnection}.
+ * Mirrors the main-process `CanAddr` interface — all fields are the same.
+ * @category CAN-TP
+ */
+export type CanTpAddr = CanAddr
+
+/**
+ * Create a CAN-TP connection and return an opaque handle string.
+ *
+ * @param addr - Full addressing configuration (TX/RX IDs, format, timing, etc.)
+ * @param device - Optional device name (channel name as configured in the project).
+ *   When omitted the first CAN channel attached to this node is used.
+ * @returns Opaque handle string to pass to the other CanTp* functions.
+ * @throws If no suitable CAN device is found, or if the connection cannot be opened.
+ *
+ * @category CAN-TP
+ *
+ * @example
+ * ```ts
+ * const handle = await CanTpCreateConnection(addr, 'CAN1')
+ * ```
+ */
+export async function CanTpCreateConnection(addr: CanTpAddr, device?: string): Promise<string> {
+  const handle = await emitWorkerEventWithReply('canApi', {
+    op: 'createConnection',
+    addr,
+    device
+  })
+  return handle as string
+}
+
+/**
+ * Close a CAN-TP connection previously opened with {@link CanTpCreateConnection}.
+ *
+ * @param handle - Handle returned by {@link CanTpCreateConnection}.
+ *
+ * @category CAN-TP
+ *
+ * @example
+ * ```ts
+ * await CanTpCloseConnection(handle)
+ * ```
+ */
+export async function CanTpCloseConnection(handle: string): Promise<void> {
+  await emitWorkerEventWithReply('canApi', { op: 'closeConnection', handle })
+}
+
+/**
+ * Send data over CAN-TP.
+ * Automatically chooses single-frame or multi-frame segmentation based on the data length.
+ *
+ * @param handle - Handle returned by {@link CanTpCreateConnection}.
+ * @param data - Payload bytes (1 – 4095 bytes).
+ * @returns Transmission timestamp in microseconds.
+ * @throws {@link TpError} on bus error, timeout or protocol violation.
+ *
+ * @category CAN-TP
+ *
+ * @example
+ * ```ts
+ * const ts = await CanTpSendData(handle, [0x10, 0x01])
+ * ```
+ */
+export async function CanTpSendData(handle: string, data: number[] | Buffer): Promise<number> {
+  const ts = await emitWorkerEventWithReply('canApi', {
+    op: 'sendData',
+    handle,
+    data: Array.from(data)
+  })
+  return ts as number
+}
+
+/**
+ * Receive data over CAN-TP, waiting up to `timeout` milliseconds.
+ *
+ * @param handle - Handle returned by {@link CanTpCreateConnection}.
+ * @param timeout - Maximum wait time in milliseconds (default: 5000).
+ * @returns Object with `data` (received bytes as a number array) and `ts` (timestamp in µs).
+ * @throws {@link TpError} on timeout, bus error or protocol violation.
+ *
+ * @category CAN-TP
+ *
+ * @example
+ * ```ts
+ * const { data, ts } = await CanTpRecvData(handle, 5000)
+ * console.log('received:', data.map(b => b.toString(16)).join(' '))
+ * ```
+ */
+export async function CanTpRecvData(
+  handle: string,
+  timeout = 5000
+): Promise<{ data: number[]; ts: number }> {
+  const result = await emitWorkerEventWithReply('canApi', { op: 'recvData', handle, timeout })
+  return result as { data: number[]; ts: number }
+}

--- a/src/main/worker/index.ts
+++ b/src/main/worker/index.ts
@@ -36,6 +36,7 @@
 
 export * from './uds'
 export * from './someip'
+export * from './cantp'
 export * from './secureAccess'
 export * from './crc'
 export * from './cryptoExt'

--- a/src/main/workerClient.ts
+++ b/src/main/workerClient.ts
@@ -38,7 +38,7 @@ type HandlerMap = {
     data: linApiStartSch | linApiStopSch | linApiPowerCtrl | linApiBaudRateCtrl
   ) => void | Promise<number> | Promise<void>
   pwmApi: (data: pwmApiSetDuty) => void
-  canApi: (data: any) => void
+  canApi: (data: any) => Promise<any>
   pluginEvent: (data: { name: string; data: any }) => void
   serialPortApi: (data: SerialPortApi) => Promise<any>
   someipApi: (data: SomeipApiCall) => Promise<any>


### PR DESCRIPTION
Expose ISO 15765-2 transport layer to worker scripts via four new functions: CanTpCreateConnection, CanTpSendData, CanTpRecvData and CanTpCloseConnection. Connections are managed per-node in NodeClass and cleaned up automatically on close.

Also adds resources/examples/can_tp — a simulate-device example with a Tester node (CanTp* API) and an ECU node (Util.OnCan + output()), covering SF and MF transfers up to 500 bytes.

Changes:
- src/main/worker/cantp.ts: new worker-side API module
- src/main/worker/index.ts: export into worker bundle
- src/main/workerClient.ts: canApi handler return type -> Promise<any>
- src/main/nodeItem.ts: implement canApi(), manage cantpSocketMap
- resources/examples/can_tp/: example project with README (en/zh)