### PR TITLE
fix(logging): prevent dropped frames in multi-device logs

### DIFF
--- a/src/main/log.ts
+++ b/src/main/log.ts
@@ -63,7 +63,7 @@ const instanceFormat = format((info, opts: any) => {
   return info
 })
 const externalTransport: { id: string; t: () => Transport }[] = []
-const deviceTransport: { id: string; t: () => Transport }[] = []
+const deviceTransport: { id: string; devices: string[]; logger: Logger }[] = []
 export function addTransport(t: () => Transport): string {
   const id = v4()
   externalTransport.push({ id, t })
@@ -71,15 +71,44 @@ export function addTransport(t: () => Transport): string {
 }
 export function addDeviceTransport(t: () => Transport): string {
   const id = v4()
-  deviceTransport.push({ id, t })
+  const transport = t()
+  const devices = (transport as Transport & { devices?: string[] }).devices ?? []
+  const logger = createLogger({ transports: [transport] })
+  deviceTransport.push({ id, devices, logger })
   return id
 }
 
 export function removeDeviceTransport(id: string) {
   const index = deviceTransport.findIndex((t) => t.id == id)
   if (index != -1) {
-    deviceTransport.splice(index, 1)
+    const [target] = deviceTransport.splice(index, 1)
+    target.logger.close()
   }
+}
+
+class DeviceTransportRouter extends Transport {
+  constructor() {
+    super({ level: 'debug' })
+  }
+
+  log(info: any, callback: () => void) {
+    const message = typeof info.message === 'object' ? info.message : undefined
+    const deviceId = message?.deviceId
+
+    if (deviceId) {
+      for (const target of deviceTransport) {
+        if (target.devices.includes(deviceId)) {
+          target.logger.log({ level: info.level, message })
+        }
+      }
+    }
+
+    callback()
+  }
+}
+
+function getDeviceTransportRouters(): Transport[] {
+  return deviceTransport.length > 0 ? [new DeviceTransportRouter()] : []
 }
 export function removeTransport(id: string) {
   const index = externalTransport.findIndex((t) => t.id == id)
@@ -110,7 +139,7 @@ export class CanLOG {
     this.deviceId = deviceId
     this.vendor = vendor
     const et1 = externalTransport.map((t) => t.t())
-    const dt1 = deviceTransport.map((t) => t.t())
+    const dt1 = getDeviceTransportRouters()
     this.log = createLogger({
       transports: [new Base(), ...et1, ...dt1],
       format: format.combine(
@@ -120,15 +149,6 @@ export class CanLOG {
         ...externalFormat
       )
     })
-
-    //check device id
-    const combinedLogs = this.log.transports.filter((transport) => {
-      return (transport as any).devices && (transport as any).devices.indexOf(this.deviceId) == -1
-    })
-
-    for (const log of combinedLogs) {
-      this.log.remove(log)
-    }
   }
   close() {
     this.log.close()
@@ -312,7 +332,7 @@ export class DoipLOG {
     this.vendor = vendor
     this.deviceId = deviceId
     const et1 = externalTransport.map((t) => t.t())
-    const dt1 = deviceTransport.map((t) => t.t())
+    const dt1 = getDeviceTransportRouters()
     this.log = createLogger({
       transports: [new Base(), ...et1, ...dt1],
       format: format.combine(
@@ -322,13 +342,6 @@ export class DoipLOG {
         ...externalFormat
       )
     })
-    //check device id
-    const combinedLogs = this.log.transports.filter((transport) => {
-      return (transport as any).devices && (transport as any).devices.indexOf(this.deviceId) == -1
-    })
-    for (const log of combinedLogs) {
-      this.log.remove(log)
-    }
   }
   close() {
     this.log.close()
@@ -444,7 +457,7 @@ export class LinLOG {
     this.vendor = vendor
     this.deviceId = deviceId
     const et1 = externalTransport.map((t) => t.t())
-    const dt1 = deviceTransport.map((t) => t.t())
+    const dt1 = getDeviceTransportRouters()
     this.log = createLogger({
       transports: [new Base(), ...et1, ...dt1],
       format: format.combine(
@@ -454,14 +467,6 @@ export class LinLOG {
         ...externalFormat
       )
     })
-
-    //check device id
-    const combinedLogs = this.log.transports.filter((transport) => {
-      return (transport as any).devices && (transport as any).devices.indexOf(this.deviceId) == -1
-    })
-    for (const log of combinedLogs) {
-      this.log.remove(log)
-    }
   }
   close() {
     this.log.close()
@@ -513,7 +518,7 @@ export class SerialLOG {
     this.vendor = vendor
     this.deviceId = deviceId
     const et1 = externalTransport.map((t) => t.t())
-    const dt1 = deviceTransport.map((t) => t.t())
+    const dt1 = getDeviceTransportRouters()
     this.log = createLogger({
       transports: [new Base(), ...et1, ...dt1],
       format: format.combine(
@@ -523,14 +528,6 @@ export class SerialLOG {
         ...externalFormat
       )
     })
-
-    //check device id
-    const combinedLogs = this.log.transports.filter((transport) => {
-      return (transport as any).devices && (transport as any).devices.indexOf(this.deviceId) == -1
-    })
-    for (const log of combinedLogs) {
-      this.log.remove(log)
-    }
   }
   close() {
     this.log.close()
@@ -659,7 +656,7 @@ export class SomeipLOG {
     this.vendor = vendor
     this.deviceId = deviceId
     const et1 = externalTransport.map((t) => t.t())
-    const dt1 = deviceTransport.map((t) => t.t())
+    const dt1 = getDeviceTransportRouters()
     this.log = createLogger({
       transports: [new Base(), ...et1, ...dt1],
       format: format.combine(
@@ -669,13 +666,6 @@ export class SomeipLOG {
         ...externalFormat
       )
     })
-    //check device id
-    const combinedLogs = this.log.transports.filter((transport) => {
-      return (transport as any).devices && (transport as any).devices.indexOf(this.deviceId) == -1
-    })
-    for (const log of combinedLogs) {
-      this.log.remove(log)
-    }
   }
   close() {
     this.log.close()

--- a/src/main/replay/blfReader.ts
+++ b/src/main/replay/blfReader.ts
@@ -43,8 +43,9 @@ const MAX_OBJECT_SIZE = 64 * 1024 * 1024
 const MAX_UNCOMPRESSED_SIZE = 64 * 1024 * 1024
 
 function blfPadSize(len: number): number {
+  // Vector BLF stores padding bytes equal to the remainder, not the amount needed to align to 4.
   const mod = len % 4
-  return mod === 0 ? 0 : 4 - mod
+  return mod === 0 ? 0 : mod
 }
 
 /**

--- a/src/main/transport/blf.ts
+++ b/src/main/transport/blf.ts
@@ -72,6 +72,7 @@ function writeSystemTime(buf: Buffer, offset: number, tsNs?: bigint) {
 }
 
 function padData(len: number): number {
+  // Vector BLF stores padding bytes equal to the remainder, not the amount needed to align to 4.
   const mod = len % 4
   return mod === 0 ? 0 : mod
 }
@@ -93,6 +94,7 @@ class BlfWriter {
   private maxContainerSize: number
   private compressionLevel: number
   private _pendingFlush = 0
+  private compressionQueue: Promise<void> = Promise.resolve()
 
   constructor(filePath: string, opts?: { compressionLevel?: number; maxContainerSize?: number }) {
     this.filePath = filePath
@@ -185,12 +187,17 @@ class BlfWriter {
     objHeader.writeBigUInt64LE(timestampNs >= 0n ? timestampNs : 0n, 8)
 
     const paddingSize = padData(data.length)
+    const bufferedObjectSize = objSize + paddingSize
+
+    if (this.bufferSize > 0 && this.bufferSize + bufferedObjectSize > this.maxContainerSize) {
+      this.flush()
+    }
 
     this.bufferParts.push(baseHeader, objHeader, data)
     if (paddingSize) {
       this.bufferParts.push(Buffer.alloc(paddingSize))
     }
-    this.bufferSize += objSize + paddingSize
+    this.bufferSize += bufferedObjectSize
     this.objectCount += 1
 
     if (this.bufferSize >= this.maxContainerSize) {
@@ -285,10 +292,9 @@ class BlfWriter {
       return
     }
 
-    const uncompressed = buffer.subarray(0, this.maxContainerSize)
-    const tail = buffer.subarray(this.maxContainerSize)
-    this.bufferParts = tail.length ? [tail] : []
-    this.bufferSize = tail.length
+    const uncompressed = buffer
+    this.bufferParts = []
+    this.bufferSize = 0
 
     if (this.compressionLevel === 0) {
       this._writeContainer(uncompressed, uncompressed, NO_COMPRESSION)
@@ -303,23 +309,27 @@ class BlfWriter {
    */
   private _compressAndWrite(uncompressed: Buffer) {
     this._pendingFlush++
-    const chunks: Buffer[] = []
-    const deflate = zlib.createDeflate({ level: this.compressionLevel })
+    this.compressionQueue = this.compressionQueue.then(
+      () =>
+        new Promise<void>((resolve) => {
+          const chunks: Buffer[] = []
+          const deflate = zlib.createDeflate({ level: this.compressionLevel })
 
-    // Collect compressed chunks directly
-    deflate.on('data', (chunk: Buffer) => chunks.push(chunk))
-    deflate.on('end', () => {
-      const payload = Buffer.concat(chunks)
-      this._writeContainer(uncompressed, payload, ZLIB_DEFLATE)
-      this._pendingFlush--
-    })
-    deflate.on('error', (err) => {
-      console.error('BLF compression error:', err)
-      this._pendingFlush--
-    })
-
-    // Write directly to deflate stream (no intermediate PassThrough)
-    deflate.end(uncompressed)
+          deflate.on('data', (chunk: Buffer) => chunks.push(chunk))
+          deflate.on('end', () => {
+            const payload = Buffer.concat(chunks)
+            this._writeContainer(uncompressed, payload, ZLIB_DEFLATE)
+            this._pendingFlush--
+            resolve()
+          })
+          deflate.on('error', (err) => {
+            console.error('BLF compression error:', err)
+            this._pendingFlush--
+            resolve()
+          })
+          deflate.end(uncompressed)
+        })
+    )
   }
 
   /**

--- a/test/transport/deviceLog.test.ts
+++ b/test/transport/deviceLog.test.ts
@@ -1,0 +1,242 @@
+import EventEmitter from 'events'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import Transport from 'winston-transport'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { addDeviceTransport, CanLOG, removeDeviceTransport } from '../../src/main/log'
+import { CAN_ID_TYPE, type CanMessage } from '../../src/main/share/can'
+import { BlfReader } from '../../src/main/replay/blfReader'
+import blfTransport from '../../src/main/transport/blf'
+
+class CaptureTransport extends Transport {
+  devices: string[]
+  messages: any[] = []
+  closeCount = 0
+
+  constructor(devices: string[]) {
+    super({ level: 'debug' })
+    this.devices = devices
+  }
+
+  log(info: any, callback: () => void) {
+    this.messages.push(info.message)
+    callback()
+  }
+
+  close() {
+    this.closeCount++
+  }
+}
+
+function createCanMessage(id: number): CanMessage {
+  return {
+    id,
+    data: Buffer.from([id]),
+    dir: 'IN',
+    msgType: {
+      idType: CAN_ID_TYPE.STANDARD,
+      canfd: false,
+      brs: false,
+      remote: false
+    },
+    ts: id
+  }
+}
+
+describe('device file logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses one transport for all selected devices and closes it once', async () => {
+    vi.spyOn(console, 'table').mockImplementation(() => {})
+
+    const transport = new CaptureTransport(['device-a', 'device-b'])
+    const factory = vi.fn(() => transport)
+    const transportId = addDeviceTransport(factory)
+    const logs = [
+      new CanLOG('TEST', 'A', 'device-a', new EventEmitter()),
+      new CanLOG('TEST', 'B', 'device-b', new EventEmitter()),
+      new CanLOG('TEST', 'C', 'device-c', new EventEmitter())
+    ]
+
+    try {
+      logs[0].canBase(createCanMessage(0x11))
+      logs[1].canBase(createCanMessage(0x22))
+      logs[2].canBase(createCanMessage(0x33))
+
+      await vi.waitFor(() => expect(transport.messages).toHaveLength(2))
+
+      expect(factory).toHaveBeenCalledTimes(1)
+      expect(transport.messages.map((message) => message.deviceId)).toEqual([
+        'device-a',
+        'device-b'
+      ])
+
+      logs.forEach((log) => log.close())
+      expect(transport.closeCount).toBe(0)
+
+      removeDeviceTransport(transportId)
+      expect(transport.closeCount).toBe(1)
+    } finally {
+      logs.forEach((log) => log.close())
+      removeDeviceTransport(transportId)
+    }
+  })
+
+  it('writes frames from two devices into one BLF file', async () => {
+    vi.spyOn(console, 'table').mockImplementation(() => {})
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ecubus-device-log-'))
+    const configuredPath = path.join(tempDir, 'device-log.blf')
+    const originalDataSet = global.dataSet
+    const originalDeviceIndexMap = new Map(global.deviceIndexMap)
+    global.dataSet = {
+      devices: {
+        'device-a': {},
+        'device-b': {}
+      }
+    } as any
+    global.deviceIndexMap.set('device-a', 1)
+    global.deviceIndexMap.set('device-b', 2)
+
+    const transport = blfTransport(configuredPath, ['device-a', 'device-b'], ['canBase'], 0)
+    const closed = new Promise<void>((resolve) => transport.once('closed', resolve))
+    const transportId = addDeviceTransport(() => transport)
+    const logs = [
+      new CanLOG('TEST', 'A', 'device-a', new EventEmitter()),
+      new CanLOG('TEST', 'B', 'device-b', new EventEmitter())
+    ]
+
+    try {
+      logs[0].canBase(createCanMessage(0x11))
+      logs[1].canBase(createCanMessage(0x22))
+      await new Promise((resolve) => setImmediate(resolve))
+
+      logs.forEach((log) => log.close())
+      removeDeviceTransport(transportId)
+      await closed
+
+      const [generatedFile] = await fs.readdir(tempDir)
+      expect(generatedFile).toBeTruthy()
+      const filePath = path.join(tempDir, generatedFile)
+      const reader = new BlfReader(filePath, 0)
+      reader.init()
+      const frames = []
+      let frame = await reader.readFrame()
+      while (frame) {
+        frames.push(frame)
+        frame = await reader.readFrame()
+      }
+      reader.close()
+
+      expect(frames.map((item) => [item.channel, item.id])).toEqual([
+        [1, 0x11],
+        [2, 0x22]
+      ])
+    } finally {
+      logs.forEach((log) => log.close())
+      removeDeviceTransport(transportId)
+      global.dataSet = originalDataSet
+      global.deviceIndexMap.clear()
+      originalDeviceIndexMap.forEach((channel, deviceId) => {
+        global.deviceIndexMap.set(deviceId, channel)
+      })
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes all frames from two devices across compressed BLF containers', async () => {
+    vi.spyOn(console, 'table').mockImplementation(() => {})
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ecubus-device-log-large-'))
+    const configuredPath = path.join(tempDir, 'device-log-large.blf')
+    const originalDataSet = global.dataSet
+    const originalDeviceIndexMap = new Map(global.deviceIndexMap)
+    global.dataSet = {
+      devices: {
+        'device-a': {},
+        'device-b': {}
+      }
+    } as any
+    global.deviceIndexMap.set('device-a', 1)
+    global.deviceIndexMap.set('device-b', 2)
+
+    const transport = blfTransport(configuredPath, ['device-a', 'device-b'], ['canBase'], -1)
+    const closed = new Promise<void>((resolve) => transport.once('closed', resolve))
+    const transportId = addDeviceTransport(() => transport)
+    const logs = [
+      new CanLOG('TEST', 'A', 'device-a', new EventEmitter()),
+      new CanLOG('TEST', 'B', 'device-b', new EventEmitter())
+    ]
+
+    try {
+      let randomState = 0x12345678
+      for (let index = 0; index < 2500; index++) {
+        for (let deviceIndex = 0; deviceIndex < logs.length; deviceIndex++) {
+          randomState = (randomState * 1664525 + 1013904223) >>> 0
+          const message = createCanMessage(deviceIndex === 0 ? 0x111 : 0x222)
+          message.data = Buffer.alloc(8)
+          message.data.writeUInt32LE(randomState, 0)
+          message.data.writeUInt32LE(index, 4)
+          message.ts = index * 100_000 + deviceIndex
+          logs[deviceIndex].canBase(message)
+        }
+      }
+      await new Promise((resolve) => setImmediate(resolve))
+
+      logs.forEach((log) => log.close())
+      removeDeviceTransport(transportId)
+      await closed
+
+      const [generatedFile] = await fs.readdir(tempDir)
+      expect(generatedFile).toBeTruthy()
+      const filePath = path.join(tempDir, generatedFile)
+      const fileData = await fs.readFile(filePath)
+      const containerRemainders = []
+      let containerOffset = fileData.readUInt32LE(4)
+      while (containerOffset < fileData.length) {
+        expect(fileData.toString('ascii', containerOffset, containerOffset + 4)).toBe('LOBJ')
+        const objectSize = fileData.readUInt32LE(containerOffset + 8)
+        const objectType = fileData.readUInt32LE(containerOffset + 12)
+        const paddingSize = objectSize % 4
+        expect(objectType).toBe(10)
+        containerRemainders.push(paddingSize)
+        containerOffset += objectSize + paddingSize
+      }
+      expect(containerOffset).toBe(fileData.length)
+      expect(containerRemainders.length).toBeGreaterThan(1)
+      expect(containerRemainders.some((remainder) => remainder === 1 || remainder === 3)).toBe(true)
+
+      const reader = new BlfReader(filePath, 0)
+      reader.init()
+      const channelCounts = new Map<number, number>()
+      let frameCount = 0
+      let frame = await reader.readFrame()
+      while (frame) {
+        frameCount++
+        channelCounts.set(frame.channel, (channelCounts.get(frame.channel) ?? 0) + 1)
+        frame = await reader.readFrame()
+      }
+      reader.close()
+
+      expect(frameCount).toBe(5000)
+      expect(channelCounts).toEqual(
+        new Map([
+          [1, 2500],
+          [2, 2500]
+        ])
+      )
+    } finally {
+      logs.forEach((log) => log.close())
+      removeDeviceTransport(transportId)
+      global.dataSet = originalDataSet
+      global.deviceIndexMap.clear()
+      originalDeviceIndexMap.forEach((channel, deviceId) => {
+        global.deviceIndexMap.set(deviceId, channel)
+      })
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- share one file transport across all selected devices instead of opening the same log file once per device
- route device messages into the shared writer while preserving channel filtering and close it only once
- keep BLF objects intact at container boundaries and serialize compression writes
- use the expected BLF padding convention in the reader and add multi-device regression coverage

## Root cause

Each device logger invoked the file transport factory independently. With multiple CAN channels selected, this created multiple writers for the same ASC/BLF path. Since each writer opened the file for writing, they could truncate or overwrite one another, even though the per-device statistics remained correct.

BLF logging also sliced the uncompressed buffer at the container limit without respecting object boundaries, and compression jobs could finish out of order. The BLF reader additionally used an incompatible padding calculation, which could stop parsing at a container boundary.

## Validation

- `npx vitest --config vitest.config.ts run test/transport/deviceLog.test.ts test/replay/replay.spec.ts` — 12 tests passed
- `npm run typecheck`
- generated a 5,000-frame, two-channel BLF and read all frames with `python-can`
- replayed the recorded BLF and confirmed both channels retained the complete 5,000-frame payload sequence

Fixes #417
