### PR TITLE
Fix Vector CAN/LIN channel filtering by bus type

### DIFF
--- a/src/main/docan/vector/index.ts
+++ b/src/main/docan/vector/index.ts
@@ -531,16 +531,12 @@ export class VECTOR_CAN extends CanBase {
           //设备通道循环索引
           const channel = channles.getitem(num) //通道数组索引
           const channelName = channel.name.replace(/\0/g, '') //通道名称
-          let busType = ''
-
-          if (channel.transceiverName.indexOf('LIN') !== -1) {
-            // busType = '#LIN' //总线类型
+          const isVirtual = channel.name.indexOf('Virtual') !== -1
+          if (!isVirtual && channel.busParams.busType !== 1) {
             continue
-          } else if (channel.name.indexOf('Virtual') !== -1) {
-            busType = ''
-          } else {
-            busType = '#CAN'
           }
+
+          const busType = isVirtual ? '' : '#CAN'
 
           devices.push({
             label: `${channelName}${busType}`, //'VN1640A Channel 1#LIN' = 通道名称#总线类型

--- a/src/main/dolin/vector/index.ts
+++ b/src/main/dolin/vector/index.ts
@@ -527,17 +527,12 @@ export class VectorLin extends LinBase {
           //设备通道循环索引
           const channel = channles.getitem(num) //通道数组索引
           const channelName = channel.name.replace(/\0/g, '') //通道名称
-          let busType = ''
 
-          if (channel.transceiverName.indexOf('LIN') !== -1) {
-            busType = '#LIN' //总线类型
-          } else if (channel.name.indexOf('Virtual') !== -1) {
-            busType = ''
-            continue
-          } else {
-            busType = '#CAN' //LIN版本不要添加CAN
+          if (channel.busParams.busType !== 2) {
             continue
           }
+
+          const busType = '#LIN'
 
           devices.push({
             label: `${channelName}${busType}`, //'VN1640A Channel 1#LIN' = 通道名称#总线类型


### PR DESCRIPTION
This PR updates Vector channel discovery to use the driver-reported `busParams.busType` instead of inferring channel type from `transceiverName`.

## Problem
On devices like VN5620, EcuBus-Pro could list non-CAN channels as CAN channels because the previous CAN discovery logic treated anything that was not LIN or Virtual as CAN.
This caused extra invalid CAN channels to appear in the UI. For example, VN5620 showed many CAN channels in EcuBus-Pro, while CANoe only exposed the actual CAN channels.

## Fix

- CAN discovery now keeps:
     - real CAN channels where `busParams.busType === 1`

     - Vector Virtual channels

- LIN discovery now keeps only real LIN channels where `busParams.busType === 2`

- Removed the weaker transceiverName-based filtering for Vector channel discovery

## Validation

- Verified with VN5620 that CAN channel listing now matches the expected CAN channels.