### PR TITLE
Fix LDF parser optional channel name handling

### DIFF
--- a/src/renderer/src/database/ldfParse.ts
+++ b/src/renderer/src/database/ldfParse.ts
@@ -1167,7 +1167,9 @@ class LdfParser extends CstParser {
     this.SUBRULE(this.version)
     this.SUBRULE(this.llversion)
     this.SUBRULE(this.speed)
-    this.OPTION(this.channel)
+    this.OPTION(() => {
+      this.SUBRULE(this.channel)
+    })
     this.MANY({
       DEF: () => {
         this.OR([

--- a/test/dolin/ldf.test.ts
+++ b/test/dolin/ldf.test.ts
@@ -14,6 +14,25 @@ test('ldf parse 2.1', () => {
   const r = parse(ldf)
 })
 
+test('ldf parse optional channel name before sections', () => {
+  const ldf = `
+LIN_description_file;
+LIN_protocol_version = "2.1";
+LIN_language_version = "2.1";
+LIN_speed = 19.2 kbps;
+Channel_name = "LIN1";
+
+Nodes {
+  Master: MasterNode, 5 ms, 0.1 ms ;
+  Slaves: SlaveNode ;
+}
+`
+  const r = parse(ldf)
+  expect(r.global.Channel_name).toEqual('LIN1')
+  expect(r.node.master.nodeName).toEqual('MasterNode')
+  expect(r.node.salveNode).toEqual(['SlaveNode'])
+})
+
 test('ldf file1', () => {
   const ldf = fs.readFileSync(path.join(__dirname, 'file1.ldf'), 'utf-8')
   const r = parse(ldf)


### PR DESCRIPTION
This PR fixes an internal parser crash when loading simple LDF files that include Channel_name.

## Problem
The LDF parser defined the optional Channel_name rule as:
`this.OPTION(this.channel)`
This is not the proper Chevrotain grammar form for an optional subrule. It could break lookahead generation and cause an internal error:
`Cannot read properties of undefined (reading 'tokenTypeIdx')`
This happened before the parser could report a useful LDF syntax error.

## Fix
Use the standard Chevrotain optional subrule form:
```
this.OPTION(() => {
  this.SUBRULE(this.channel)
})
```

## Tests
Added a regression test for a minimal LDF with:

- header/version/speed

- `Channel_name`

- `Nodes` section immediately after it

## Validation
Ran:
```
npx vitest run test/dolin/ldf.test.ts --config vitest.config.ts
npm run typecheck:web
```