### PR TITLE
fix(cli): package vsomeip worker so SOME/IP tests can run headless

### DIFF
--- a/cli.vite.ts
+++ b/cli.vite.ts
@@ -17,10 +17,15 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(__dirname, 'src/cli/index.ts'),
-          fake: resolve(__dirname, 'src/cli/fake.ts')
+          fake: resolve(__dirname, 'src/cli/fake.ts'),
+          vsomeip: resolve(__dirname, 'src/main/vsomeip/worker.ts')
         },
         output: {
-          entryFileNames: 'ecb_cli.js',
+          entryFileNames: (chunk) => {
+            if (chunk.name === 'vsomeip') return 'vsomeip.js'
+            if (chunk.name === 'index') return 'ecb_cli.js'
+            return chunk.name + '.js'
+          },
           format: 'cjs',
           dir: resolve(__dirname, 'cli/out/')
         }

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,6 +4,9 @@
   "description": "EcbBus-Pro CLI Tool",
   "bin": "dist/ecb_cli.js",
   "pkg": {
+    "scripts": [
+      "./dist/vsomeip.js"
+    ],
     "assets": [
       "./dist/*.node"
     ],

--- a/cli/webpack.config.js
+++ b/cli/webpack.config.js
@@ -2,22 +2,24 @@ const path = require('path');
 const webpack = require('webpack');
 const fs = require('fs');
 
-// Custom plugin to preprocess ecb_cli.js before packaging
+// Custom plugin to preprocess ecb_cli.js and vsomeip.js before packaging
 class PreprocessEcbCliPlugin {
     apply(compiler) {
         compiler.hooks.afterEmit.tapAsync('PreprocessEcbCliPlugin', (compilation, callback) => {
-            const ecbCliPath = path.resolve(__dirname, 'dist', 'ecb_cli.js');
-            const content = fs.readFileSync(ecbCliPath, 'utf8');
-            let processedContent = content.replace(
-                /path\.join\(__dirname\s*,\s*([^)]*)\)\.replace\(\s*["']app\.asar["']\s*,\s*["']app\.asar\.unpacked["']\s*\)/g,
-                'path.join(path.dirname(process.execPath), $1)'
-            );
-            //require: __webpack_require__("./out sync recursive"), to require:require
-            processedContent = processedContent.replace(
-                /require:\s*__webpack_require__\s*\(\s*["']\.\/out\s+sync\s+recursive["']\s*\)/g,
-                'require:require'
-            );
-            fs.writeFileSync(ecbCliPath, processedContent, 'utf8');
+            for (const file of ['ecb_cli.js', 'vsomeip.js']) {
+                const jsPath = path.resolve(__dirname, 'dist', file);
+                const content = fs.readFileSync(jsPath, 'utf8');
+                let processedContent = content.replace(
+                    /path\.join\(__dirname\s*,\s*([^)]*)\)\.replace\(\s*["']app\.asar["']\s*,\s*["']app\.asar\.unpacked["']\s*\)/g,
+                    'path.join(path.dirname(process.execPath), $1)'
+                );
+                //require: __webpack_require__("./out sync recursive"), to require:require
+                processedContent = processedContent.replace(
+                    /require:\s*__webpack_require__\s*\(\s*["']\.\/out\s+sync\s+recursive["']\s*\)/g,
+                    'require:require'
+                );
+                fs.writeFileSync(jsPath, processedContent, 'utf8');
+            }
             callback();
         });
     }
@@ -26,6 +28,7 @@ class PreprocessEcbCliPlugin {
 module.exports = {
     entry: {
         ecb_cli: path.resolve(__dirname, 'out', 'ecb_cli.js'),
+        vsomeip: path.resolve(__dirname, 'out', 'vsomeip.js'),
     },
     mode: 'development',
     output: {

--- a/src/cli/device.ts
+++ b/src/cli/device.ts
@@ -7,7 +7,7 @@ import { openLinDevice } from 'src/main/dolin'
 import LinBase from 'src/main/dolin/base'
 import { createPwmDevice, PwmBase } from 'src/main/pwm'
 import { SerialBase } from 'src/main/serial'
-import { generateConfigFile, VSomeIP_Client } from 'src/main/vsomeip'
+import { generateConfigFile, startRouterCounter, stopRouterCounter, VSomeIP_Client } from 'src/main/vsomeip'
 
 export default async function main(
   projectPath: string,
@@ -20,6 +20,7 @@ export default async function main(
   const pwmBaseMap = new Map<string, PwmBase>()
   const serialBaseMap = new Map<string, SerialBase>()
   const someipMap = new Map<string, VSomeIP_Client>()
+  let rounterInit = false
   for (const key in devices) {
     const device = devices[key]
     if (device.type == 'can' && device.canDevice) {
@@ -83,6 +84,10 @@ export default async function main(
     } else if (device.type == 'someip' && device.someipDevice) {
       const val = device.someipDevice
       const file = await generateConfigFile(val, projectPath, devices)
+      if (rounterInit == false) {
+        await startRouterCounter(file)
+        rounterInit = true
+      }
       const client = new VSomeIP_Client(val.name, file, val)
       client.init()
       someipMap.set(key, client)
@@ -115,4 +120,5 @@ export async function closeDevice(
   for (const someipBase of someipMap.values()) {
     await someipBase.stop()
   }
+  stopRouterCounter()
 }

--- a/src/main/nodeItem.ts
+++ b/src/main/nodeItem.ts
@@ -88,6 +88,7 @@ export class NodeClass {
   private pwmBaseId: string[] = []
   private serialBaseId: string[] = []
   private someipBaseId: string[] = []
+  private someipCbs: Map<string, (msg: SomeipMessage) => void> = new Map()
   private startTs = 0
   private boundCb: (frame: CanMessage | LinMsg | SomeipMessage | SerialMessage) => void
   private boundSomeipServiceValidCb: (info: VsomeipAvailabilityInfo) => void
@@ -229,7 +230,12 @@ export class NodeClass {
       const someipBaseItem = this.someipMap.get(c)
       if (someipBaseItem) {
         this.someipBaseId.push(c)
-        someipBaseItem.attachSomeipMessage(this.boundCb)
+        const wrappedSomeipCb = (msg: SomeipMessage) => {
+          msg.device = someipBaseItem.info.name
+          this.boundCb(msg)
+        }
+        this.someipCbs.set(c, wrappedSomeipCb)
+        someipBaseItem.attachSomeipMessage(wrappedSomeipCb)
         someipBaseItem.attachSomeipServiceValid(this.boundSomeipServiceValidCb)
       }
     }
@@ -1514,7 +1520,10 @@ export class NodeClass {
       }
       const someipBaseItem = this.someipMap.get(c)
       if (someipBaseItem) {
-        someipBaseItem.detachSomeipMessage(this.boundCb)
+        const wrappedSomeipCb = this.someipCbs.get(c)
+        if (wrappedSomeipCb) {
+          someipBaseItem.detachSomeipMessage(wrappedSomeipCb)
+        }
         someipBaseItem.detachSomeipServiceValid(this.boundSomeipServiceValidCb)
       }
       const serialBaseItem = this.serialBaseMap.get(c)


### PR DESCRIPTION
## Problem

`ecb_cli.exe test` on a project with SOME/IP devices always failed before any assertion ran with:

```
Error: Cannot find module 'C:\snapshot\cli\dist\vsomeip.js'
Error: Channel closed
```

Root cause: `VSomeIP_Client` / the routing manager start their vSomeIP worker via
`fork(resolve(__dirname, 'vsomeip.js'))` (`src/main/vsomeip/index.ts`). The CLI build
(`cli.vite.ts`) only emitted `index`/`fake` entries, so `vsomeip.js` was never produced,
and `cli/package.json` did not list it in pkg `scripts`, so the file was not in the pkg
snapshot either. The GUI app works because `electron.vite.config.ts` has a dedicated
`vsomeip` entry (`src/main/vsomeip/worker.ts`); the CLI build simply forgot the equivalent
entry.

## Changes

- **cli.vite.ts**: add a `vsomeip` entry (`src/main/vsomeip/worker.ts`) and name it
  `vsomeip.js` next to `ecb_cli.js` (the previous fixed `entryFileNames` string would have
  numbered extra entries, so a per-chunk function is used).
- **cli/package.json**: add `./dist/vsomeip.js` to pkg `scripts` so `fork()` can resolve it
  inside the packaged snapshot.
- **cli/webpack.config.js**: bundle the new `vsomeip` entry and apply the same
  `app.asar.unpacked` → `path.dirname(process.execPath)` preprocessing to `vsomeip.js`
  (DLL load path).
- **src/cli/device.ts**: start/stop the vSomeIP routing manager like the GUI main process
  does (`src/main/ipc/uds.ts`). Without it, clients never reach `ST_REGISTERED` and every
  request fails with `SomeIP is not registered`.
- **src/main/nodeItem.ts**: tag forwarded SOME/IP messages with the source device name so
  `sendFrame` can route responses when a node has more than one SOME/IP channel attached
  (previously `output()` responses failed with `device undefined not found`).

## Verification

Built locally on Windows (VS2022 Build Tools + Node 24, matching CI) and ran the official
`resources/examples/someip/` project headless:

```
ecb_cli.exe test someip.ecb "SOMEIP Loopback POC" --build --report someip-report.html
```

- exit code 0
- 3/3 assertions pass: method request/response payload, subscribe → notify → payload
  received → unsubscribe
- HTML report generated
- no leftover processes / listeners on 30490/30491/31490/30510 after run
