### PR TITLE
fix(logging): configure log destination and file names

### DIFF
--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -2282,7 +2282,8 @@
           "transport": "Transport",
           "format": "Format",
           "compression": "Compression",
-          "filePath": "File Path",
+          "destinationFolder": "Destination Folder",
+          "fileNameRule": "File Name Rule",
           "recordTypes": "Record Types"
         },
         "placeholders": {
@@ -2290,7 +2291,8 @@
           "transport": "Transport",
           "format": "Format",
           "compressionLevel": "Compression level",
-          "logFilePath": "Log file Path"
+          "destinationFolder": "Select a destination folder",
+          "fileNameRule": "For example: {LocalTime} or CAN_{LocalTime}"
         },
         "options": {
           "disabled": "Disabled",
@@ -2314,11 +2316,17 @@
         },
         "buttons": {
           "browse": "Browse",
+          "fieldCodes": "Field Codes",
           "cancel": "Cancel",
           "ok": "OK"
         },
         "messages": {
-          "timestampAppended": "A timestamp (YYYYMMDDHHmmss) will be automatically appended to the filename."
+          "fileNameExample": "Example"
+        },
+        "fieldCodes": {
+          "localTime": "Local System Time",
+          "loggerName": "Logger Name",
+          "projectName": "Project Name"
         },
         "transfer": {
           "valid": "Valid",
@@ -2327,10 +2335,12 @@
         "validation": {
           "logNameExists": "The log name already exists",
           "inputNodeName": "Please input node name",
-          "inputLogFilePath": "Please input log file path"
+          "inputDestinationFolder": "Please select a destination folder",
+          "inputFileNameRule": "Please input a file name rule",
+          "invalidFileNameRule": "The file name rule contains invalid characters"
         },
         "dialog": {
-          "selectLogFile": "Select Log File",
+          "selectLogFolder": "Select Log Destination Folder",
           "allFiles": "All Files",
           "logFile": "Log File"
         }

--- a/src/main/ipc/fs.ts
+++ b/src/main/ipc/fs.ts
@@ -61,6 +61,12 @@ ipcMain.on('ipc-path-parse', async (event, arg) => {
 ipcMain.on('ipc-path-relative', async (event, ...args) => {
   event.returnValue = path.relative(args[0], args[1])
 })
+ipcMain.on('ipc-path-join', async (event, ...args) => {
+  event.returnValue = path.join(...args)
+})
+ipcMain.on('ipc-path-is-absolute', async (event, arg) => {
+  event.returnValue = path.isAbsolute(arg)
+})
 ipcMain.handle('ipc-glob', async (event, ...args) => {
   const par = args.shift()
   return glob(par, ...args)

--- a/src/main/ipc/uds.ts
+++ b/src/main/ipc/uds.ts
@@ -3,6 +3,7 @@ import scriptIndex from '../../../resources/docs/.gitkeep?asset&asarUnpack'
 import esbuild from '../../../resources/bin/esbuild.exe?asset&asarUnpack'
 import ascTransport from '../transport/asc'
 import blfTransport from '../transport/blf'
+import { resolveLogFilePath } from '../transport/filePath'
 let esbuild_executable = esbuild
 if (process.platform === 'darwin') {
   esbuild_executable = esbuild.replace('.exe', '_mac')
@@ -797,12 +798,17 @@ ipcMain.handle('ipc-global-start', async (event, ...arg) => {
         log.path = path.join(projectInfo.path, log.path)
       }
 
+      const logFilePath = resolveLogFilePath(log.path, log.format, {
+        loggerName: log.name,
+        projectName: path.parse(projectInfo.name).name
+      })
+
       const id =
         log.format === 'blf'
           ? addDeviceTransport(() =>
-              blfTransport(log.path, log.channel, log.method, log.compression)
+              blfTransport(logFilePath, log.channel, log.method, log.compression)
             )
-          : addDeviceTransport(() => ascTransport(log.path, log.channel, log.method))
+          : addDeviceTransport(() => ascTransport(logFilePath, log.channel, log.method))
 
       exTransportList.push(id)
     }

--- a/src/main/share/logFile.ts
+++ b/src/main/share/logFile.ts
@@ -1,0 +1,43 @@
+import dayjs from 'dayjs'
+
+export const LOG_FILE_FIELD_CODES = {
+  localTime: '{LocalTime}',
+  loggerName: '{LoggerName}',
+  projectName: '{ProjectName}'
+} as const
+
+export interface LogFileNameContext {
+  loggerName: string
+  projectName: string
+}
+
+const INVALID_FILE_NAME_CHARACTERS = /[<>:"/\\|?*]/g
+
+export function isValidLogFileNameRule(rule: string): boolean {
+  return rule.trim().length > 0 && !/[<>:"/\\|?*]/.test(rule)
+}
+
+function sanitizeFileName(value: string): string {
+  return value.replace(INVALID_FILE_NAME_CHARACTERS, '_').trim()
+}
+
+export function resolveLogFileName(
+  rule: string,
+  context: LogFileNameContext,
+  now: Date = new Date()
+): string {
+  const normalizedRule = rule.trim() || LOG_FILE_FIELD_CODES.localTime
+  const hasLocalTime = normalizedRule.includes(LOG_FILE_FIELD_CODES.localTime)
+  const localTime = dayjs(now).format('YYYY-MM-DD_HH-mm-ss')
+
+  let fileName = normalizedRule
+    .replaceAll(LOG_FILE_FIELD_CODES.localTime, localTime)
+    .replaceAll(LOG_FILE_FIELD_CODES.loggerName, context.loggerName)
+    .replaceAll(LOG_FILE_FIELD_CODES.projectName, context.projectName)
+
+  if (!hasLocalTime) {
+    fileName += `_${dayjs(now).format('YYYYMMDDHHmmss')}`
+  }
+
+  return sanitizeFileName(fileName) || localTime
+}

--- a/src/main/transport/asc.ts
+++ b/src/main/transport/asc.ts
@@ -1,8 +1,6 @@
 import { CanMessage } from '../share/can'
 import winston, { format } from 'winston'
 import Transport from 'winston-transport'
-import dayjs from 'dayjs'
-import path from 'path'
 import { getCheckSum, LinChecksumType, LinDirection, LinError, LinMsg } from '../share/lin'
 
 // LogData interface matching the one from trace.vue
@@ -328,19 +326,10 @@ class FileTransport extends winston.transports.File {
 export default (filePath: string, devices: string[], method: string[]) => {
   const now = new Date()
   const keys = Object.keys(global.dataSet.devices)
-  // 获取当前时间作为时间戳后缀 (格式: YYYYMMDDHHmmss)
-  const timestamp = dayjs().format('YYYYMMDDHHmmss')
-
-  const parsedPath = path.parse(filePath)
-  const fileWithSuffix = path.format({
-    dir: parsedPath.dir,
-    name: parsedPath.name + '_' + timestamp,
-    ext: parsedPath.ext
-  })
   return new FileTransport(
     {
       format: ascFormat(method, keys, now.getTime()),
-      filename: fileWithSuffix,
+      filename: filePath,
       options: {
         flags: 'w'
       },

--- a/src/main/transport/blf.ts
+++ b/src/main/transport/blf.ts
@@ -1,7 +1,5 @@
 import fs from 'fs'
-import path from 'path'
 import zlib from 'zlib'
-import dayjs from 'dayjs'
 import Transport from 'winston-transport'
 import { CanMessage } from '../share/can'
 
@@ -501,14 +499,6 @@ export default (
   method: string[],
   compressionLevel?: number
 ) => {
-  const timestamp = dayjs().format('YYYYMMDDHHmmss')
-  const parsedPath = path.parse(filePath)
-  const fileWithSuffix = path.format({
-    dir: parsedPath.dir,
-    name: `${parsedPath.name}_${timestamp}`,
-    ext: parsedPath.ext
-  })
-
   const channelOrder = Object.keys((global as any).dataSet?.devices || {})
-  return new BlfTransport(fileWithSuffix, devices, method, channelOrder, compressionLevel)
+  return new BlfTransport(filePath, devices, method, channelOrder, compressionLevel)
 }

--- a/src/main/transport/filePath.ts
+++ b/src/main/transport/filePath.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import { LogFileNameContext, resolveLogFileName } from '../share/logFile'
+
+export function resolveLogFilePath(
+  configuredPath: string,
+  format: string,
+  context: LogFileNameContext,
+  now: Date = new Date()
+): string {
+  const parsedPath = path.parse(configuredPath)
+  const fileName = resolveLogFileName(parsedPath.name, context, now)
+
+  return path.format({
+    dir: parsedPath.dir,
+    name: fileName,
+    ext: parsedPath.ext || `.${format}`
+  })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,12 @@ path.parse = (path: string) => {
 path.relative = (from: string, to: string) => {
   return ipcRenderer.sendSync('ipc-path-relative', from, to)
 }
+path.join = (...paths: string[]) => {
+  return ipcRenderer.sendSync('ipc-path-join', ...paths)
+}
+path.isAbsolute = (path: string) => {
+  return ipcRenderer.sendSync('ipc-path-is-absolute', path)
+}
 
 const getPort = (id: string): void => {
   ipcRenderer.once('port', (event, id) => {

--- a/src/renderer/src/views/uds/network/index.vue
+++ b/src/renderer/src/views/uds/network/index.vue
@@ -1372,7 +1372,7 @@ function addNode(type: string, parent?: Tree) {
       id: id,
       type: 'file',
       format: 'asc',
-      path: 'log.txt',
+      path: '{LocalTime}.asc',
       channel: [],
       method: []
     }

--- a/src/renderer/src/views/uds/network/logConfig.vue
+++ b/src/renderer/src/views/uds/network/logConfig.vue
@@ -99,31 +99,57 @@
             </el-form-item>
             <el-form-item
               v-if="formData.type == 'file'"
-              :label="i18next.t('uds.network.logConfig.labels.filePath')"
+              :label="i18next.t('uds.network.logConfig.labels.destinationFolder')"
               prop="path"
             >
               <el-input
-                v-model="formData.path"
-                :placeholder="i18next.t('uds.network.logConfig.placeholders.logFilePath')"
+                v-model="destinationFolder"
+                :placeholder="i18next.t('uds.network.logConfig.placeholders.destinationFolder')"
               >
                 <template #append>
-                  <el-button size="small" @click="browseFile">{{
+                  <el-button size="small" @click="browseDirectory">{{
                     i18next.t('uds.network.logConfig.buttons.browse')
                   }}</el-button>
                 </template>
               </el-input>
             </el-form-item>
-            <el-alert
+            <el-form-item
               v-if="formData.type == 'file'"
-              type="info"
-              :closable="false"
-              show-icon
-              style="margin-bottom: 15px"
+              :label="i18next.t('uds.network.logConfig.labels.fileNameRule')"
             >
-              <template #title>
-                {{ i18next.t('uds.network.logConfig.messages.timestampAppended') }}
-              </template>
-            </el-alert>
+              <div class="file-name-rule">
+                <el-input
+                  v-model="fileNameRule"
+                  :placeholder="i18next.t('uds.network.logConfig.placeholders.fileNameRule')"
+                >
+                  <template #append>
+                    <el-dropdown trigger="click" @command="insertFieldCode">
+                      <el-button size="small">
+                        {{ i18next.t('uds.network.logConfig.buttons.fieldCodes') }}
+                        <el-icon class="el-icon--right"><ArrowDown /></el-icon>
+                      </el-button>
+                      <template #dropdown>
+                        <el-dropdown-menu>
+                          <el-dropdown-item :command="LOG_FILE_FIELD_CODES.localTime">
+                            {{ i18next.t('uds.network.logConfig.fieldCodes.localTime') }}
+                          </el-dropdown-item>
+                          <el-dropdown-item :command="LOG_FILE_FIELD_CODES.loggerName">
+                            {{ i18next.t('uds.network.logConfig.fieldCodes.loggerName') }}
+                          </el-dropdown-item>
+                          <el-dropdown-item :command="LOG_FILE_FIELD_CODES.projectName">
+                            {{ i18next.t('uds.network.logConfig.fieldCodes.projectName') }}
+                          </el-dropdown-item>
+                        </el-dropdown-menu>
+                      </template>
+                    </el-dropdown>
+                  </template>
+                </el-input>
+                <div class="file-name-example">
+                  {{ i18next.t('uds.network.logConfig.messages.fileNameExample') }}:
+                  {{ fileNamePreview }}
+                </div>
+              </div>
+            </el-form-item>
 
             <el-form-item
               :label="i18next.t('uds.network.logConfig.labels.recordTypes')"
@@ -209,6 +235,7 @@ import { TesterInfo } from 'nodeCan/tester'
 import { getCeilInstance } from './udsView'
 import { useGlobalStart } from '@r/stores/runtime'
 import i18next from 'i18next'
+import { isValidLogFileNameRule, LOG_FILE_FIELD_CODES, resolveLogFileName } from 'nodeCan/logFile'
 
 const activeName = ref('general')
 const props = defineProps<{
@@ -218,9 +245,43 @@ const globalStart = useGlobalStart()
 const editIndex = toRef(props, 'editIndex')
 const dataBase = useDataStore()
 const methodRef = ref<Record<string, boolean>>({})
+const project = useProjectStore()
 const formData = ref(cloneDeep(dataBase.logs[editIndex.value]))
 if (formData.value.format === 'blf' && formData.value.compression === undefined) {
   formData.value.compression = -1
+}
+const initialPathInfo = window.path.parse(formData.value.path || '')
+const initialDirectory = initialPathInfo.dir
+  ? window.path.isAbsolute(initialPathInfo.dir) || !project.projectInfo.path
+    ? initialPathInfo.dir
+    : window.path.join(project.projectInfo.path, initialPathInfo.dir)
+  : project.projectInfo.path
+const destinationFolder = ref(initialDirectory)
+const fileNameRule = ref(initialPathInfo.name || LOG_FILE_FIELD_CODES.localTime)
+const projectName = computed(() => {
+  if (!project.projectInfo.name) return ''
+  return window.path.parse(project.projectInfo.name).name
+})
+const fileNamePreview = computed(() => {
+  const fileName = resolveLogFileName(fileNameRule.value, {
+    loggerName: formData.value.name,
+    projectName: projectName.value
+  })
+  return `${fileName}.${formData.value.format}`
+})
+
+function buildConfiguredLogPath(): string {
+  const fileName = `${fileNameRule.value.trim()}.${formData.value.format}`
+  const selectedPath = window.path.join(destinationFolder.value.trim(), fileName)
+
+  if (project.projectInfo.path && window.path.isAbsolute(selectedPath)) {
+    return window.path.relative(project.projectInfo.path, selectedPath)
+  }
+  return selectedPath
+}
+
+function insertFieldCode(fieldCode: string) {
+  fileNameRule.value += fieldCode
 }
 const nameCheck = (rule: any, value: any, callback: any) => {
   if (value) {
@@ -274,8 +335,21 @@ const rules = computed(() => {
     ],
     path: [
       {
-        required: formData.value.type == 'file' ? true : false,
-        message: i18next.t('uds.network.logConfig.validation.inputLogFilePath')
+        validator: (rule: any, value: any, callback: any) => {
+          if (formData.value.type != 'file') {
+            callback()
+          } else if (!destinationFolder.value.trim()) {
+            callback(
+              new Error(i18next.t('uds.network.logConfig.validation.inputDestinationFolder'))
+            )
+          } else if (!fileNameRule.value.trim()) {
+            callback(new Error(i18next.t('uds.network.logConfig.validation.inputFileNameRule')))
+          } else if (!isValidLogFileNameRule(fileNameRule.value)) {
+            callback(new Error(i18next.t('uds.network.logConfig.validation.invalidFileNameRule')))
+          } else {
+            callback()
+          }
+        }
       }
     ]
   }
@@ -301,42 +375,16 @@ function handleMethodChange(
     }
   }
 }
-const project = useProjectStore()
-
-async function browseFile() {
-  const formatExtensions: Record<string, string[]> = {
-    asc: ['asc'],
-    blf: ['blf'],
-    csv: ['csv']
-  }
-
-  const formatNames: Record<string, string> = {
-    asc: i18next.t('uds.network.logConfig.options.ascFormat'),
-    blf: i18next.t('uds.network.logConfig.options.blfFormat'),
-    csv: i18next.t('uds.network.logConfig.options.csvFormat')
-  }
-
-  const currentFormat = formData.value.format || 'asc'
-  const extensions = formatExtensions[currentFormat] || ['*']
-  const formatName = formatNames[currentFormat] || i18next.t('uds.network.logConfig.dialog.logFile')
-
+async function browseDirectory() {
   const r = await window.electron.ipcRenderer.invoke('ipc-show-open-dialog', {
-    defaultPath: project.projectInfo.path,
-    title: i18next.t('uds.network.logConfig.dialog.selectLogFile'),
-    properties: ['openFile'],
-    filters: [
-      { name: formatName, extensions: extensions },
-      { name: i18next.t('uds.network.logConfig.dialog.allFiles'), extensions: ['*'] }
-    ]
+    defaultPath: destinationFolder.value || project.projectInfo.path,
+    title: i18next.t('uds.network.logConfig.dialog.selectLogFolder'),
+    properties: ['openDirectory']
   })
 
-  const file = r.filePaths[0]
-  if (file) {
-    if (project.projectInfo.path) {
-      formData.value.path = window.path.relative(project.projectInfo.path, file)
-    } else {
-      formData.value.path = file
-    }
+  const directory = r.filePaths[0]
+  if (directory) {
+    destinationFolder.value = directory
   }
 }
 
@@ -432,6 +480,7 @@ const handleConfirm = async () => {
   await ruleFormRef.value.validate((valid, fields) => {
     if (valid) {
       // 验证通过，更新数据
+      formData.value.path = buildConfiguredLogPath()
       dataBase.logs[editIndex.value] = cloneDeep(formData.value)
 
       const ceil = getCeilInstance(editIndex.value)
@@ -466,6 +515,17 @@ onMounted(() => {
   .el-input-group__prepend {
     padding: 0 5px !important;
   }
+}
+
+.file-name-rule {
+  width: 100%;
+}
+
+.file-name-example {
+  margin-top: 4px;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 18px;
 }
 </style>
 <style scoped>

--- a/test/transport/logFile.test.ts
+++ b/test/transport/logFile.test.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import { isValidLogFileNameRule, resolveLogFileName } from '../../src/main/share/logFile'
+import { resolveLogFilePath } from '../../src/main/transport/filePath'
+
+const TEST_TIME = new Date(2026, 7, 1, 1, 57, 46)
+const TEST_CONTEXT = {
+  loggerName: 'CAN Logger',
+  projectName: 'Issue 417'
+}
+
+describe('log file naming', () => {
+  it('expands field codes in a custom naming rule', () => {
+    expect(
+      resolveLogFileName('{ProjectName}_{LoggerName}_{LocalTime}', TEST_CONTEXT, TEST_TIME)
+    ).toBe('Issue 417_CAN Logger_2026-08-01_01-57-46')
+  })
+
+  it('keeps the legacy automatic timestamp when LocalTime is absent', () => {
+    expect(resolveLogFileName('capture', TEST_CONTEXT, TEST_TIME)).toBe('capture_20260801015746')
+  })
+
+  it('rejects path separators in a file name rule', () => {
+    expect(isValidLogFileNameRule('capture/{LocalTime}')).toBe(false)
+    expect(isValidLogFileNameRule('capture_{LocalTime}')).toBe(true)
+  })
+
+  it('preserves the configured directory and extension', () => {
+    expect(
+      resolveLogFilePath(path.join('logs', 'capture.asc'), 'asc', TEST_CONTEXT, TEST_TIME)
+    ).toBe(path.join('logs', 'capture_20260801015746.asc'))
+  })
+
+  it('uses the selected format when the configured path has no extension', () => {
+    expect(resolveLogFilePath('{LocalTime}', 'blf', TEST_CONTEXT, TEST_TIME)).toBe(
+      '2026-08-01_01-57-46.blf'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- change the log path browser from selecting an existing file to selecting a destination folder
- add a separate file naming rule with field codes such as `{LocalTime}` and a live filename preview
- apply the same path and naming behavior to ASC and BLF output
- preserve existing configurations while validating Windows-safe file names and output extensions

## Why

The previous browser used an open-file dialog, so users had to select an existing file even though logging creates a new file. It also did not provide a clear way to configure timestamped log names independently from the destination directory.

This change lets users select where logs should be saved and define how new log files are named before recording starts.

## Validation

- `npx vitest --config vitest.config.ts run test/transport/logFile.test.ts` — 5 tests passed
- `npm run typecheck`
- verified custom field-code expansion, legacy timestamp behavior, invalid-name rejection, directory preservation, and automatic extension selection
