### PR TITLE
Refactor Candle capabilities and enhance timing features

### DIFF
--- a/src/main/docan/candle/api/candle.c
+++ b/src/main/docan/candle/api/candle.c
@@ -303,8 +303,10 @@ static bool candle_dev_interal_open(candle_handle hdev)
         dev->last_error = CANDLE_ERR_GET_BITTIMING_CONST;
         goto winusb_free;
     }
-    candle_capability_extended_t cap_externd;
+    memset(&dev->data_bt_const, 0, sizeof(dev->data_bt_const));
     if (dev->bt_const.feature & CANDLE_MODE_FD) {
+        candle_capability_extended_t cap_externd;
+        memset(&cap_externd, 0, sizeof(cap_externd));
         if (!candle_ctrl_get_capability_externd(dev, 0, &cap_externd)) {
             dev->last_error = CANDLE_ERR_GET_DATA_BITTIMING_CONST;
             goto winusb_free;
@@ -446,65 +448,49 @@ bool __stdcall DLL candle_channel_set_bitrate(candle_handle hdev, uint8_t ch, ui
     // TODO ensure device is open, check channel count..
     candle_device_t *dev = (candle_device_t*)hdev;
 
-    if (dev->bt_const.fclk_can != 48000000) {
-        /* this function only works for the candleLight base clock of 48MHz */
+    uint32_t fclk = dev->bt_const.fclk_can;
+    if (fclk == 0) {
         dev->last_error = CANDLE_ERR_BITRATE_FCLK;
         return false;
     }
 
-    candle_bittiming_t t;
-    t.prop_seg = 1;
-    t.sjw = 1;
-    t.phase_seg1 = 13 - t.prop_seg;
-    t.phase_seg2 = 2;
+    uint32_t prop_seg = 1;
+    uint32_t phase_seg1 = 12;
+    uint32_t phase_seg2 = 2;
+    uint32_t sjw = 1;
+    uint32_t total_tq = 1 + prop_seg + phase_seg1 + phase_seg2;
 
-    switch (bitrate) {
-        case 10000:
-            t.brp = 300;
-            break;
+    uint32_t brp = fclk / (bitrate * total_tq);
 
-        case 20000:
-            t.brp = 150;
-            break;
-
-        case 50000:
-            t.brp = 60;
-            break;
-
-        case 83333:
-            t.brp = 36;
-            break;
-
-        case 100000:
-            t.brp = 30;
-            break;
-
-        case 125000:
-            t.brp = 24;
-            break;
-
-        case 250000:
-            t.brp = 12;
-            break;
-
-        case 500000:
-            t.brp = 6;
-            break;
-
-        case 800000:
-            t.brp = 4;
-            t.phase_seg1 = 12 - t.prop_seg;
-            t.phase_seg2 = 2;
-            break;
-
-        case 1000000:
-            t.brp = 3;
-            break;
-
-        default:
-            dev->last_error = CANDLE_ERR_BITRATE_UNSUPPORTED;
-            return false;
+    // Adjust BRP if it falls outside device limits
+    if (brp < dev->bt_const.brp_min) {
+        brp = dev->bt_const.brp_min;
     }
+    if (brp > dev->bt_const.brp_max) {
+        dev->last_error = CANDLE_ERR_BITRATE_UNSUPPORTED;
+        return false;
+    }
+
+    // Verify the resulting bitrate is reasonably close
+    uint32_t actual_bitrate = fclk / (brp * total_tq);
+    uint32_t error;
+    if (actual_bitrate > bitrate) {
+        error = actual_bitrate - bitrate;
+    } else {
+        error = bitrate - actual_bitrate;
+    }
+    // Allow up to 2% error for the convenience function
+    if (error > bitrate / 50) {
+        dev->last_error = CANDLE_ERR_BITRATE_UNSUPPORTED;
+        return false;
+    }
+
+    candle_bittiming_t t;
+    t.prop_seg = prop_seg;
+    t.phase_seg1 = phase_seg1;
+    t.phase_seg2 = phase_seg2;
+    t.sjw = sjw;
+    t.brp = brp;
 
     return candle_ctrl_set_bittiming(dev, ch, &t);
 }
@@ -544,15 +530,15 @@ bool __stdcall DLL candle_frame_send(candle_handle hdev, uint8_t ch, candle_fram
     candle_device_t *dev = (candle_device_t*)hdev;
 
     unsigned long bytes_sent = 0;
-    uint32_t size;
 
     frame->echo_id = 0;
     frame->channel = ch;
 
+    uint32_t size;
     if (frame->flags & CANDLE_FLAG_FD) {
-        size = 12 + sizeof(struct canfd);
+        size = 12 + 64;
     } else {
-        size = 12 + sizeof(struct classic_can);
+        size = 12 + 8;
     }
 
     bool rc = WinUsb_WritePipe(

--- a/src/main/docan/candle/index.ts
+++ b/src/main/docan/candle/index.ts
@@ -88,25 +88,6 @@ export class Candle_CAN extends CanBase {
       throw new Error('Clock frequency is not set')
     }
 
-    // 检查波特率配置
-    const CLOCK = Number(this.info.bitrate.clock) * 1000000
-
-    // 检查普通CAN波特率
-    if (info.bitrate.freq) {
-      const calcFreq = Math.floor(
-        CLOCK / (info.bitrate.preScaler * (1 + info.bitrate.timeSeg1 + info.bitrate.timeSeg2))
-      )
-      // 允许1%的误差
-      if (Math.abs(calcFreq - info.bitrate.freq) / info.bitrate.freq > 0.01) {
-        throw new Error(
-          `Invalid CAN bitrate config: expected ${info.bitrate.freq}, got ${calcFreq}. ` +
-            `preScaler=${info.bitrate.preScaler}, ` +
-            `timeSeg1=${info.bitrate.timeSeg1}, ` +
-            `timeSeg2=${info.bitrate.timeSeg2}`
-        )
-      }
-    }
-
     this.event = new EventEmitter()
 
     this.log = new CanLOG('CANABLE', info.name, this.id, this.event)
@@ -116,9 +97,36 @@ export class Candle_CAN extends CanBase {
     }
 
     try {
-      // Check baud rate parameters against device capabilities
+      // Use the device's actual clock frequency from BT_CONST for all calculations
       const cap = this.target.bt_const
       const data_cap = this.target.data_bt_const
+      const userClock = Number(this.info.bitrate.clock) * 1000000
+
+      // If user-specified clock doesn't match device's actual fclk_can,
+      // auto-correct to use the device's clock (with a warning)
+      if (userClock != cap.fclk_can) {
+        sysLog.warn(
+          `Clock frequency auto-corrected: user specified ${userClock} Hz, device reports ${cap.fclk_can} Hz. Using device clock.`
+        )
+      }
+      const actualClock = cap.fclk_can
+
+      // Validate baud rate config against the device's actual clock
+      if (info.bitrate.freq) {
+        const calcFreq = Math.floor(
+          actualClock /
+            (info.bitrate.preScaler * (1 + info.bitrate.timeSeg1 + info.bitrate.timeSeg2))
+        )
+        // Allow 1% error tolerance
+        if (Math.abs(calcFreq - info.bitrate.freq) / info.bitrate.freq > 0.01) {
+          throw new Error(
+            `Invalid CAN bitrate config: expected ${info.bitrate.freq} Hz, got ${calcFreq} Hz (fclk=${actualClock}). ` +
+              `preScaler=${info.bitrate.preScaler}, ` +
+              `timeSeg1=${info.bitrate.timeSeg1}, ` +
+              `timeSeg2=${info.bitrate.timeSeg2}`
+          )
+        }
+      }
       if (Candle_CAN.candleOpened == false) {
         const candleInfo = {
           channel_count: this.target.dconf.icount,
@@ -158,12 +166,6 @@ export class Candle_CAN extends CanBase {
         }
         Candle_CAN.candleOpened = true
       }
-      if (CLOCK != cap.fclk_can) {
-        throw new Error(
-          `Clock frequency mismatch: expected ${CLOCK}, got ${cap.fclk_can}, open fail, please modify parameters and start again`
-        )
-      }
-      // Check time segments
       if (info.bitrate.timeSeg1 < cap.tseg1_min || info.bitrate.timeSeg1 > cap.tseg1_max) {
         throw new Error(
           `Time segment 1 (${info.bitrate.timeSeg1}) out of valid range [${cap.tseg1_min}-${cap.tseg1_max}], open fail, please modify parameters and start again`
@@ -243,6 +245,14 @@ export class Candle_CAN extends CanBase {
       let flag = 0
       //canfd config
       if (info.canfd && info.bitratefd) {
+        // Verify device actually supports CAN FD before proceeding
+        // (GS_CAN_FEATURE_FD = BIT(8) = 0x100, same as CANDLE_MODE_FD)
+        if (!(cap.feature & 0x100)) {
+          throw new Error(
+            'CAN FD is enabled in configuration but the device does not support CAN FD. ' +
+              'Please disable CAN FD in the hardware settings, or use a CAN FD capable device.'
+          )
+        }
         //check
         const canfd_cap = this.target.data_bt_const
         if (
@@ -521,11 +531,53 @@ export class Candle_CAN extends CanBase {
         // 直接使用设备对象获取友好名称
         const pathStr = Candle.GetDevicePath(device)
         const friendlyNameStr = Candle.GetDeviceFriendlyName(device)
+
+        // Extract capability info from device bt_const (already populated during scan)
+        const cap = device.bt_const
+        const candleCap = {
+          feature: cap.feature,
+          fclk_can: cap.fclk_can,
+          tseg1_min: cap.tseg1_min,
+          tseg1_max: cap.tseg1_max,
+          tseg2_min: cap.tseg2_min,
+          tseg2_max: cap.tseg2_max,
+          sjw_max: cap.sjw_max,
+          brp_min: cap.brp_min,
+          brp_max: cap.brp_max,
+          brp_inc: cap.brp_inc
+        }
+
+        let candleDataCap = null
+        // Check if device supports CAN FD (feature bit 8 = 0x100)
+        if (cap.feature & 0x100) {
+          const dataCap = device.data_bt_const
+          candleDataCap = {
+            feature: dataCap.feature,
+            fclk_can: dataCap.fclk_can,
+            tseg1_min: dataCap.tseg1_min,
+            tseg1_max: dataCap.tseg1_max,
+            tseg2_min: dataCap.tseg2_min,
+            tseg2_max: dataCap.tseg2_max,
+            sjw_max: dataCap.sjw_max,
+            brp_min: dataCap.brp_min,
+            brp_max: dataCap.brp_max,
+            brp_inc: dataCap.brp_inc
+          }
+        }
+
         devices.push({
           label: friendlyNameStr,
           id: `Candle_${device.interfaceNumber}`,
           handle: device.interfaceNumber,
-          serialNumber: pathStr
+          serialNumber: pathStr,
+          extra: {
+            candle: {
+              cap: candleCap,
+              dataCap: candleDataCap || undefined,
+              fdSupported: !!(cap.feature & 0x100),
+              Res: !!(cap.feature & 0x800)
+            }
+          }
           // serialNumber: pathStr
         })
       }

--- a/src/main/share/can.ts
+++ b/src/main/share/can.ts
@@ -469,13 +469,34 @@ export interface CanAddr extends CanMsgType {
   paddingValue: string
 }
 
+export interface CandleCapability {
+  feature: number
+  fclk_can: number
+  tseg1_min: number
+  tseg1_max: number
+  tseg2_min: number
+  tseg2_max: number
+  sjw_max: number
+  brp_min: number
+  brp_max: number
+  brp_inc: number
+}
+
 export interface CanDevice {
   label: string
   id: string
   handle: any
   serialNumber?: string
   busy?: boolean
-  candleRes?: boolean
+  /** Vendor-specific metadata, keyed by vendor name */
+  extra?: {
+    candle?: {
+      cap?: CandleCapability
+      dataCap?: CandleCapability
+      fdSupported?: boolean
+      Res?: boolean
+    }
+  }
 }
 
 export interface CanEventMap {

--- a/src/renderer/src/views/uds/hardware/BitTimingCalculator.vue
+++ b/src/renderer/src/views/uds/hardware/BitTimingCalculator.vue
@@ -118,16 +118,14 @@ function calculate() {
   const tseg2Min = props.ability.tsg2?.min || 1
   const tseg2Max = props.ability.tsg2?.max || 128
 
-  // Calculate target number of time quanta
-  const targetTq = clock / bitrate
-
   // Enumerate all possible combinations
   for (let presc = prescalerMin; presc <= prescalerMax; presc++) {
-    // Skip if clock/prescaler is not integer
+    // Clock must be divisible by prescaler
     if (clock % presc !== 0) continue
 
-    // Calculate total time quanta for this prescaler
-    const totalTq = Math.round(targetTq / presc)
+    // Total time quanta must be an exact integer for exact baud rate match
+    const totalTq = clock / (presc * bitrate)
+    if (totalTq !== Math.floor(totalTq)) continue
 
     // Enumerate all possible TSEG1 values
     for (let t1 = tseg1Min; t1 <= tseg1Max; t1++) {
@@ -156,6 +154,29 @@ function calculate() {
 
   // Sort results by sp
   results.value = newResults.sort((a, b) => a.sp - b.sp)
+
+  // Auto-select the best row: baud rate is already exact, prefer sample point in 75%-85%
+  if (newResults.length > 0) {
+    // First try to find rows within [75, 85] range
+    const inRange = newResults.filter((r) => r.sp >= 75 && r.sp <= 85)
+    if (inRange.length > 0) {
+      // Pick the one closest to 80% (center of ideal range)
+      const TARGET_SP = 80
+      let best = inRange[0]
+      for (const r of inRange) {
+        if (Math.abs(r.sp - TARGET_SP) < Math.abs(best.sp - TARGET_SP)) best = r
+      }
+      selectedRow.value = best
+    } else {
+      // Fallback: closest to 80% among all results
+      const TARGET_SP = 80
+      let best = newResults[0]
+      for (const r of newResults) {
+        if (Math.abs(r.sp - TARGET_SP) < Math.abs(best.sp - TARGET_SP)) best = r
+      }
+      selectedRow.value = best
+    }
+  }
 }
 
 function handleCurrentChange(row: CalculatorResult) {

--- a/src/renderer/src/views/uds/hardware/canNode.vue
+++ b/src/renderer/src/views/uds/hardware/canNode.vue
@@ -69,7 +69,7 @@
       </el-select>
     </el-form-item>
     <el-form-item
-      v-else-if="props.vendor == 'candle'"
+      v-else-if="props.vendor == 'candle' && getSelectedCandleDevice()?.extra?.candle?.Res"
       :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
       prop="candleRes"
       :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
@@ -118,12 +118,13 @@
     </el-divider>
 
     <el-form-item label-width="0">
-      <el-col :span="12">
+      <el-col v-if="showCanFdCheckbox" :span="12">
         <el-form-item :label="i18next.t('uds.hardware.canNode.labels.canFdEnable')" prop="canfd">
           <el-checkbox v-model="data.canfd" @change="canFdChange" />
         </el-form-item>
       </el-col>
-      <el-col :span="12">
+      <!-- Non-candle: clock frequency dropdown -->
+      <el-col v-if="props.vendor !== 'candle'" :span="12">
         <el-form-item
           v-if="vendorConfigLimit.clock"
           :label="i18next.t('uds.hardware.canNode.labels.clockFreq')"
@@ -136,10 +137,7 @@
                 <template #content>
                   {{ i18next.t('uds.hardware.canNode.tooltips.clockFreq') }}
                 </template>
-
-                <el-icon>
-                  <InfoFilled />
-                </el-icon>
+                <el-icon><InfoFilled /></el-icon>
               </el-tooltip>
             </span>
           </template>
@@ -160,80 +158,60 @@
           </el-select>
         </el-form-item>
       </el-col>
-      <!-- <el-col :span="12">
-        <el-form-item label="DLC" prop="dlc">
-          <template #label="{ label }">
-            <span class="vm">
-              <span style="margin-right: 2px">{{ label }}</span>
-              <el-tooltip>
-                <template #content>
-                  CAN:0:0,1:1,2:2,3:3,4:4,5:5,6:6,7:7,8:8,9-15:8<br>
-                  CAN-FD:0:0,1:1,2:2,3:3,4:4,5:5,6:6,7:7,8:8,9:12,10:16,11:20,12:24,13:32,14:48,15:64
-                </template>
-
-                <el-icon>
-                  <InfoFilled />
-                </el-icon>
-              </el-tooltip>
-            </span>
-          </template>
-          <el-input-number :min="8" :max="15" v-model="data.dlc" controls-position="right" />
+      <!-- Candle: clock is fixed, shown as info tag -->
+      <el-col v-if="showCandleTimingTable" :span="12">
+        <el-form-item :label="i18next.t('uds.hardware.canNode.labels.clockFreq')">
+          <el-tag type="info"
+            >{{ selectedCandleClock ?? '?' }} MHz（{{
+              i18next.t('uds.hardware.canNode.labels.hardware')
+            }}）</el-tag
+          >
         </el-form-item>
-      </el-col> -->
+      </el-col>
     </el-form-item>
-    <!-- <el-form-item label-width="0">
 
-      <el-col :span="12">
-        <el-form-item label="Padding Enable" prop="padding">
-          <el-checkbox v-model="data.padding" />
-        </el-form-item>
-      </el-col>
-      <el-col :span="12">
-        <el-form-item label="Padding Value" prop="paddingValue">
-          <el-input v-model="data.paddingValue" :disabled="!data.padding" />
-        </el-form-item>
-      </el-col>
-
-    </el-form-item> -->
+    <!-- vxe-grid for all vendors (candle uses same style + calculator button) -->
     <el-form-item label-width="0" prop="bitrate">
       <vxe-grid v-bind="gridOptions" style="width: 100%">
-        <template #edit_freq="{ row }">
-          <el-input v-model.number="row.freq" style="width: 100%" />
-        </template>
+        <template #edit_freq="{ row }"
+          ><el-input v-model.number="row.freq" style="width: 100%"
+        /></template>
         <template #default_time="{ row }">
-          <el-tooltip effect="light" placement="bottom">
-            <template #content>
-              {{ i18next.t('uds.hardware.canNode.tooltips.bitTimingCalculator') }}
-            </template>
-            <el-button type="primary" size="small" plain @click="showCalculator(row)">
-              <Icon :icon="tableIcon" />
-            </el-button>
+          <el-tooltip effect="light" placement="bottom"
+            ><template #content>{{
+              i18next.t('uds.hardware.canNode.tooltips.bitTimingCalculator')
+            }}</template>
+            <el-button type="primary" size="small" plain @click="showCalculator(row)"
+              ><Icon :icon="tableIcon"
+            /></el-button>
           </el-tooltip>
         </template>
-        <template #default_clock="{ row, rowIndex }">
-          <span v-if="rowIndex == 0">{{ row.clock }}</span>
-          <span v-else>{{ data.bitrate.clock }}</span>
-        </template>
-        <template #edit_preScaler="{ row }">
-          <el-input-number v-model="row.preScaler" controls-position="right" />
-        </template>
-        <template #edit_sjw="{ row }">
-          <el-input-number v-model="row.sjw" :min="1" controls-position="right" />
-        </template>
-        <template #edit_timeSeg1="{ row }">
-          <el-input-number v-model="row.timeSeg1" controls-position="right" />
-        </template>
-        <template #edit_timeSeg2="{ row }">
-          <el-input-number v-model="row.timeSeg2" controls-position="right" />
-        </template>
-        <template #edit_zlg="{ row, rowIndex }">
-          <el-input v-if="rowIndex == 0" v-model="row.zlgSpec" />
-        </template>
-        <template #default_baudrate="{ row, rowIndex }">
-          <el-tag>{{ getBaudrateSP(row, rowIndex) }}</el-tag>
-        </template>
+        <template #default_clock="{ row, rowIndex }"
+          ><span v-if="rowIndex == 0">{{ row.clock }}</span
+          ><span v-else>{{ data.bitrate.clock }}</span></template
+        >
+        <template #edit_preScaler="{ row }"
+          ><el-input-number v-model="row.preScaler" controls-position="right"
+        /></template>
+        <template #edit_sjw="{ row }"
+          ><el-input-number v-model="row.sjw" :min="1" controls-position="right"
+        /></template>
+        <template #edit_timeSeg1="{ row }"
+          ><el-input-number v-model="row.timeSeg1" controls-position="right"
+        /></template>
+        <template #edit_timeSeg2="{ row }"
+          ><el-input-number v-model="row.timeSeg2" controls-position="right"
+        /></template>
+        <template #edit_zlg="{ row, rowIndex }"
+          ><el-input v-if="rowIndex == 0" v-model="row.zlgSpec"
+        /></template>
+        <template #default_baudrate="{ row, rowIndex }"
+          ><el-tag>{{ getBaudrateSP(row, rowIndex) }}</el-tag></template
+        >
       </vxe-grid>
     </el-form-item>
+
+    <!-- Candle: same vxe-grid style, clock is read-only tag -->
     <el-divider content-position="left">
       {{ i18next.t('uds.hardware.canNode.sections.database') }}
     </el-divider>
@@ -734,7 +712,89 @@ const configInfo: Record<CanVendor, any> = {
   }
 }
 
+/** Look up the currently selected candle device from the device list */
+function getSelectedCandleDevice(): CanDevice | undefined {
+  if (props.vendor !== 'candle') return undefined
+  // Explicitly check for empty string or null/undefined (handle can be 0!)
+  if (data.value.handle === '' || data.value.handle == null) return undefined
+  return deviceList.value.find((d) => d.handle === data.value.handle)
+}
+
+/** Build dynamic candle config from the selected device's BT_CONST / BT_CONST_EXT capabilities */
+function getCandleDynamicConfig(isFd: boolean) {
+  const dev = getSelectedCandleDevice()
+  const cap = dev?.extra?.candle?.cap
+  if (!cap) {
+    // No device selected yet, fallback to static config
+    return configInfo.candle[isFd ? 'canFd' : 'can']
+  }
+
+  const clockMhz = Math.round(cap.fclk_can / 1000000)
+  const clockStr = String(clockMhz)
+
+  const arbLimits = {
+    preScaler: { min: cap.brp_min, max: cap.brp_max },
+    tsg1: { min: cap.tseg1_min, max: cap.tseg1_max },
+    tsg2: { min: cap.tseg2_min, max: cap.tseg2_max }
+  }
+
+  const baseConfig = {
+    clock: [{ clock: clockStr, name: `${clockStr} (HW)` }],
+    ...arbLimits,
+    bitrate: {
+      sjw: Math.min(1, cap.sjw_max),
+      timeSeg1: Math.min(13, cap.tseg1_max),
+      timeSeg2: Math.max(2, cap.tseg2_min),
+      preScaler: Math.min(10, cap.brp_max),
+      freq: 500000,
+      clock: clockStr
+    }
+  }
+
+  if (isFd && dev?.extra?.candle?.dataCap) {
+    const dataCap = dev.extra.candle?.dataCap
+    // Only add FD defaults; validation limits stay from bt_const (baseConfig)
+    // so both arb and data rows are validated against arbitration constraints
+    return {
+      ...baseConfig,
+      bitratefd: {
+        sjw: Math.min(1, dataCap.sjw_max),
+        timeSeg1: Math.min(7, dataCap.tseg1_max),
+        timeSeg2: Math.max(2, dataCap.tseg2_min),
+        preScaler: Math.min(4, dataCap.brp_max),
+        freq: 2000000,
+        clock: clockStr
+      }
+    }
+  }
+
+  return baseConfig
+}
+
+const showCandleTimingTable = computed(() => {
+  if (props.vendor !== 'candle') return false
+  if (data.value.handle === '' || data.value.handle == null) return false
+  const dev = getSelectedCandleDevice()
+  return !!dev?.extra?.candle?.cap
+})
+
+const showCanFdCheckbox = computed(() => {
+  if (props.vendor !== 'candle') return true
+  const dev = getSelectedCandleDevice()
+  return !!dev?.extra?.candle?.fdSupported
+})
+
+const selectedCandleClock = computed(() => {
+  if (props.vendor !== 'candle') return null
+  const dev = getSelectedCandleDevice()
+  if (!dev?.extra?.candle?.cap || !dev.extra.candle.cap.fclk_can) return null
+  return Math.round(dev.extra.candle.cap.fclk_can / 1000000)
+})
+
 const vendorConfigLimit = computed(() => {
+  if (props.vendor === 'candle') {
+    return getCandleDynamicConfig(data.value.canfd)
+  }
   return configInfo[props.vendor][data.value.canfd ? 'canFd' : 'can']
 })
 
@@ -926,6 +986,126 @@ function getBaudrateSP(speed: CanBitrate, index: number) {
 
 const deviceList = ref<CanDevice[]>([])
 const deviceLoading = ref(false)
+
+// Sync clock frequency from the selected candle device's actual hardware capability.
+// Watches both deviceList (async load) and handle (user selection) for candle devices only.
+/** Pick the best (tseg1, tseg2, prescaler) for candle hardware that exactly matches freq */
+function autoPickCandleTiming(
+  freq: number,
+  cap: {
+    brp_min: number
+    brp_max: number
+    tseg1_min: number
+    tseg1_max: number
+    tseg2_min: number
+    tseg2_max: number
+    sjw_max: number
+  },
+  clockHz: number
+) {
+  const results: { t1: number; t2: number; sp: number; sjw: number; presc: number }[] = []
+  for (let presc = cap.brp_min; presc <= cap.brp_max; presc++) {
+    if (clockHz % presc !== 0) continue
+    const totalTq = clockHz / (presc * freq)
+    if (totalTq !== Math.floor(totalTq)) continue
+    for (let t1 = cap.tseg1_min; t1 <= cap.tseg1_max; t1++) {
+      const t2 = totalTq - t1 - 1
+      if (t2 < cap.tseg2_min || t2 > cap.tseg2_max) continue
+      if (t1 < t2) continue
+      results.push({
+        t1,
+        t2,
+        sp: Math.round(((t1 + 1) / (t1 + t2 + 1)) * 10000) / 100,
+        sjw: Math.min(1, cap.sjw_max),
+        presc
+      })
+    }
+  }
+  if (!results.length) return null
+  // Prefer sample point in 75%-85%, closest to 80%
+  const inRange = results.filter((r) => r.sp >= 75 && r.sp <= 85)
+  const pool = inRange.length > 0 ? inRange : results
+  let best = pool[0]
+  for (const r of pool) {
+    if (Math.abs(r.sp - 80) < Math.abs(best.sp - 80)) best = r
+  }
+  return best
+}
+
+watch([deviceList, () => data.value.handle], () => {
+  if (props.vendor !== 'candle') return
+  const dev = getSelectedCandleDevice()
+  if (!dev?.extra?.candle?.cap) return
+  // Disable CAN FD if the selected device doesn't support it
+  if (!dev.extra.candle?.fdSupported && data.value.canfd) {
+    data.value.canfd = false
+  }
+  const clockMhz = Math.round(dev.extra.candle.cap.fclk_can / 1000000)
+  const clockStr = String(clockMhz)
+  const clockChanged = data.value.bitrate.clock !== clockStr
+  if (clockChanged) {
+    data.value.bitrate.clock = clockStr
+    if (data.value.bitratefd) {
+      data.value.bitratefd.clock = clockStr
+    }
+  }
+  // Auto-pick timing params that match the current freq with device's actual clock
+  const best = autoPickCandleTiming(
+    data.value.bitrate.freq,
+    dev.extra.candle.cap,
+    clockMhz * 1000000
+  )
+  if (best) {
+    data.value.bitrate.timeSeg1 = best.t1
+    data.value.bitrate.timeSeg2 = best.t2
+    data.value.bitrate.sjw = best.sjw
+    data.value.bitrate.preScaler = best.presc
+  }
+  nextTick(() => {
+    ruleFormRef.value?.validateField('bitrate')
+    if (data.value.canfd) {
+      ruleFormRef.value?.validateField('bitratefd')
+    }
+  })
+})
+
+// When user edits the baud rate, auto-pick optimal timing for candle
+watch(
+  () => [data.value.bitrate.freq, data.value.bitratefd?.freq],
+  () => {
+    if (props.vendor !== 'candle') return
+    const dev = getSelectedCandleDevice()
+    if (!dev?.extra?.candle?.cap) return
+    const clockHz = (selectedCandleClock.value ?? 0) * 1000000
+    if (!clockHz) return
+
+    const best = autoPickCandleTiming(data.value.bitrate.freq, dev.extra.candle.cap, clockHz)
+    if (best) {
+      data.value.bitrate.timeSeg1 = best.t1
+      data.value.bitrate.timeSeg2 = best.t2
+      data.value.bitrate.sjw = best.sjw
+      data.value.bitrate.preScaler = best.presc
+    }
+    if (data.value.canfd && data.value.bitratefd && dev.extra.candle?.dataCap) {
+      const bestFd = autoPickCandleTiming(
+        data.value.bitratefd.freq,
+        dev.extra.candle.dataCap,
+        clockHz
+      )
+      if (bestFd) {
+        data.value.bitratefd.timeSeg1 = bestFd.t1
+        data.value.bitratefd.timeSeg2 = bestFd.t2
+        data.value.bitratefd.sjw = bestFd.sjw
+        data.value.bitratefd.preScaler = bestFd.presc
+      }
+    }
+    nextTick(() => {
+      ruleFormRef.value?.validateField('bitrate')
+      if (data.value.canfd) ruleFormRef.value?.validateField('bitratefd')
+    })
+  }
+)
+
 function getDevice(visible: boolean) {
   if (visible) {
     deviceLoading.value = true
@@ -958,7 +1138,12 @@ const error1 = ref(false)
 const bitrateCheck = (rule: any, value: any, callback: any) => {
   error0.value = false
   error1.value = false
-  if (props.vendor == 'peak' || props.vendor == 'kvaser' || props.vendor == 'toomoss') {
+  if (
+    props.vendor == 'peak' ||
+    props.vendor == 'kvaser' ||
+    props.vendor == 'toomoss' ||
+    props.vendor == 'candle'
+  ) {
     if (data.value.bitrate.clock == undefined) {
       callback(new Error(i18next.t('uds.hardware.canNode.validation.selectClock')))
     }
@@ -1083,7 +1268,12 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
         }
       }
     }
-    if (props.vendor == 'kvaser' || props.vendor == 'toomoss' || props.vendor == 'peak') {
+    if (
+      props.vendor == 'kvaser' ||
+      props.vendor == 'toomoss' ||
+      props.vendor == 'peak' ||
+      props.vendor == 'candle'
+    ) {
       const calcFreq =
         (Number(data.value.bitrate.clock || 40) * 1000000) /
         (data.value.bitrate.preScaler *


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes for handling CAN device capabilities, especially for Candle devices, across both backend (C) and frontend (TypeScript/Vue) code. The main focus is on accurately detecting and using hardware timing parameters, dynamically exposing device-specific features (like CAN FD and clock frequency), and improving the user interface for CAN configuration. The changes ensure that the software adapts to the actual hardware capabilities, provides better validation, and offers a more robust and user-friendly experience.

**Device capability detection and propagation:**

- Candle device capability information (`bt_const` and `data_bt_const`) is now extracted and propagated through the device list, making hardware features (e.g., clock frequency, CAN FD support, resistor presence) available to the frontend via the `extra.candle` property in the `CanDevice` interface. 

**Frontend dynamic configuration and validation:**

- The frontend now dynamically builds timing configuration limits for Candle devices based on the selected device's actual capabilities, ensuring that the UI and validation logic always match the connected hardware. 

**Backend device handling and validation improvements:**

- The backend C code for Candle device initialization and bitrate setting is refactored to use the actual device clock for calculations, perform stricter validation on supported bitrates, and handle device capability queries more robustly. 

**Bit timing calculator enhancements:**

- The bit timing calculator now only considers exact matches for total time quanta and auto-selects the best configuration based on a preferred sample point (75–85%, ideally 80%), improving usability and correctness. 