### PR TITLE
Fix running selected test cases in test config

### DIFF
--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -2606,6 +2606,7 @@
       "testLog": {
         "testStarting": "----- Test {{name}} starting -----",
         "testPassed": "----- Test {{name}} passed, {{duration}}ms -----",
+        "testSkipped": "----- Test {{name}} skipped, {{duration}}ms -----",
         "testFailed": "----- Test {{name}} failed, {{duration}}ms, details: {{error}} -----",
         "testDiagnostic": "Test Diagnostic"
       }

--- a/src/main/worker/uds.ts
+++ b/src/main/worker/uds.ts
@@ -300,19 +300,30 @@ export function test(name: string, fn: () => void | Promise<void>) {
       init = true
     }
 
-    t.before(async () => {
-      if (testEnableControl[testCnt] != true) {
-        t.skip()
-        return
+    const currentTestCnt = testCnt
+    const enabled = testEnableControl[currentTestCnt] == true
+    let advanced = false
+    const advanceTestCnt = () => {
+      if (!advanced) {
+        testCnt = Math.max(testCnt, currentTestCnt + 1)
+        advanced = true
       }
-      console.log(`<<< TEST START ${name}>>>`)
+    }
+
+    t.before(async () => {
+      if (enabled) {
+        console.log(`<<< TEST START ${name}>>>`)
+      }
     })
     t.after(() => {
-      console.log(`<<< TEST END ${name}>>>`)
-      testCnt++
+      if (enabled) {
+        console.log(`<<< TEST END ${name}>>>`)
+      }
+      advanceTestCnt()
     })
 
-    if (testEnableControl[testCnt] != true) {
+    if (!enabled) {
+      advanceTestCnt()
       t.skip()
     } else {
       return preserveErrorStack(fn)
@@ -322,13 +333,23 @@ export function test(name: string, fn: () => void | Promise<void>) {
 
 test.skip = function (name: string, fn: () => void | Promise<void>) {
   selfTest(name, (t) => {
+    const currentTestCnt = testCnt
+    let advanced = false
+    const advanceTestCnt = () => {
+      if (!advanced) {
+        testCnt = Math.max(testCnt, currentTestCnt + 1)
+        advanced = true
+      }
+    }
+
     t.before(() => {
       console.log(`<<< TEST START ${name}>>>`)
     })
     t.after(() => {
       console.log(`<<< TEST END ${name}>>>`)
-      testCnt++
+      advanceTestCnt()
     })
+    advanceTestCnt()
     t.skip()
   })
 }
@@ -593,10 +614,6 @@ const selfTest = process.env.ONLY == 'true' ? nodeTest.only : nodeTest
  */
 export function describe(name: string, fn: () => void | Promise<void>) {
   selfDescribe(name, async (t) => {
-    before(() => {
-      testCnt++
-    })
-
     return preserveErrorStack(fn)
   })
 }

--- a/src/renderer/src/views/uds/message.vue
+++ b/src/renderer/src/views/uds/message.vue
@@ -284,15 +284,27 @@ function testLog({
       if (testId.value != undefined && !testId.value.includes(key)) {
         continue
       }
-      writeToTerminal(
-        time,
-        item.message.data.data.name,
-        'success',
-        i18next.t('uds.message.testLog.testPassed', {
-          name: item.message.data.data.name,
-          duration: item.message.data.data.details.duration_ms
-        })
-      )
+      if (item.message.data.data.skip) {
+        writeToTerminal(
+          time,
+          item.message.data.data.name,
+          'warning',
+          i18next.t('uds.message.testLog.testSkipped', {
+            name: item.message.data.data.name,
+            duration: item.message.data.data.details.duration_ms
+          })
+        )
+      } else {
+        writeToTerminal(
+          time,
+          item.message.data.data.name,
+          'success',
+          i18next.t('uds.message.testLog.testPassed', {
+            name: item.message.data.data.name,
+            duration: item.message.data.data.details.duration_ms
+          })
+        )
+      }
     } else if (item.message.data.type == 'test:fail') {
       const key =
         item.message.data.data.name +

--- a/src/renderer/src/views/uds/test.vue
+++ b/src/renderer/src/views/uds/test.vue
@@ -416,17 +416,29 @@ const isSingleRun = ref<string[] | undefined>(undefined)
 function handleRun(data: TestTree, clearLog: boolean = true, singleId?: string) {
   handleRefresh(data)
     .then(() => {
-      runtime.testStates.isRunning[data.id] = true
-      runtime.testStates.activeTest = data
-      const id = singleId || data.id
+      const configId = data.id
+      const id = singleId || configId
+      const configNode = tData.value[0].children?.find((item) => item.id === configId)
+      const runNode = singleId ? treeRef.value.getNode(singleId)?.data : configNode
+      if (!configNode || !runNode) {
+        throw new Error('Test tree changed, please refresh and run again')
+      }
+
+      runtime.testStates.isRunning[configId] = true
+      runtime.testStates.activeTest = runNode
       if (clearLog) {
         traceRef.value.clearLog()
       }
       const cnt: number[] = []
+      const pushCnt = (testCnt?: number) => {
+        if (testCnt != undefined && !cnt.includes(testCnt)) {
+          cnt.push(testCnt)
+        }
+      }
       const getChildren = (val: TestTree, ids?: string[]) => {
         for (const item of val.children) {
           if (item.testCnt != undefined) {
-            cnt.push(item.testCnt)
+            pushCnt(item.testCnt)
             if (ids) {
               ids.push(item.id)
             }
@@ -436,24 +448,22 @@ function handleRun(data: TestTree, clearLog: boolean = true, singleId?: string) 
           }
         }
       }
-      if (data.type == 'config') {
+      if (runNode.type == 'config') {
         isSingleRun.value = undefined
         //get node from the tree
 
-        getChildren(data)
+        getChildren(runNode)
       } else {
         isSingleRun.value = [id]
 
         const node = treeRef.value.getNode(id)
-        if (data.testCnt != undefined) {
-          cnt.push(data.testCnt)
-        }
-        getChildren(data, isSingleRun.value)
+        pushCnt(runNode.testCnt)
+        getChildren(runNode, isSingleRun.value)
         if (node) {
           const getParent = (val: any) => {
             if (val.parent && val.parent.data && val.parent.data.type == 'test') {
               if (val.parent.data.testCnt != undefined) {
-                cnt.push(val.parent.data.testCnt)
+                pushCnt(val.parent.data.testCnt)
               }
               getParent(val.parent)
             }
@@ -473,7 +483,7 @@ function handleRun(data: TestTree, clearLog: boolean = true, singleId?: string) 
             'ipc-run-test',
             project.projectInfo.path,
             project.projectInfo.name,
-            cloneDeep(dataBase.nodes[data.id]),
+            cloneDeep(dataBase.nodes[configId]),
             cloneDeep(dataBase.tester),
             EnableObj
           )
@@ -486,7 +496,7 @@ function handleRun(data: TestTree, clearLog: boolean = true, singleId?: string) 
             })
           })
           .finally(() => {
-            runtime.testStates.isRunning[data.id] = false
+            runtime.testStates.isRunning[configId] = false
             runtime.testStates.activeTest = undefined
           })
       })
@@ -1051,20 +1061,21 @@ function buildSubTree(infos: TestEvent[]) {
 
 const root2tree = (cnt: number, parent: TestTree, root: TestTree) => {
   const newNode: TestTree = {
-    testCnt: cnt,
     id: root.id,
     type: 'test',
     canAdd: false,
     label: root.label,
     children: []
   }
-  cnt++
   parent.children.push(newNode)
 
   if (root.children && root.children.length > 0) {
     for (const child of root.children) {
       cnt = root2tree(cnt, newNode, child)
     }
+  } else {
+    newNode.testCnt = cnt
+    cnt++
   }
   return cnt
 }


### PR DESCRIPTION
## Summary

Fix single test execution in Test Config.

Previously, running a whole `describe` block worked correctly, but running an individual test case could mark the selected test as passed even when it should fail.

Project used: test_simple

Before fix
<img width="1201" height="692" alt="image" src="https://github.com/user-attachments/assets/e1549636-79c8-480f-bb78-d36b7c19469f" />

After fix
<img width="1176" height="608" alt="image" src="https://github.com/user-attachments/assets/07a163d2-49d6-4365-9e7d-7477dd3970c8" />

## Root cause

The test tree UI and worker runtime used inconsistent `testCnt` indexing.

- The UI assigned `testCnt` to both `describe`/suite nodes and real test cases.
- The worker runtime consumed `testCnt` while executing test cases, and also advanced the counter inconsistently for skipped/disabled tests.
- As a result, when a non-first test was run individually, the selected test could be skipped while another counter position was enabled.
- The message view also displayed skipped `test:pass` events as normal passed tests, which made the issue look like an assertion failure was passing.

## Fix

- Align test selection indexing between the UI and worker runtime.
- Only assign `testCnt` to leaf test cases in the UI tree.
- Ensure skipped/disabled tests advance the worker test counter exactly once.
- Remove the extra counter increment from `describe`.
- Display skipped test events as skipped instead of passed.
