### PR TITLE
Implement SERIAL_TP core and serial device hardware config UI

### DIFF
--- a/src/main/ipc/serialPort.ts
+++ b/src/main/ipc/serialPort.ts
@@ -1,6 +1,17 @@
 import { ipcMain } from 'electron'
 import { SerialPort } from 'serialport'
+import { SerialDevice } from '../share/serial'
 
 ipcMain.handle('ipc-get-serial-port-list', async (event, ...arg) => {
   return await SerialPort.list()
+})
+
+ipcMain.handle('ipc-get-serial-devices', async (event, ...arg) => {
+  const ports = await SerialPort.list()
+  const devices: SerialDevice[] = ports.map((p) => ({
+    label: p.friendlyName || p.path,
+    id: p.serialNumber || p.path,
+    handle: p.path
+  }))
+  return devices
 })

--- a/src/main/serial/index.ts
+++ b/src/main/serial/index.ts
@@ -1,0 +1,623 @@
+import { SerialPort } from 'serialport'
+import EventEmitter from 'events'
+import { SerialAddr, SerialBaseInfo } from '../share/serial'
+
+/**
+ * Structural logger interface for serial frames. Decoupled from the concrete
+ * SerialLOG implementation so the driver does not depend on the log module.
+ */
+export interface SerialFrameLogger {
+  serialBase(data: {
+    dir: 'TX' | 'RX'
+    data: Buffer
+    ts: number
+    name: string
+    canId?: number
+  }): void
+}
+
+export enum SERIAL_TP_ERROR_ID {
+  TP_BUS_ERROR,
+  TP_TIMEOUT_A,
+  TP_TIMEOUT_BS,
+  TP_TIMEOUT_CR,
+  TP_TIMEOUT_UPPER_READ,
+  TP_BUS_CLOSED,
+  TP_LEN_ERROR,
+  TP_INVALID_FS,
+  TP_BUFFER_OVERFLOW,
+  TP_PARAM_ERROR,
+  TP_WRONG_SN
+}
+
+const tpErrorMap: Record<SERIAL_TP_ERROR_ID, string> = {
+  [SERIAL_TP_ERROR_ID.TP_BUS_ERROR]: 'bus error',
+  [SERIAL_TP_ERROR_ID.TP_TIMEOUT_A]: 'N_TIMEOUT_A timeout',
+  [SERIAL_TP_ERROR_ID.TP_TIMEOUT_BS]: 'N_TIMEOUT_BS timeout',
+  [SERIAL_TP_ERROR_ID.TP_TIMEOUT_CR]: 'N_TIMEOUT_CR timeout',
+  [SERIAL_TP_ERROR_ID.TP_TIMEOUT_UPPER_READ]: 'upper layer read timeout',
+  [SERIAL_TP_ERROR_ID.TP_BUS_CLOSED]: 'bus closed',
+  [SERIAL_TP_ERROR_ID.TP_LEN_ERROR]: 'data length error',
+  [SERIAL_TP_ERROR_ID.TP_INVALID_FS]: 'invalid flow status',
+  [SERIAL_TP_ERROR_ID.TP_BUFFER_OVERFLOW]: 'buffer overflow',
+  [SERIAL_TP_ERROR_ID.TP_PARAM_ERROR]: 'param error',
+  [SERIAL_TP_ERROR_ID.TP_WRONG_SN]: 'wrong SN'
+}
+
+export class TpError extends Error {
+  errorId: SERIAL_TP_ERROR_ID
+  addr: SerialAddr
+  data?: Buffer
+  constructor(errorId: SERIAL_TP_ERROR_ID, addr: SerialAddr, data?: Buffer, extMsg?: string) {
+    super(tpErrorMap[errorId] + (extMsg ? `, ${extMsg}` : ''))
+    this.errorId = errorId
+    this.addr = addr
+    this.data = data
+  }
+}
+
+function getTsUs() {
+  const hrtime = process.hrtime()
+  return hrtime[0] * 1000000 + Math.floor(hrtime[1] / 1000)
+}
+
+/**
+ * Serial port driver implementing ISO 15765-2 (ISO-TP) over UART.
+ *
+ * Frame format over the wire:
+ *   [LEN_HI][LEN_LO][PDU_BYTES...]
+ * where LEN is the number of bytes in the PDU (big-endian uint16).
+ *
+ * Each ISO-TP PDU (SF/FF/CF/FC) is wrapped in one such serial frame.
+ */
+export class SERIAL_TP {
+  port: SerialPort
+  event = new EventEmitter()
+  serialLog?: SerialFrameLogger
+  private startTs: number
+  private recvBuf = Buffer.alloc(0)
+  private closed = false
+  private abortController = new AbortController()
+
+  // ISO-TP receive state per registered id (keyed by SERIAL_TP_SOCKET recvId)
+  private tpStatus: Record<string, number> = {}
+  private tpDataBuffer: Record<string, Buffer> = {}
+  private tpDataFc: Record<
+    string,
+    {
+      ts: number
+      bs: number
+      stMin: number
+      bc: number
+      leftLen: number
+      curBs: number
+      crTimer?: NodeJS.Timeout
+    }
+  > = {}
+  private addrMap = new Map<string, SerialAddr>()
+
+  constructor(public info: SerialBaseInfo) {
+    this.startTs = getTsUs()
+    this.port = new SerialPort({
+      path: info.device.handle,
+      baudRate: info.baudRate,
+      dataBits: info.dataBits,
+      stopBits: info.stopBits,
+      parity: info.parity,
+      autoOpen: false
+    })
+  }
+
+  async open(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.port.open((err) => {
+        if (err) {
+          reject(new Error(`Serial port open error: ${err.message}`))
+          return
+        }
+        this.port.on('data', (data: Buffer) => {
+          this.recvBuf = Buffer.concat([this.recvBuf, data])
+          this.parseFrames()
+        })
+        this.port.on('error', (err) => {
+          if (!this.closed) this.event.emit('error', err)
+        })
+        this.port.on('close', () => {
+          if (!this.closed) {
+            this.closed = true
+            this.event.emit('close')
+          }
+        })
+        resolve()
+      })
+    })
+  }
+
+  private parseFrames() {
+    // Fixed 13-byte CAN-over-UART frame: [4B CAN ID BE][1B DLC][8B data padded]
+    const FRAME_SIZE = 13
+    while (this.recvBuf.length >= FRAME_SIZE) {
+      const canId = this.recvBuf.readUInt32BE(0) & 0x1fffffff
+      const dlc = Math.min(this.recvBuf[4] & 0x0f, 8)
+      const data = Buffer.from(this.recvBuf.subarray(5, 5 + dlc))
+      this.recvBuf = this.recvBuf.subarray(FRAME_SIZE)
+      const ts = getTsUs() - this.startTs
+      this.serialLog?.serialBase({ dir: 'RX', data, ts, name: '', canId })
+      this.handleIncomingFrame(data, ts)
+    }
+  }
+
+  private async sendFrame(pdu: Buffer): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const frame = Buffer.alloc(2 + pdu.length)
+      frame.writeUInt16BE(pdu.length, 0)
+      pdu.copy(frame, 2)
+      this.port.write(frame, (err) => {
+        if (err) {
+          reject(new TpError(SERIAL_TP_ERROR_ID.TP_BUS_ERROR, {} as SerialAddr, pdu, err.message))
+        } else {
+          resolve(getTsUs() - this.startTs)
+        }
+      })
+    })
+  }
+
+  private async sendFC(
+    addr: SerialAddr,
+    fs: number
+  ): Promise<{ ts: number; bs: number; stMin: number }> {
+    const stMin = addr.stMin > 127 ? 127 : addr.stMin
+    const bs = addr.bs
+    const raw = Buffer.from([0x30 | (fs & 0xf), bs, stMin])
+    const pdu = this.applyPadding(raw, addr, 3)
+    const timer = setTimeout(() => {}, addr.nAr)
+    try {
+      const ts = await this.sendFrame(pdu)
+      clearTimeout(timer)
+      return { ts, bs, stMin }
+    } catch (e) {
+      clearTimeout(timer)
+      throw e
+    }
+  }
+
+  private applyPadding(pdu: Buffer, addr: SerialAddr, minLen: number): Buffer {
+    if (addr.padding && pdu.length < addr.maxFrameSize) {
+      const padded = Buffer.alloc(addr.maxFrameSize).fill(addr.paddingValue)
+      pdu.copy(padded)
+      return padded
+    }
+    return pdu
+  }
+
+  private async waitForFC(addr: SerialAddr, nBs: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.event.off('fc-frame', handler)
+        reject(new TpError(SERIAL_TP_ERROR_ID.TP_TIMEOUT_BS, addr))
+      }, nBs)
+
+      const handler = (pdu: Buffer) => {
+        clearTimeout(timer)
+        resolve(pdu)
+      }
+      this.event.once('fc-frame', handler)
+
+      this.abortController.signal.addEventListener('abort', () => {
+        clearTimeout(timer)
+        this.event.off('fc-frame', handler)
+        reject(new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, addr))
+      })
+    })
+  }
+
+  getReadId(addr: SerialAddr): string {
+    return `serial-tp-${addr.name}`
+  }
+
+  registerAddr(id: string, addr: SerialAddr) {
+    this.addrMap.set(id, addr)
+    if (this.tpStatus[id] === undefined) {
+      this.tpStatus[id] = 0
+    }
+  }
+
+  unregisterAddr(id: string) {
+    this.addrMap.delete(id)
+    delete this.tpStatus[id]
+    delete this.tpDataBuffer[id]
+    if (this.tpDataFc[id]?.crTimer) clearTimeout(this.tpDataFc[id].crTimer)
+    delete this.tpDataFc[id]
+  }
+
+  handleIncomingFrame(pdu: Buffer, ts: number) {
+    if (pdu.length === 0) return
+    const pciType = (pdu[0] & 0xf0) >> 4
+
+    if (pciType === 3) {
+      // FC: consumed by the pending writeTp multi-frame send
+      this.event.emit('fc-frame', pdu, ts)
+      return
+    }
+
+    // Dispatch to all registered sockets
+    for (const id of Object.keys(this.tpStatus)) {
+      this.processIncomingPdu(id, pdu, ts)
+    }
+  }
+
+  private processIncomingPdu(id: string, pdu: Buffer, ts: number) {
+    const status = this.tpStatus[id] ?? 0
+    const pciType = (pdu[0] & 0xf0) >> 4
+
+    if (status === 0) {
+      if (pciType === 0) {
+        // SF
+        const len = pdu[0] & 0xf
+        if (len === 0 || len > pdu.length - 1) return
+        this.event.emit(id, { data: pdu.subarray(1, 1 + len), ts })
+      } else if (pciType === 1) {
+        // FF
+        if (pdu.length < 2) return
+        const len = ((pdu[0] & 0xf) << 8) | pdu[1]
+        if (len < 7) return
+        const payload = pdu.subarray(2)
+        this.tpDataBuffer[id] = Buffer.from(payload)
+        this.tpStatus[id] = 2
+
+        const addr = this.addrMap.get(id) ?? this.getDefaultAddr()
+        const nbrTimer = setTimeout(async () => {
+          try {
+            const fcResult = await this.sendFC(addr, 0)
+            this.tpStatus[id] = 1
+            this.tpDataFc[id] = {
+              ts: fcResult.ts,
+              bs: fcResult.bs,
+              stMin: fcResult.stMin,
+              bc: 1,
+              leftLen: len - payload.length,
+              curBs: 0,
+              crTimer: setTimeout(() => {
+                this.event.emit(id, new TpError(SERIAL_TP_ERROR_ID.TP_TIMEOUT_CR, addr))
+                delete this.tpDataBuffer[id]
+                this.tpStatus[id] = 0
+                delete this.tpDataFc[id]
+              }, addr.nCr)
+            }
+          } catch (e: any) {
+            if (e instanceof TpError) this.event.emit(id, e)
+            delete this.tpDataBuffer[id]
+            this.tpStatus[id] = 0
+            delete this.tpDataFc[id]
+          }
+        }, addr.nBr ?? 0)
+        this.abortController.signal.addEventListener('abort', () => clearTimeout(nbrTimer))
+      }
+    } else if (status === 1) {
+      if (pciType !== 2) return
+      const fc = this.tpDataFc[id]
+      if (!fc) return
+      const addr = this.addrMap.get(id) ?? this.getDefaultAddr()
+      const expectedSn = fc.bc & 0xf
+      const receivedSn = pdu[0] & 0xf
+      if (fc.crTimer) clearTimeout(fc.crTimer)
+
+      if (receivedSn !== expectedSn) {
+        this.event.emit(id, new TpError(SERIAL_TP_ERROR_ID.TP_WRONG_SN, addr, pdu))
+        delete this.tpDataBuffer[id]
+        this.tpStatus[id] = 0
+        delete this.tpDataFc[id]
+        return
+      }
+
+      const cfData = pdu.subarray(1)
+      const leftLen = fc.leftLen
+
+      if (cfData.length >= leftLen) {
+        const finalData = Buffer.concat([this.tpDataBuffer[id], cfData.subarray(0, leftLen)])
+        this.event.emit(id, { data: finalData, ts })
+        delete this.tpDataBuffer[id]
+        this.tpStatus[id] = 0
+        delete this.tpDataFc[id]
+      } else {
+        this.tpDataBuffer[id] = Buffer.concat([this.tpDataBuffer[id], cfData])
+        fc.leftLen -= cfData.length
+
+        if (fc.bs !== 0) {
+          fc.curBs++
+          if (fc.curBs >= fc.bs) {
+            fc.curBs = 0
+            this.tpStatus[id] = 2
+            this.sendFC(addr, 0)
+              .then((val) => {
+                this.tpStatus[id] = 1
+                fc.stMin = val.stMin
+                fc.bs = val.bs
+                fc.crTimer = setTimeout(() => {
+                  this.event.emit(id, new TpError(SERIAL_TP_ERROR_ID.TP_TIMEOUT_CR, addr))
+                  delete this.tpDataBuffer[id]
+                  this.tpStatus[id] = 0
+                  delete this.tpDataFc[id]
+                }, addr.nCr)
+              })
+              .catch((e: any) => {
+                if (e instanceof TpError) this.event.emit(id, e)
+                delete this.tpDataBuffer[id]
+                this.tpStatus[id] = 0
+                delete this.tpDataFc[id]
+              })
+            return
+          }
+        }
+
+        fc.bc++
+        if (fc.bc === 0x10) fc.bc = 0
+        fc.crTimer = setTimeout(() => {
+          this.event.emit(id, new TpError(SERIAL_TP_ERROR_ID.TP_TIMEOUT_CR, addr))
+          delete this.tpDataBuffer[id]
+          this.tpStatus[id] = 0
+          delete this.tpDataFc[id]
+        }, addr.nCr)
+      }
+    }
+  }
+
+  private getDefaultAddr(): SerialAddr {
+    return {
+      name: 'default',
+      nAs: 1000,
+      nAr: 1000,
+      nBs: 1000,
+      nBr: 0,
+      nCs: 0,
+      nCr: 1000,
+      stMin: 0,
+      bs: 0,
+      maxWTF: 0,
+      padding: false,
+      paddingValue: 0xcc,
+      maxFrameSize: 7
+    }
+  }
+
+  async writeTp(addr: SerialAddr, data: Buffer): Promise<number> {
+    if (this.closed) throw new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, addr)
+    if (data.length === 0 || data.length > 4095) {
+      throw new TpError(SERIAL_TP_ERROR_ID.TP_PARAM_ERROR, addr, data, 'data length error')
+    }
+
+    const maxPayload = Math.min(addr.maxFrameSize, 7)
+    const sfLimit = maxPayload - 1
+
+    if (data.length <= sfLimit) {
+      const pdu = this.applyPadding(
+        Buffer.concat([Buffer.from([data.length & 0xf]), data]),
+        addr,
+        2
+      )
+      return this.sendFrame(pdu)
+    }
+
+    // Multi-frame
+    const ffPayloadLen = maxPayload - 2
+    const pciHi = 0x10 | ((data.length >> 8) & 0xf)
+    const pciLo = data.length & 0xff
+    const ffPdu = this.applyPadding(
+      Buffer.concat([Buffer.from([pciHi, pciLo]), data.subarray(0, ffPayloadLen)]),
+      addr,
+      2 + ffPayloadLen
+    )
+    const ffTs = await this.sendFrame(ffPdu)
+
+    let sendLen = ffPayloadLen
+    let sn = 1
+    let sessionBs = 0
+    let sessionStMin = 0
+    let sessionCurBs = 0
+    let waitFC = true
+
+    while (sendLen < data.length) {
+      if (waitFC) {
+        const fcPdu = await this.waitForFC(addr, addr.nBs)
+        if (fcPdu.length < 3 || (fcPdu[0] & 0xf0) !== 0x30) {
+          throw new TpError(SERIAL_TP_ERROR_ID.TP_INVALID_FS, addr, fcPdu, 'expected FC frame')
+        }
+        const fs = fcPdu[0] & 0x0f
+        sessionBs = fcPdu[1]
+        let stMin = fcPdu[2]
+        if ((stMin >= 0x80 && stMin <= 0xf0) || stMin > 0xfa) {
+          stMin = 127
+        } else if (stMin >= 0xf1 && stMin <= 0xf9) {
+          stMin = 1
+        }
+        sessionStMin = Math.max(stMin, addr.nCs ?? 0)
+        sessionCurBs = 0
+
+        if (fs === 0) {
+          waitFC = false
+        } else if (fs === 1) {
+          if (addr.maxWTF === 0) {
+            throw new TpError(SERIAL_TP_ERROR_ID.TP_INVALID_FS, addr, fcPdu, 'WFT not supported')
+          }
+          continue
+        } else if (fs === 2) {
+          throw new TpError(SERIAL_TP_ERROR_ID.TP_BUFFER_OVERFLOW, addr, fcPdu)
+        } else {
+          throw new TpError(SERIAL_TP_ERROR_ID.TP_INVALID_FS, addr, fcPdu, `received fs:${fs}`)
+        }
+      }
+
+      if (sessionStMin > 0) {
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(resolve, sessionStMin)
+          this.abortController.signal.addEventListener('abort', () => {
+            clearTimeout(t)
+            reject(new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, addr))
+          })
+        })
+      }
+
+      const cfPayloadLen = maxPayload - 1
+      const cfSlice = data.subarray(sendLen, sendLen + cfPayloadLen)
+      const cfPdu = this.applyPadding(
+        Buffer.concat([Buffer.from([0x20 | (sn & 0xf)]), cfSlice]),
+        addr,
+        1 + cfSlice.length
+      )
+      await this.sendFrame(cfPdu)
+      sendLen += cfSlice.length
+      sn = (sn + 1) & 0xf
+      if (sn === 0) sn = 1
+
+      if (sessionBs !== 0) {
+        sessionCurBs++
+        if (sessionCurBs >= sessionBs) {
+          waitFC = true
+          sessionCurBs = 0
+        }
+      }
+    }
+
+    return ffTs
+  }
+
+  async sendRaw(data: Buffer): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.port.write(data, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+
+  async sendCanFrame(canId: number, data: Buffer): Promise<void> {
+    const frame = Buffer.alloc(13, 0x00)
+    frame.writeUInt32BE(canId & 0x1fffffff, 0)
+    const dlc = Math.min(data.length, 8)
+    frame[4] = dlc
+    data.copy(frame, 5, 0, dlc)
+    return new Promise((resolve, reject) => {
+      this.port.write(frame, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          const ts = getTsUs() - this.startTs
+          this.serialLog?.serialBase({
+            dir: 'TX',
+            data: data.subarray(0, dlc),
+            ts,
+            name: '',
+            canId
+          })
+          resolve()
+        }
+      })
+    })
+  }
+
+  close() {
+    this.closed = true
+    this.abortController.abort()
+    for (const id of Object.keys(this.tpDataFc)) {
+      if (this.tpDataFc[id]?.crTimer) clearTimeout(this.tpDataFc[id].crTimer)
+    }
+    this.event.removeAllListeners()
+    if (this.port.isOpen) {
+      this.port.close()
+    }
+  }
+}
+
+export class SERIAL_TP_SOCKET {
+  closed = false
+  recvBuffer: ({ data: Buffer; ts: number } | TpError)[] = []
+  recvTimer: NodeJS.Timeout | undefined = undefined
+  cb: (val: { data: Buffer; ts: number } | TpError) => void
+  abortController = new AbortController()
+  pendingRecv: {
+    resolve: (value: { data: Buffer; ts: number }) => void
+    reject: (reason: TpError) => void
+  } | null = null
+  readonly recvId: string
+
+  constructor(
+    private tp: SERIAL_TP,
+    private addr: SerialAddr
+  ) {
+    this.recvId = tp.getReadId(addr)
+    tp.registerAddr(this.recvId, addr)
+    this.cb = this.recvHandle.bind(this)
+    tp.event.on(this.recvId, this.cb)
+  }
+
+  private recvHandle(val: { data: Buffer; ts: number } | TpError) {
+    if (this.pendingRecv) {
+      if (this.recvTimer) {
+        clearTimeout(this.recvTimer)
+        this.recvTimer = undefined
+      }
+      if (val instanceof TpError) {
+        this.pendingRecv.reject(val)
+      } else {
+        this.pendingRecv.resolve(val)
+      }
+      this.pendingRecv = null
+    } else {
+      this.recvBuffer.push(val)
+    }
+  }
+
+  clear() {
+    this.recvBuffer = []
+  }
+
+  async read(timeout: number): Promise<{ data: Buffer; ts: number }> {
+    return new Promise((resolve, reject) => {
+      if (this.closed) {
+        reject(new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, this.addr))
+        return
+      }
+      this.abortController.signal.addEventListener('abort', () => {
+        reject(new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, this.addr))
+        this.pendingRecv = null
+        if (this.recvTimer) clearTimeout(this.recvTimer)
+      })
+      const val = this.recvBuffer.shift()
+      if (val) {
+        if (val instanceof TpError) {
+          reject(val)
+        } else {
+          resolve(val)
+        }
+      } else {
+        this.pendingRecv = { resolve, reject }
+        this.recvTimer = setTimeout(() => {
+          if (this.pendingRecv) {
+            reject(new TpError(SERIAL_TP_ERROR_ID.TP_TIMEOUT_UPPER_READ, this.addr))
+            this.pendingRecv = null
+          }
+        }, timeout)
+      }
+    })
+  }
+
+  async write(data: Buffer): Promise<number> {
+    if (this.closed) throw new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, this.addr)
+    return this.tp.writeTp(this.addr, data)
+  }
+
+  close() {
+    if (this.pendingRecv) {
+      this.pendingRecv.reject(new TpError(SERIAL_TP_ERROR_ID.TP_BUS_CLOSED, this.addr))
+      this.pendingRecv = null
+    }
+    if (this.recvTimer) {
+      clearTimeout(this.recvTimer)
+      this.recvTimer = undefined
+    }
+    this.tp.event.off(this.recvId, this.cb)
+    this.tp.unregisterAddr(this.recvId)
+    this.abortController.abort()
+    this.closed = true
+  }
+}

--- a/src/main/share/serial.ts
+++ b/src/main/share/serial.ts
@@ -1,0 +1,33 @@
+export interface SerialDevice {
+  label: string
+  id: string
+  handle: string // port path, e.g. 'COM3' or '/dev/ttyUSB0'
+}
+
+export interface SerialBaseInfo {
+  id: string
+  name: string
+  vendor: 'serial'
+  device: SerialDevice
+  baudRate: number
+  dataBits: 5 | 6 | 7 | 8
+  stopBits: 1 | 1.5 | 2
+  parity: 'none' | 'even' | 'odd' | 'mark' | 'space'
+}
+
+export interface SerialAddr {
+  name: string
+  // ISO-TP timing parameters (ms)
+  nAs: number // sender side N_As
+  nAr: number // receiver side N_Ar
+  nBs: number // sender waits for FC timeout
+  nBr: number // receiver before sending FC
+  nCs: number // sender separation time min
+  nCr: number // receiver consecutive frame timeout
+  stMin: number // STmin to send in FC
+  bs: number // BlockSize to send in FC
+  maxWTF: number // max wait flow control frames
+  padding: boolean
+  paddingValue: number
+  maxFrameSize: number // max bytes per serial frame (default 7, like CAN)
+}

--- a/src/main/share/uds.ts
+++ b/src/main/share/uds.ts
@@ -4,9 +4,10 @@ import { CAN_ADDR_FORMAT, CAN_ID_TYPE, CanAddr, CanBaseInfo, CanVendor } from '.
 import { EthBaseInfo, EthAddr, EntityAddr } from './doip'
 import { LinAddr, LinBaseInfo } from './lin'
 import { SomeipInfo } from './someip'
+import { SerialAddr, SerialBaseInfo } from './serial'
 
 export type DataType = 'NUM' | 'ARRAY' | 'ASCII' | 'UNICODE' | 'FLOAT' | 'DOUBLE' | 'FILE'
-export type HardwareType = 'can' | 'lin' | 'eth' | 'pwm' | 'someip'
+export type HardwareType = 'can' | 'lin' | 'eth' | 'pwm' | 'someip' | 'serial'
 //serviceDetail所有的key作为serviceId
 
 /**
@@ -499,6 +500,7 @@ export interface UdsAddress {
   canAddr?: CanAddr
   ethAddr?: EthAddr
   linAddr?: LinAddr
+  serialAddr?: SerialAddr
 }
 
 export function getUdsAddrName(item?: UdsAddress) {
@@ -547,6 +549,7 @@ export interface UdsDevice {
   linDevice?: LinBaseInfo
   pwmDevice?: PwmBaseInfo
   someipDevice?: SomeipInfo
+  serialDevice?: SerialBaseInfo
 }
 
 /**

--- a/src/renderer/src/views/uds/hardware/index.vue
+++ b/src/renderer/src/views/uds/hardware/index.vue
@@ -102,6 +102,13 @@
           :vendor="activeTree.vendor"
           @change="nodeChange"
         />
+        <SerialNodeVue
+          v-else-if="activeTree.type == 'serial'"
+          ref="serialNodeRef"
+          v-model="dataModify"
+          :index="activeTree.id"
+          @change="nodeChange"
+        />
       </div>
     </div>
   </div>
@@ -135,6 +142,7 @@ import { ecubusPro } from '../../../../../../package.json'
 import questionIcon from '@iconify/icons-mdi/question-mark-circle-outline'
 import questionIcon1 from '@iconify/icons-mdi/question-mark-circle'
 import PwmNodeVue from './pwmNode.vue'
+import SerialNodeVue from './serialNode.vue'
 import i18next from 'i18next'
 
 const loading = ref(false)
@@ -159,6 +167,7 @@ const canNodeRef = ref()
 const ethNodeRef = ref()
 const linNodeRef = ref()
 const pwmNodeRef = ref()
+const serialNodeRef = ref()
 
 function openEcuBusHardware() {
   window.electron.ipcRenderer.send('ipc-open-link', 'https://app.whyengineer.com/docs/um/hardware/')
@@ -191,6 +200,8 @@ async function showSaveDialog(done: () => void): Promise<void> {
       saved = await linNodeRef.value.save?.()
     } else if (activeTree.value?.type == 'pwm' && pwmNodeRef.value) {
       saved = await pwmNodeRef.value.save?.()
+    } else if (activeTree.value?.type == 'serial' && serialNodeRef.value) {
+      saved = await serialNodeRef.value.save?.()
     }
 
     if (saved) {
@@ -300,7 +311,7 @@ function nodeChange(id: string, name: string) {
 interface tree {
   label: string
   vendor: CanVendor
-  type?: 'can' | 'lin' | 'eth' | 'pwm'
+  type?: 'can' | 'lin' | 'eth' | 'pwm' | 'serial'
   append: boolean
   id: string
   children?: tree[]
@@ -531,6 +542,29 @@ async function buildTree() {
     t.push(candle)
     addSubTree('candle', candle, deviceIndexMap)
   }
+
+  // Serial port devices (not vendor-specific)
+  const serialTree: tree = {
+    label: 'Serial Port (USART)',
+    vendor: 'simulate' as CanVendor,
+    append: true,
+    id: 'SERIAL',
+    type: 'serial',
+    children: []
+  }
+  for (const [key, value] of Object.entries(devices.devices)) {
+    if (value.type == 'serial' && value.serialDevice) {
+      serialTree.children?.push({
+        label: value.serialDevice.name,
+        append: false,
+        vendor: 'simulate' as CanVendor,
+        id: key,
+        type: 'serial',
+        index: deviceIndexMap.get(key)
+      })
+    }
+  }
+  t.push(serialTree)
 
   tData.value = t
 }

--- a/src/renderer/src/views/uds/hardware/serialNode.vue
+++ b/src/renderer/src/views/uds/hardware/serialNode.vue
@@ -1,0 +1,247 @@
+<template>
+  <el-form
+    ref="ruleFormRef"
+    :model="data"
+    label-width="120px"
+    size="small"
+    class="hardware"
+    :rules="rules"
+    :disabled="globalStart"
+    hide-required-asterisk
+  >
+    <el-divider content-position="left">Serial Port Device</el-divider>
+    <el-form-item label="Name" prop="name" required>
+      <el-input v-model="data.name" />
+    </el-form-item>
+    <el-form-item label="Port" prop="device.handle" required>
+      <el-select v-model="data.device.handle" :loading="deviceLoading" style="width: 300px">
+        <el-option
+          v-for="item in deviceList"
+          :key="item.handle"
+          :label="item.label"
+          :value="item.handle"
+        >
+          <span
+            style="
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+              width: 100%;
+              gap: 15px;
+            "
+          >
+            <span>{{ item.handle }}</span>
+            <span style="color: var(--el-text-color-secondary)">{{ item.label }}</span>
+          </span>
+        </el-option>
+        <template #footer>
+          <el-button
+            text
+            style="float: right; margin-bottom: 10px"
+            size="small"
+            icon="RefreshRight"
+            @click="getDevice(true)"
+          >
+            Refresh
+          </el-button>
+        </template>
+      </el-select>
+    </el-form-item>
+    <el-divider content-position="left">Serial Parameters</el-divider>
+    <el-form-item label-width="0">
+      <el-col :span="12">
+        <el-form-item label="Baud Rate" prop="baudRate" required>
+          <el-select v-model="data.baudRate" allow-create filterable>
+            <el-option label="9600" :value="9600" />
+            <el-option label="19200" :value="19200" />
+            <el-option label="38400" :value="38400" />
+            <el-option label="57600" :value="57600" />
+            <el-option label="115200" :value="115200" />
+            <el-option label="230400" :value="230400" />
+            <el-option label="460800" :value="460800" />
+            <el-option label="500000" :value="500000" />
+            <el-option label="921600" :value="921600" />
+            <el-option label="1000000" :value="1000000" />
+          </el-select>
+        </el-form-item>
+      </el-col>
+      <el-col :span="12">
+        <el-form-item label="Data Bits" prop="dataBits">
+          <el-select v-model="data.dataBits">
+            <el-option label="8" :value="8" />
+            <el-option label="7" :value="7" />
+            <el-option label="6" :value="6" />
+            <el-option label="5" :value="5" />
+          </el-select>
+        </el-form-item>
+      </el-col>
+    </el-form-item>
+    <el-form-item label-width="0">
+      <el-col :span="12">
+        <el-form-item label="Stop Bits" prop="stopBits">
+          <el-select v-model="data.stopBits">
+            <el-option label="1" :value="1" />
+            <el-option label="1.5" :value="1.5" />
+            <el-option label="2" :value="2" />
+          </el-select>
+        </el-form-item>
+      </el-col>
+      <el-col :span="12">
+        <el-form-item label="Parity" prop="parity">
+          <el-select v-model="data.parity">
+            <el-option label="None" value="none" />
+            <el-option label="Even" value="even" />
+            <el-option label="Odd" value="odd" />
+            <el-option label="Mark" value="mark" />
+            <el-option label="Space" value="space" />
+          </el-select>
+        </el-form-item>
+      </el-col>
+    </el-form-item>
+    <el-divider />
+    <el-form-item label-width="0">
+      <div style="text-align: left; width: 100%">
+        <el-button v-if="editIndex == ''" type="primary" plain @click="onSubmit">
+          Add Device
+        </el-button>
+        <el-button v-else type="warning" plain @click="onSubmit"> Save Device </el-button>
+      </div>
+    </el-form-item>
+  </el-form>
+</template>
+
+<script lang="ts" setup>
+import { ref, onBeforeMount } from 'vue'
+import { v4 } from 'uuid'
+import { type FormRules, type FormInstance } from 'element-plus'
+import { assign, cloneDeep } from 'lodash'
+import { useDataStore } from '@r/stores/data'
+import { useGlobalStart } from '@r/stores/runtime'
+import type { SerialBaseInfo, SerialDevice } from 'nodeCan/serial'
+
+const ruleFormRef = ref<FormInstance>()
+const devices = useDataStore()
+const globalStart = useGlobalStart()
+const props = defineProps<{
+  index: string
+}>()
+const emit = defineEmits(['change'])
+
+const data = ref<SerialBaseInfo>({
+  device: {
+    label: '',
+    handle: '',
+    id: ''
+  },
+  name: '',
+  id: '',
+  vendor: 'serial',
+  baudRate: 115200,
+  dataBits: 8,
+  stopBits: 1,
+  parity: 'none'
+})
+
+const editIndex = ref('')
+const deviceList = ref<SerialDevice[]>([])
+const deviceLoading = ref(false)
+
+function getDevice(visible: boolean) {
+  if (visible) {
+    deviceLoading.value = true
+    window.electron.ipcRenderer
+      .invoke('ipc-get-serial-devices')
+      .then((res: SerialDevice[]) => {
+        deviceList.value = res
+      })
+      .finally(() => {
+        deviceLoading.value = false
+      })
+  }
+}
+
+const nameCheck = (rule: any, value: any, callback: any) => {
+  if (value) {
+    for (const id of Object.keys(devices.devices)) {
+      const hasName = devices.devices[id].serialDevice?.name
+      if (hasName == value && id != editIndex.value) {
+        callback(new Error('Device name already exists'))
+      }
+    }
+    callback()
+  } else {
+    callback(new Error('Please enter a device name'))
+  }
+}
+
+const rules: FormRules = {
+  name: [{ validator: nameCheck, trigger: 'blur' }],
+  'device.handle': [{ required: true, message: 'Please select a port', trigger: 'change' }],
+  baudRate: [{ required: true, message: 'Please select baud rate', trigger: 'change' }]
+}
+
+async function onSubmit() {
+  if (!ruleFormRef.value) return
+  await ruleFormRef.value.validate((valid) => {
+    if (valid) {
+      const id = editIndex.value || v4()
+      const deviceData = cloneDeep(data.value)
+      deviceData.id = id
+      deviceData.device.label = deviceData.device.handle
+      deviceData.device.id = deviceData.device.handle
+      deviceData.baudRate = Number(deviceData.baudRate)
+
+      if (editIndex.value == '') {
+        devices.devices[id] = {
+          type: 'serial',
+          serialDevice: deviceData
+        }
+      } else {
+        devices.devices[id].serialDevice = deviceData
+      }
+      emit('change', id, deviceData.name)
+    }
+  })
+}
+
+const dataModify = defineModel<boolean>({ default: false })
+
+function updateFromStore() {
+  const device = devices.devices[props.index]
+  if (device?.serialDevice) {
+    assign(data.value, cloneDeep(device.serialDevice))
+    editIndex.value = props.index
+    getDevice(true)
+  } else {
+    editIndex.value = ''
+    getDevice(true)
+  }
+}
+
+defineExpose({
+  save: async () => {
+    if (!ruleFormRef.value) return false
+    return new Promise<boolean>((resolve) => {
+      ruleFormRef.value!.validate((valid) => {
+        if (valid) {
+          onSubmit()
+          resolve(true)
+        } else {
+          resolve(false)
+        }
+      })
+    })
+  }
+})
+
+onBeforeMount(() => {
+  updateFromStore()
+})
+</script>
+
+<style scoped>
+.hardware {
+  padding: 20px;
+  min-width: 500px;
+}
+</style>


### PR DESCRIPTION
## Overview
Adds the foundational serial port (USART) support for EcuBus-Pro: the
SERIAL_TP driver core and the device hardware configuration UI. This is
the base layer; UDS-over-serial tester, interactive node, and trace
integration follow in separate PRs.

## Changes
- **SERIAL_TP core** (`src/main/serial/`): ISO-TP over UART driver,
  fixed 13-byte CAN-over-UART frame format (4B CAN ID + 1B DLC + 8B data),
  `SERIAL_TP_SOCKET` for per-address sessions, `SerialFrameLogger`
  structural interface for optional frame logging (decoupled from log module)
- **Shared types** (`src/main/share/serial.ts`): `SerialBaseInfo`,
  `SerialAddr`, `SerialDevice`; `serial` added to `HardwareType`
- **IPC**: `ipc-get-serial-devices` for port enumeration
- **Hardware UI** (`serialNode.vue`): port / baud rate / data bits /
  stop bits / parity config; baud presets incl. 500000 and 1000000

## Testing
- `npm run typecheck:node` passed
- `npm run typecheck:web` passed
