### PR TITLE
feat(xcp): add XCP master implementation with worker script API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ This section captures non-obvious, durable notes for developing EcuBus-Pro in a 
 
 **Native modules on Linux:** `src/main/docan|dolin|vsomeip/binding.gyp` compile only `fake_linux.cxx` stubs on Linux — no SWIG or vendor SDKs are needed to build them, and the committed `*_wrap.cxx` files are only used on Windows. Only the `simulate` and `slcan` CAN vendors are functional on Linux (see `ecubusPro.vendor` in `package.json`); other vendors are stubbed. After changing `src/main/worker/`, rerun `npm run worker:js`.
 
+**SocketCAN tests:** `test/docan/socketcan.test.ts` and `test/xcp/xcpCanSocketcan.test.ts` pack Linux `struct can_frame` / `canfd_frame` and drive two independent sockets. This Cloud kernel is built without `CONFIG_CAN` (`socket(AF_CAN)` → `EAFNOSUPPORT`), so the kernel vcan cases skip and the helper falls back to an in-process bus that still exchanges packed SocketCAN frames. On a normal Linux host, create `vcan0` (`sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`) to exercise real AF_CAN.
+
 **Python for diagnostic DB parsing:** ODX (`test/odx`) and CDD (`test/cdd`) parsing shell out to `resources/python/bin/python3` (see `getPythonPath()`). If that embedded Python or its packages (`odxtools`, `canmatrix`, `openpyxl`, ...) are missing, those tests and the app's ODX/CDD features fail with `spawn ... ENOENT`.
 
 **Running the GUI:** This is an Electron desktop app. Run it with `DISPLAY=:1 npm run dev` (a headless X server is already running on display `:1`). It launches without extra `--no-sandbox` flags. The `Autofill.enable`/`Autofill.setAddresses` DevTools console errors at startup are harmless.

--- a/src/main/nodeItem.ts
+++ b/src/main/nodeItem.ts
@@ -12,6 +12,7 @@ import UdsTester, {
   SomeipApiCall
 } from './workerClient'
 import { CAN_TP, CAN_TP_SOCKET, TpError as CanTpError } from './docan/cantp'
+import { XcpMaster, XcpCanTransport } from './xcp'
 import { UdsLOG, VarLOG } from './log'
 import { applyBuffer, getRxPdu, getTxPdu, PwmBaseInfo, ServiceItem, UdsDevice } from './share/uds'
 import { findService, UDSTesterMain } from './docan/uds'
@@ -77,11 +78,58 @@ class TestTransport extends Transport {
     callback()
   }
 }
+/** Whitelist of {@link XcpMaster} methods callable through the worker `xcpApi` bridge. */
+const XCP_ALLOWED_METHODS = new Set<string>([
+  'connect',
+  'disconnect',
+  'getStatus',
+  'synch',
+  'getCommModeInfo',
+  'getVersion',
+  'getId',
+  'setRequest',
+  'getSeed',
+  'unlock',
+  'setMta',
+  'upload',
+  'shortUpload',
+  'buildChecksum',
+  'userCmd',
+  'transportLayerCmd',
+  'download',
+  'downloadNext',
+  'downloadMax',
+  'shortDownload',
+  'modifyBits',
+  'setCalPage',
+  'getCalPage',
+  'copyCalPage',
+  'setDaqPtr',
+  'writeDaq',
+  'setDaqListMode',
+  'startStopDaqList',
+  'startStopSynch',
+  'getDaqClock',
+  'freeDaq',
+  'allocDaq',
+  'allocOdt',
+  'allocOdtEntry',
+  'clearDaqList',
+  'programStart',
+  'programClear',
+  'program',
+  'programReset',
+  'programNext',
+  'programMax',
+  'programVerify'
+])
+
 export class NodeClass {
   pool?: UdsTester
   private cantp: CAN_TP[] = []
   private lintp: LIN_TP[] = []
   private cantpSocketMap: Map<string, { tp: CAN_TP; socket: CAN_TP_SOCKET }> = new Map()
+  private xcpMasterMap: Map<string, { master: XcpMaster; transport: XcpCanTransport }> = new Map()
   private linBaseId: string[] = []
   private canBaseId: string[] = []
   private ethBaseId: string[] = []
@@ -247,6 +295,7 @@ export class NodeClass {
       this.pool.registerHandler('runUdsSeq', this.runUdsSeq.bind(this))
       this.pool.registerHandler('linApi', this.linApi.bind(this))
       this.pool.registerHandler('canApi', this.canApi.bind(this))
+      this.pool.registerHandler('xcpApi', this.xcpApi.bind(this))
       this.pool.registerHandler('stopUdsSeq', this.stopUdsSeq.bind(this))
       this.pool.registerHandler('pwmApi', this.pwmApi.bind(this))
       this.pool.registerHandler('serialApi', this.serialApi.bind(this))
@@ -1030,6 +1079,65 @@ export class NodeClass {
     throw new Error(`unknown canApi op: ${op}`)
   }
 
+  /**
+   * Worker RPC: XCP-on-CAN master operations.
+   *
+   * Ops:
+   * - `createConnection` — open an {@link XcpMaster} bound to an {@link XcpCanTransport}.
+   * - `closeConnection` — dispose a previously opened connection.
+   * - `command` — invoke a whitelisted {@link XcpMaster} method by name with args.
+   */
+  async xcpApi(data: any): Promise<any> {
+    const { op } = data
+
+    const findCanBase = (device?: string) => {
+      if (device != undefined) {
+        for (const channelId of this.canBaseId) {
+          const item = this.canBaseMap.get(channelId)
+          if (item && item.info.name == device) return item
+        }
+        throw new Error(`CAN device '${device}' not found`)
+      }
+      if (this.canBaseId.length > 0) {
+        const item = this.canBaseMap.get(this.canBaseId[0])
+        if (item) return item
+      }
+      throw new Error('no CAN device attached to this node')
+    }
+
+    if (op === 'createConnection') {
+      const base = findCanBase(data.device)
+      const transport = new XcpCanTransport(base, data.addr)
+      const master = new XcpMaster(transport)
+      const handle = `xcp-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      this.xcpMasterMap.set(handle, { master, transport })
+      return handle
+    }
+
+    if (op === 'closeConnection') {
+      const entry = this.xcpMasterMap.get(data.handle)
+      if (!entry) throw new Error(`XCP handle '${data.handle}' not found`)
+      entry.master.close()
+      this.xcpMasterMap.delete(data.handle)
+      return
+    }
+
+    if (op === 'command') {
+      const entry = this.xcpMasterMap.get(data.handle)
+      if (!entry) throw new Error(`XCP handle '${data.handle}' not found`)
+      const method = data.method as string
+      if (!XCP_ALLOWED_METHODS.has(method)) {
+        throw new Error(`unknown or forbidden xcp command: ${method}`)
+      }
+      const fn = (entry.master as any)[method]
+      const result = await fn.apply(entry.master, data.args ?? [])
+      // Normalize Buffers to plain number arrays so they survive worker RPC cleanly.
+      return Buffer.isBuffer(result) ? Array.from(result) : result
+    }
+
+    throw new Error(`unknown xcpApi op: ${op}`)
+  }
+
   private resolveSomeipClient(channel?: string): VSomeIP_Client {
     if (channel) {
       const c = this.someipMap.get(channel)
@@ -1543,6 +1651,10 @@ export class NodeClass {
       tp.close(false)
     }
     this.cantpSocketMap.clear()
+    for (const { master } of this.xcpMasterMap.values()) {
+      master.close()
+    }
+    this.xcpMasterMap.clear()
     this.lintp.forEach((tp) => {
       tp.close(false)
     })

--- a/src/main/worker/index.ts
+++ b/src/main/worker/index.ts
@@ -37,6 +37,7 @@
 export * from './uds'
 export * from './someip'
 export * from './cantp'
+export * from './xcp'
 export * from './secureAccess'
 export * from './crc'
 export * from './cryptoExt'

--- a/src/main/worker/node.d.ts
+++ b/src/main/worker/node.d.ts
@@ -20,3 +20,15 @@ declare module '*.html?raw' {
   const content: string
   export default content
 }
+
+/** Asset path import (electron-vite `?asset` query) — resolves to a file path string. */
+declare module '*?asset' {
+  const path: string
+  export default path
+}
+
+/** Asset path import unpacked from the asar archive (`?asset&asarUnpack`) — resolves to a file path string. */
+declare module '*?asset&asarUnpack' {
+  const path: string
+  export default path
+}

--- a/src/main/worker/xcp.ts
+++ b/src/main/worker/xcp.ts
@@ -1,0 +1,322 @@
+/**
+ * XCP (ASAM MCD-1 XCP) worker API — drive an XCP slave from a user script.
+ *
+ * @remarks
+ * All functions bridge to the main process via `emitWorkerEventWithReply('xcpApi', ...)`.
+ * Use {@link XcpCreateConnection} to open an XCP-on-CAN connection and obtain a handle,
+ * then pass that handle to the command helpers. Always call {@link XcpCloseConnection}
+ * when done.
+ *
+ * This first iteration targets XCP-on-CAN and the standard command set (session,
+ * memory transfer, calibration/paging, basic DAQ and programming). The protocol
+ * codec is validated against the test vectors of the mature
+ * {@link https://github.com/christoph2/pyxcp | pyXCP} master.
+ *
+ * @module xcp
+ * @category XCP
+ *
+ * @example
+ * ```ts
+ * import { XcpCreateConnection, XcpConnect, XcpShortUpload, XcpCloseConnection } from 'ecubus-worker'
+ *
+ * Util.Init(async () => {
+ *   const handle = await XcpCreateConnection({
+ *     name: 'ecu',
+ *     canIdCmd: 0x7e0,
+ *     canIdResp: 0x7e1,
+ *     padding: true
+ *   })
+ *   const info = await XcpConnect(handle)
+ *   console.log('MAX_CTO', info.maxCto, 'MAX_DTO', info.maxDto)
+ *   const bytes = await XcpShortUpload(handle, 4, 0x1000)
+ *   console.log('mem', bytes)
+ *   await XcpCloseConnection(handle)
+ * })
+ * ```
+ */
+
+import { emitWorkerEventWithReply } from './uds'
+import type { XcpCanAddr } from '../xcp/xcpCan'
+import type {
+  BuildChecksumResponse,
+  ConnectResponse,
+  GetCommModeInfoResponse,
+  GetIdResponse,
+  GetSeedResponse,
+  GetStatusResponse,
+  GetVersionResponse,
+  ResourceFlags,
+  StartStopDaqListResponse
+} from '../xcp/xcpProtocol'
+
+/**
+ * XCP-on-CAN addressing configuration passed to {@link XcpCreateConnection}.
+ * @category XCP
+ */
+export type { XcpCanAddr }
+
+async function xcpCommand<T>(handle: string, method: string, args: any[] = []): Promise<T> {
+  return (await emitWorkerEventWithReply('xcpApi', {
+    op: 'command',
+    handle,
+    method,
+    args
+  })) as T
+}
+
+/**
+ * Open an XCP-on-CAN connection and return an opaque handle string.
+ *
+ * @param addr - XCP-on-CAN addressing (command / response CAN identifiers, framing).
+ * @param device - Optional CAN channel name; the first attached CAN channel is used when omitted.
+ * @returns Opaque handle string to pass to the other Xcp* functions.
+ * @throws If no suitable CAN device is found.
+ * @category XCP
+ */
+export async function XcpCreateConnection(addr: XcpCanAddr, device?: string): Promise<string> {
+  const handle = await emitWorkerEventWithReply('xcpApi', {
+    op: 'createConnection',
+    addr,
+    device
+  })
+  return handle as string
+}
+
+/**
+ * Close an XCP connection previously opened with {@link XcpCreateConnection}.
+ * @category XCP
+ */
+export async function XcpCloseConnection(handle: string): Promise<void> {
+  await emitWorkerEventWithReply('xcpApi', { op: 'closeConnection', handle })
+}
+
+/** CONNECT to the slave and read back its properties. @category XCP */
+export function XcpConnect(handle: string, mode = 0): Promise<ConnectResponse> {
+  return xcpCommand(handle, 'connect', [mode])
+}
+
+/** DISCONNECT from the slave. @category XCP */
+export function XcpDisconnect(handle: string): Promise<number[]> {
+  return xcpCommand(handle, 'disconnect')
+}
+
+/** GET_STATUS: current session and resource-protection status. @category XCP */
+export function XcpGetStatus(handle: string): Promise<GetStatusResponse> {
+  return xcpCommand(handle, 'getStatus')
+}
+
+/** GET_COMM_MODE_INFO: optional communication modes and timing. @category XCP */
+export function XcpGetCommModeInfo(handle: string): Promise<GetCommModeInfoResponse> {
+  return xcpCommand(handle, 'getCommModeInfo')
+}
+
+/** GET_VERSION: protocol and transport layer versions. @category XCP */
+export function XcpGetVersion(handle: string): Promise<GetVersionResponse> {
+  return xcpCommand(handle, 'getVersion')
+}
+
+/** GET_ID: request the identifier header (identifier bytes follow via {@link XcpUpload}). @category XCP */
+export function XcpGetId(handle: string, mode: number): Promise<GetIdResponse> {
+  return xcpCommand(handle, 'getId', [mode])
+}
+
+/** GET_SEED: request a seed for seed & key unlock. @category XCP */
+export function XcpGetSeed(
+  handle: string,
+  mode: number,
+  resource: number
+): Promise<GetSeedResponse> {
+  return xcpCommand(handle, 'getSeed', [mode, resource])
+}
+
+/** UNLOCK: send the computed key to unlock a protected resource. @category XCP */
+export function XcpUnlock(handle: string, length: number, key: number[]): Promise<ResourceFlags> {
+  return xcpCommand(handle, 'unlock', [length, key])
+}
+
+/** SET_MTA: set the Memory Transfer Address pointer. @category XCP */
+export function XcpSetMta(
+  handle: string,
+  address: number,
+  addressExtension = 0
+): Promise<number[]> {
+  return xcpCommand(handle, 'setMta', [address, addressExtension])
+}
+
+/** UPLOAD: read `count` elements from the current MTA. @category XCP */
+export function XcpUpload(handle: string, count: number): Promise<number[]> {
+  return xcpCommand(handle, 'upload', [count])
+}
+
+/** SHORT_UPLOAD: read `count` elements from an explicit address. @category XCP */
+export function XcpShortUpload(
+  handle: string,
+  count: number,
+  address: number,
+  addressExtension = 0
+): Promise<number[]> {
+  return xcpCommand(handle, 'shortUpload', [count, address, addressExtension])
+}
+
+/** BUILD_CHECKSUM: compute a checksum over a memory block from the current MTA. @category XCP */
+export function XcpBuildChecksum(
+  handle: string,
+  blockSize: number
+): Promise<BuildChecksumResponse> {
+  return xcpCommand(handle, 'buildChecksum', [blockSize])
+}
+
+/** DOWNLOAD: write `data` to the current MTA. @category XCP */
+export function XcpDownload(handle: string, data: number[]): Promise<number[]> {
+  return xcpCommand(handle, 'download', [data])
+}
+
+/** SHORT_DOWNLOAD: write `data` to an explicit address. @category XCP */
+export function XcpShortDownload(
+  handle: string,
+  address: number,
+  addressExtension: number,
+  data: number[]
+): Promise<number[]> {
+  return xcpCommand(handle, 'shortDownload', [address, addressExtension, data])
+}
+
+/** MODIFY_BITS: atomic read-modify-write of a 16-bit word at the current MTA. @category XCP */
+export function XcpModifyBits(
+  handle: string,
+  shiftValue: number,
+  andMask: number,
+  xorMask: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'modifyBits', [shiftValue, andMask, xorMask])
+}
+
+/** SET_CAL_PAGE: activate a calibration page. @category XCP */
+export function XcpSetCalPage(
+  handle: string,
+  mode: number,
+  segment: number,
+  page: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'setCalPage', [mode, segment, page])
+}
+
+/** GET_CAL_PAGE: get the active calibration page of a segment. @category XCP */
+export function XcpGetCalPage(handle: string, mode: number, segment: number): Promise<number> {
+  return xcpCommand(handle, 'getCalPage', [mode, segment])
+}
+
+/** SET_DAQ_PTR: select the DAQ list / ODT / ODT-entry for subsequent WRITE_DAQ. @category XCP */
+export function XcpSetDaqPtr(
+  handle: string,
+  daqListNumber: number,
+  odtNumber: number,
+  odtEntryNumber: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'setDaqPtr', [daqListNumber, odtNumber, odtEntryNumber])
+}
+
+/** WRITE_DAQ: configure the currently selected ODT entry. @category XCP */
+export function XcpWriteDaq(
+  handle: string,
+  bitOffset: number,
+  size: number,
+  addressExtension: number,
+  address: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'writeDaq', [bitOffset, size, addressExtension, address])
+}
+
+/** SET_DAQ_LIST_MODE: set the mode of a DAQ list. @category XCP */
+export function XcpSetDaqListMode(
+  handle: string,
+  mode: number,
+  daqListNumber: number,
+  eventChannelNumber: number,
+  prescaler: number,
+  priority: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'setDaqListMode', [
+    mode,
+    daqListNumber,
+    eventChannelNumber,
+    prescaler,
+    priority
+  ])
+}
+
+/** START_STOP_DAQ_LIST: start/stop/select a single DAQ list. @category XCP */
+export function XcpStartStopDaqList(
+  handle: string,
+  mode: number,
+  daqListNumber: number
+): Promise<StartStopDaqListResponse> {
+  return xcpCommand(handle, 'startStopDaqList', [mode, daqListNumber])
+}
+
+/** START_STOP_SYNCH: start/stop all selected DAQ lists synchronously. @category XCP */
+export function XcpStartStopSynch(handle: string, mode: number): Promise<number[]> {
+  return xcpCommand(handle, 'startStopSynch', [mode])
+}
+
+/** GET_DAQ_CLOCK: get the current slave DAQ clock timestamp. @category XCP */
+export function XcpGetDaqClock(handle: string): Promise<number> {
+  return xcpCommand(handle, 'getDaqClock')
+}
+
+/** FREE_DAQ: free the dynamic DAQ list configuration. @category XCP */
+export function XcpFreeDaq(handle: string): Promise<number[]> {
+  return xcpCommand(handle, 'freeDaq')
+}
+
+/** ALLOC_DAQ: allocate a number of dynamic DAQ lists. @category XCP */
+export function XcpAllocDaq(handle: string, daqCount: number): Promise<number[]> {
+  return xcpCommand(handle, 'allocDaq', [daqCount])
+}
+
+/** ALLOC_ODT: allocate ODTs for a dynamic DAQ list. @category XCP */
+export function XcpAllocOdt(
+  handle: string,
+  daqListNumber: number,
+  odtCount: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'allocOdt', [daqListNumber, odtCount])
+}
+
+/** ALLOC_ODT_ENTRY: allocate ODT entries for a dynamic ODT. @category XCP */
+export function XcpAllocOdtEntry(
+  handle: string,
+  daqListNumber: number,
+  odtNumber: number,
+  odtEntriesCount: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'allocOdtEntry', [daqListNumber, odtNumber, odtEntriesCount])
+}
+
+/** PROGRAM_START: begin a programming sequence. @category XCP */
+export function XcpProgramStart(handle: string): Promise<number[]> {
+  return xcpCommand(handle, 'programStart')
+}
+
+/** PROGRAM_CLEAR: erase a range of program memory. @category XCP */
+export function XcpProgramClear(
+  handle: string,
+  mode: number,
+  clearRange: number
+): Promise<number[]> {
+  return xcpCommand(handle, 'programClear', [mode, clearRange])
+}
+
+/** PROGRAM: program `data` to the current MTA. @category XCP */
+export function XcpProgram(
+  handle: string,
+  numberOfElements: number,
+  data: number[]
+): Promise<number[]> {
+  return xcpCommand(handle, 'program', [numberOfElements, data])
+}
+
+/** PROGRAM_RESET: reset the slave after a programming sequence. @category XCP */
+export function XcpProgramReset(handle: string): Promise<number[]> {
+  return xcpCommand(handle, 'programReset')
+}

--- a/src/main/workerClient.ts
+++ b/src/main/workerClient.ts
@@ -38,6 +38,7 @@ type HandlerMap = {
   ) => void | Promise<number> | Promise<void>
   pwmApi: (data: pwmApiSetDuty) => void
   canApi: (data: any) => Promise<any>
+  xcpApi: (data: any) => Promise<any>
   pluginEvent: (data: { name: string; data: any }) => void
   serialApi: (data: SerialApi) => Promise<number>
   someipApi: (data: SomeipApiCall) => Promise<any>

--- a/src/main/xcp/index.ts
+++ b/src/main/xcp/index.ts
@@ -1,0 +1,10 @@
+/**
+ * XCP (ASAM MCD-1 XCP) master implementation for EcuBus-Pro.
+ *
+ * @module xcp
+ * @category XCP
+ */
+
+export * from './xcpProtocol'
+export * from './xcpMaster'
+export * from './xcpCan'

--- a/src/main/xcp/xcpCan.ts
+++ b/src/main/xcp/xcpCan.ts
@@ -1,0 +1,101 @@
+/**
+ * XCP-on-CAN transport binding.
+ *
+ * Implements {@link XcpTransport} on top of the existing CAN hardware layer
+ * ({@link CAN_SOCKET} / {@link CanBase}). The raw XCP packet is carried directly
+ * in the CAN frame data field: command messages use the TX identifier, responses
+ * are received on the RX identifier.
+ *
+ * @module xcpCan
+ * @category XCP
+ */
+
+import { CAN_SOCKET, CanBase } from '../docan/base'
+import { CAN_ID_TYPE, CanMsgType, getDlcByLen, getLenByDlc } from '../share/can'
+import { XcpTransport } from './xcpMaster'
+
+/**
+ * XCP-on-CAN addressing configuration.
+ * @category XCP
+ */
+export interface XcpCanAddr {
+  /** Optional connection name (for logging / identification). */
+  name?: string
+  /** CAN identifier the master sends commands (CMD/STIM) on. */
+  canIdCmd: number
+  /** CAN identifier the slave sends responses (RES/DAQ) on. */
+  canIdResp: number
+  /** Standard (11-bit) or extended (29-bit) identifiers. */
+  extended?: boolean
+  /** Use CAN-FD frames. */
+  canfd?: boolean
+  /** Use bit-rate switching (CAN-FD only). */
+  brs?: boolean
+  /** Pad every command frame to a fixed length. */
+  padding?: boolean
+  /** Padding byte value (default 0x00). */
+  paddingValue?: number
+  /**
+   * Fixed frame length when {@link XcpCanAddr.padding} is enabled
+   * (classic CAN default 8).
+   */
+  dlc?: number
+}
+
+function toMsgType(addr: XcpCanAddr): CanMsgType {
+  return {
+    idType: addr.extended ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+    brs: !!addr.brs,
+    canfd: !!addr.canfd,
+    remote: false
+  }
+}
+
+/**
+ * XCP transport over a single CAN channel.
+ * @category XCP
+ */
+export class XcpCanTransport implements XcpTransport {
+  private readonly txSocket: CAN_SOCKET
+  private readonly rxSocket: CAN_SOCKET
+  private readonly addr: XcpCanAddr
+  private closed = false
+
+  constructor(base: CanBase, addr: XcpCanAddr) {
+    this.addr = addr
+    const msgType = toMsgType(addr)
+    this.txSocket = new CAN_SOCKET(base, addr.canIdCmd, msgType, { name: addr.name })
+    this.rxSocket = new CAN_SOCKET(base, addr.canIdResp, msgType, { name: addr.name })
+  }
+
+  private frame(packet: Buffer): Buffer {
+    if (!this.addr.padding) return packet
+    const target = this.addr.canfd
+      ? getLenByDlc(getDlcByLen(Math.max(packet.length, 1), true), true)
+      : Math.max(this.addr.dlc ?? 8, packet.length)
+    if (packet.length >= target) return packet
+    const pad = Buffer.alloc(target - packet.length, this.addr.paddingValue ?? 0)
+    return Buffer.concat([packet, pad])
+  }
+
+  async request(request: Buffer, timeout = 1000): Promise<Buffer> {
+    if (this.closed) throw new Error('XCP CAN transport is closed')
+    // Drop any stale frames buffered on the response id before issuing a request.
+    this.rxSocket.recvBuffer = []
+    await this.txSocket.write(this.frame(request))
+    const { data } = await this.rxSocket.read(timeout)
+    return data
+  }
+
+  async send(request: Buffer): Promise<void> {
+    if (this.closed) throw new Error('XCP CAN transport is closed')
+    await this.txSocket.write(this.frame(request))
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    this.txSocket.close()
+    this.rxSocket.close()
+  }
+}

--- a/src/main/xcp/xcpMaster.ts
+++ b/src/main/xcp/xcpMaster.ts
@@ -1,0 +1,411 @@
+/**
+ * XCP master (client) built on top of the {@link module:xcpProtocol | protocol codec}.
+ *
+ * {@link XcpMaster} is transport-agnostic: it talks to any {@link XcpTransport}
+ * implementation (XCP-on-CAN, XCP-on-Ethernet, a mock, ...). It negotiates the
+ * slave byte order during {@link XcpMaster.connect} and applies it to every
+ * subsequent multi-byte parameter, mirroring the behaviour of the mature
+ * {@link https://github.com/christoph2/pyxcp | pyXCP} master.
+ *
+ * @module xcpMaster
+ * @category XCP
+ */
+
+import * as P from './xcpProtocol'
+import { ByteOrder } from './xcpProtocol'
+
+/**
+ * Transport abstraction used by {@link XcpMaster}. An implementation only has to
+ * move raw XCP packets (CTOs) to/from the slave; framing is its own concern.
+ * @category XCP
+ */
+export interface XcpTransport {
+  /**
+   * Send a CTO request and resolve with the CTO response packet.
+   * @param request - Raw XCP request packet (starting with the command PID).
+   * @param timeout - Max time to wait for the response, in milliseconds.
+   */
+  request(request: Buffer, timeout?: number): Promise<Buffer>
+  /**
+   * Send a request without waiting for a response (block-transfer intermediate packets).
+   */
+  send(request: Buffer): Promise<void>
+  /** Release any resources held by the transport. */
+  close(): void
+}
+
+/**
+ * Properties of the connected slave, populated by {@link XcpMaster.connect}.
+ * @category XCP
+ */
+export interface SlaveProperties {
+  byteOrder: ByteOrder
+  addressGranularity: P.AddressGranularity
+  maxCto: number
+  maxDto: number
+  protocolLayerVersion: number
+  transportLayerVersion: number
+  resource: P.ConnectResponse['resource']
+  supportsSlaveBlockMode: boolean
+}
+
+/**
+ * High-level XCP master. Each method builds a request with the codec, sends it
+ * through the transport, validates the response, and returns a parsed result.
+ * @category XCP
+ */
+export class XcpMaster {
+  readonly transport: XcpTransport
+  /** Default response timeout, in milliseconds. */
+  timeout: number
+  slaveProperties: SlaveProperties = {
+    byteOrder: ByteOrder.INTEL,
+    addressGranularity: P.AddressGranularity.BYTE,
+    maxCto: 8,
+    maxDto: 8,
+    protocolLayerVersion: 0,
+    transportLayerVersion: 0,
+    resource: { calpag: false, daq: false, stim: false, pgm: false, dbg: false },
+    supportsSlaveBlockMode: false
+  }
+  connected = false
+
+  constructor(transport: XcpTransport, timeout = 1000) {
+    this.transport = transport
+    this.timeout = timeout
+  }
+
+  private get bo(): ByteOrder {
+    return this.slaveProperties.byteOrder
+  }
+
+  private async request(packet: Buffer): Promise<Buffer> {
+    return this.transport.request(packet, this.timeout)
+  }
+
+  /* ------------------------------ STD ------------------------------ */
+
+  /** CONNECT to the slave and record its properties (byte order, MAX_CTO, ...). */
+  async connect(mode = 0): Promise<P.ConnectResponse> {
+    const resp = await this.request(P.buildConnect(mode))
+    const parsed = P.parseConnectResponse(resp)
+    this.slaveProperties = {
+      byteOrder: parsed.commModeBasic.byteOrder,
+      addressGranularity: parsed.commModeBasic.addressGranularity,
+      maxCto: parsed.maxCto,
+      maxDto: parsed.maxDto,
+      protocolLayerVersion: parsed.protocolLayerVersion,
+      transportLayerVersion: parsed.transportLayerVersion,
+      resource: parsed.resource,
+      supportsSlaveBlockMode: parsed.commModeBasic.slaveBlockMode
+    }
+    this.connected = true
+    return parsed
+  }
+
+  /** DISCONNECT from the slave. */
+  async disconnect(): Promise<Buffer> {
+    const resp = await this.request(P.buildDisconnect())
+    const payload = P.checkResponse(resp)
+    this.connected = false
+    return Buffer.from(payload)
+  }
+
+  /** GET_STATUS: current session and resource-protection status. */
+  async getStatus(): Promise<P.GetStatusResponse> {
+    const resp = await this.request(P.buildGetStatus())
+    return P.parseGetStatusResponse(resp, this.bo)
+  }
+
+  /** SYNCH: bring the command processor back to a defined state. */
+  async synch(): Promise<Buffer> {
+    const resp = await this.request(P.buildSynch())
+    // SYNCH is answered either with a positive response or the standard
+    // ERR_CMD_SYNCH (0xFE 0x00); both indicate success.
+    if (resp[0] === P.XcpResponse.ERR && resp[1] === P.XcpErrorCode.ERR_CMD_SYNCH) {
+      return Buffer.from([P.XcpErrorCode.ERR_CMD_SYNCH])
+    }
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** GET_COMM_MODE_INFO: optional communication modes and timing. */
+  async getCommModeInfo(): Promise<P.GetCommModeInfoResponse> {
+    const resp = await this.request(P.buildGetCommModeInfo())
+    return P.parseGetCommModeInfoResponse(resp)
+  }
+
+  /** GET_VERSION: protocol and transport layer versions. */
+  async getVersion(): Promise<P.GetVersionResponse> {
+    const resp = await this.request(P.buildGetVersion())
+    return P.parseGetVersionResponse(resp)
+  }
+
+  /** GET_ID: request the identifier header (bytes are then read via UPLOAD). */
+  async getId(mode: number): Promise<P.GetIdResponse> {
+    const resp = await this.request(P.buildGetId(mode))
+    return P.parseGetIdResponse(resp, this.bo)
+  }
+
+  /** SET_REQUEST: request a persistent slave action (e.g. store CAL/DAQ). */
+  async setRequest(mode: number, sessionConfigurationId: number): Promise<Buffer> {
+    const resp = await this.request(P.buildSetRequest(mode, sessionConfigurationId))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** GET_SEED: request a seed for the seed & key unlock procedure. */
+  async getSeed(mode: number, resource: number): Promise<P.GetSeedResponse> {
+    const resp = await this.request(P.buildGetSeed(mode, resource))
+    return P.parseGetSeedResponse(resp)
+  }
+
+  /** UNLOCK: send the computed key to unlock a protected resource. */
+  async unlock(length: number, key: number[] | Buffer): Promise<P.ResourceFlags> {
+    const resp = await this.request(P.buildUnlock(length, key))
+    return P.parseUnlockResponse(resp)
+  }
+
+  /** SET_MTA: set the Memory Transfer Address pointer. */
+  async setMta(address: number, addressExtension = 0): Promise<Buffer> {
+    const resp = await this.request(P.buildSetMta(address, addressExtension, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** UPLOAD: read `count` elements starting at the current MTA. */
+  async upload(count: number): Promise<Buffer> {
+    const resp = await this.request(P.buildUpload(count))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** SHORT_UPLOAD: read `count` elements from an explicit address in one command. */
+  async shortUpload(count: number, address: number, addressExtension = 0): Promise<Buffer> {
+    const resp = await this.request(P.buildShortUpload(count, address, addressExtension, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** BUILD_CHECKSUM: compute a checksum over a memory block from the current MTA. */
+  async buildChecksum(blockSize: number): Promise<P.BuildChecksumResponse> {
+    const resp = await this.request(P.buildBuildChecksum(blockSize, this.bo))
+    return P.parseBuildChecksumResponse(resp, this.bo)
+  }
+
+  /** USER_CMD: transmit a user-defined command. */
+  async userCmd(subCommand: number, data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildUserCmd(subCommand, data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** TRANSPORT_LAYER_CMD: transmit a transport-layer specific command. */
+  async transportLayerCmd(subCommand: number, data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildTransportLayerCmd(subCommand, data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /* --------------------------- CAL / PAG --------------------------- */
+
+  /** DOWNLOAD: write `data` to the current MTA. */
+  async download(data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildDownload(data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** DOWNLOAD_NEXT: write the next block of a block-mode download. */
+  async downloadNext(remainingBlockLength: number, data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildDownloadNext(remainingBlockLength, data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** DOWNLOAD_MAX: write a fixed MAX_CTO-sized block to the current MTA. */
+  async downloadMax(data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildDownloadMax(data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** SHORT_DOWNLOAD: write `data` to an explicit address in one command. */
+  async shortDownload(
+    address: number,
+    addressExtension: number,
+    data: number[] | Buffer
+  ): Promise<Buffer> {
+    const resp = await this.request(P.buildShortDownload(address, addressExtension, data, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** MODIFY_BITS: atomic read-modify-write of a 16-bit word at the current MTA. */
+  async modifyBits(shiftValue: number, andMask: number, xorMask: number): Promise<Buffer> {
+    const resp = await this.request(P.buildModifyBits(shiftValue, andMask, xorMask, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** SET_CAL_PAGE: activate a calibration page for the given segment(s). */
+  async setCalPage(mode: number, segment: number, page: number): Promise<Buffer> {
+    const resp = await this.request(P.buildSetCalPage(mode, segment, page))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** GET_CAL_PAGE: get the active calibration page of a segment. */
+  async getCalPage(mode: number, segment: number): Promise<number> {
+    const resp = await this.request(P.buildGetCalPage(mode, segment))
+    return P.parseGetCalPageResponse(resp)
+  }
+
+  /** COPY_CAL_PAGE: copy one calibration page to another. */
+  async copyCalPage(
+    srcSegment: number,
+    srcPage: number,
+    dstSegment: number,
+    dstPage: number
+  ): Promise<Buffer> {
+    const resp = await this.request(P.buildCopyCalPage(srcSegment, srcPage, dstSegment, dstPage))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /* ------------------------------ DAQ ------------------------------ */
+
+  /** SET_DAQ_PTR: select the DAQ list / ODT / ODT-entry for subsequent WRITE_DAQ. */
+  async setDaqPtr(
+    daqListNumber: number,
+    odtNumber: number,
+    odtEntryNumber: number
+  ): Promise<Buffer> {
+    const resp = await this.request(
+      P.buildSetDaqPtr(daqListNumber, odtNumber, odtEntryNumber, this.bo)
+    )
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** WRITE_DAQ: configure the currently selected ODT entry. */
+  async writeDaq(
+    bitOffset: number,
+    size: number,
+    addressExtension: number,
+    address: number
+  ): Promise<Buffer> {
+    const resp = await this.request(
+      P.buildWriteDaq(bitOffset, size, addressExtension, address, this.bo)
+    )
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** SET_DAQ_LIST_MODE: set the mode of a DAQ list (event channel, prescaler, ...). */
+  async setDaqListMode(
+    mode: number,
+    daqListNumber: number,
+    eventChannelNumber: number,
+    prescaler: number,
+    priority: number
+  ): Promise<Buffer> {
+    const resp = await this.request(
+      P.buildSetDaqListMode(mode, daqListNumber, eventChannelNumber, prescaler, priority, this.bo)
+    )
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** START_STOP_DAQ_LIST: start/stop/select a single DAQ list. */
+  async startStopDaqList(mode: number, daqListNumber: number): Promise<P.StartStopDaqListResponse> {
+    const resp = await this.request(P.buildStartStopDaqList(mode, daqListNumber, this.bo))
+    return P.parseStartStopDaqListResponse(resp)
+  }
+
+  /** START_STOP_SYNCH: start/stop all selected DAQ lists synchronously. */
+  async startStopSynch(mode: number): Promise<Buffer> {
+    const resp = await this.request(P.buildStartStopSynch(mode))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** GET_DAQ_CLOCK: get the current slave DAQ clock timestamp. */
+  async getDaqClock(): Promise<number> {
+    const resp = await this.request(P.buildGetDaqClock())
+    return P.parseGetDaqClockResponse(resp, this.bo)
+  }
+
+  /** FREE_DAQ: free the dynamic DAQ list configuration. */
+  async freeDaq(): Promise<Buffer> {
+    const resp = await this.request(P.buildFreeDaq())
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** ALLOC_DAQ: allocate a number of dynamic DAQ lists. */
+  async allocDaq(daqCount: number): Promise<Buffer> {
+    const resp = await this.request(P.buildAllocDaq(daqCount, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** ALLOC_ODT: allocate ODTs for a dynamic DAQ list. */
+  async allocOdt(daqListNumber: number, odtCount: number): Promise<Buffer> {
+    const resp = await this.request(P.buildAllocOdt(daqListNumber, odtCount, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** ALLOC_ODT_ENTRY: allocate ODT entries for a dynamic ODT. */
+  async allocOdtEntry(
+    daqListNumber: number,
+    odtNumber: number,
+    odtEntriesCount: number
+  ): Promise<Buffer> {
+    const resp = await this.request(
+      P.buildAllocOdtEntry(daqListNumber, odtNumber, odtEntriesCount, this.bo)
+    )
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** CLEAR_DAQ_LIST: clear a DAQ list. */
+  async clearDaqList(daqListNumber: number): Promise<Buffer> {
+    const resp = await this.request(P.buildClearDaqList(daqListNumber, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /* ------------------------------ PGM ------------------------------ */
+
+  /** PROGRAM_START: indicate the beginning of a programming sequence. */
+  async programStart(): Promise<Buffer> {
+    const resp = await this.request(P.buildProgramStart())
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** PROGRAM_CLEAR: erase a range of program memory. */
+  async programClear(mode: number, clearRange: number): Promise<Buffer> {
+    const resp = await this.request(P.buildProgramClear(mode, clearRange, this.bo))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** PROGRAM: program `data` to the current MTA. */
+  async program(numberOfElements: number, data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildProgram(numberOfElements, data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** PROGRAM_RESET: reset the slave after a programming sequence. */
+  async programReset(): Promise<Buffer> {
+    const resp = await this.request(P.buildProgramReset())
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** PROGRAM_NEXT: program the next block of a block-mode programming sequence. */
+  async programNext(remainingBlockLength: number, data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildProgramNext(remainingBlockLength, data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** PROGRAM_MAX: program a fixed MAX_CTO-sized block. */
+  async programMax(data: number[] | Buffer): Promise<Buffer> {
+    const resp = await this.request(P.buildProgramMax(data))
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** PROGRAM_VERIFY: verify the programmed memory. */
+  async programVerify(
+    mode: number,
+    verificationType: number,
+    verificationValue: number
+  ): Promise<Buffer> {
+    const resp = await this.request(
+      P.buildProgramVerify(mode, verificationType, verificationValue, this.bo)
+    )
+    return Buffer.from(P.checkResponse(resp))
+  }
+
+  /** Close the underlying transport. */
+  close(): void {
+    this.transport.close()
+  }
+}

--- a/src/main/xcp/xcpProtocol.ts
+++ b/src/main/xcp/xcpProtocol.ts
@@ -1,0 +1,948 @@
+/**
+ * XCP protocol codec (ASAM MCD-1 XCP).
+ *
+ * Pure, transport-agnostic helpers that build XCP master request packets (CTOs)
+ * and parse slave response packets. The command/response byte layout follows the
+ * ASAM XCP specification and is validated against the test vectors of the mature
+ * open-source master {@link https://github.com/christoph2/pyxcp | pyXCP}.
+ *
+ * A "packet" here is the raw XCP PDU (starting with the command / response PID);
+ * transport-specific framing (CAN id, Ethernet length/counter header, ...) is added
+ * by the transport layer, not here.
+ *
+ * @module xcpProtocol
+ * @category XCP
+ */
+
+/**
+ * XCP master-to-slave command codes (the first byte / PID of a CTO request).
+ * @category XCP
+ */
+export enum XcpCommand {
+  CONNECT = 0xff,
+  DISCONNECT = 0xfe,
+  GET_STATUS = 0xfd,
+  SYNCH = 0xfc,
+  GET_COMM_MODE_INFO = 0xfb,
+  GET_ID = 0xfa,
+  SET_REQUEST = 0xf9,
+  GET_SEED = 0xf8,
+  UNLOCK = 0xf7,
+  SET_MTA = 0xf6,
+  UPLOAD = 0xf5,
+  SHORT_UPLOAD = 0xf4,
+  BUILD_CHECKSUM = 0xf3,
+  TRANSPORT_LAYER_CMD = 0xf2,
+  USER_CMD = 0xf1,
+  // Calibration / paging
+  DOWNLOAD = 0xf0,
+  DOWNLOAD_NEXT = 0xef,
+  DOWNLOAD_MAX = 0xee,
+  SHORT_DOWNLOAD = 0xed,
+  MODIFY_BITS = 0xec,
+  SET_CAL_PAGE = 0xeb,
+  GET_CAL_PAGE = 0xea,
+  GET_PAG_PROCESSOR_INFO = 0xe9,
+  GET_SEGMENT_INFO = 0xe8,
+  GET_PAGE_INFO = 0xe7,
+  SET_SEGMENT_MODE = 0xe6,
+  GET_SEGMENT_MODE = 0xe5,
+  COPY_CAL_PAGE = 0xe4,
+  // DAQ
+  CLEAR_DAQ_LIST = 0xe3,
+  SET_DAQ_PTR = 0xe2,
+  WRITE_DAQ = 0xe1,
+  SET_DAQ_LIST_MODE = 0xe0,
+  GET_DAQ_LIST_MODE = 0xdf,
+  START_STOP_DAQ_LIST = 0xde,
+  START_STOP_SYNCH = 0xdd,
+  GET_DAQ_CLOCK = 0xdc,
+  READ_DAQ = 0xdb,
+  GET_DAQ_PROCESSOR_INFO = 0xda,
+  GET_DAQ_RESOLUTION_INFO = 0xd9,
+  GET_DAQ_LIST_INFO = 0xd8,
+  GET_DAQ_EVENT_INFO = 0xd7,
+  FREE_DAQ = 0xd6,
+  ALLOC_DAQ = 0xd5,
+  ALLOC_ODT = 0xd4,
+  ALLOC_ODT_ENTRY = 0xd3,
+  // PGM
+  PROGRAM_START = 0xd2,
+  PROGRAM_CLEAR = 0xd1,
+  PROGRAM = 0xd0,
+  PROGRAM_RESET = 0xcf,
+  GET_PGM_PROCESSOR_INFO = 0xce,
+  GET_SECTOR_INFO = 0xcd,
+  PROGRAM_PREPARE = 0xcc,
+  PROGRAM_FORMAT = 0xcb,
+  PROGRAM_NEXT = 0xca,
+  PROGRAM_MAX = 0xc9,
+  PROGRAM_VERIFY = 0xc8,
+  WRITE_DAQ_MULTIPLE = 0xc7,
+  // 0xC0 introduces the second command level (sub-command in the next byte)
+  GET_VERSION = 0xc0
+}
+
+/** GET_VERSION second-level sub-command (0xC0 0x00). @category XCP */
+export const GET_VERSION_SUB = 0x00
+
+/**
+ * Response / packet identifier codes (first byte of a slave DTO/CTO).
+ * @category XCP
+ */
+export enum XcpResponse {
+  /** Positive response. */
+  RES = 0xff,
+  /** Error response, second byte is an {@link XcpErrorCode}. */
+  ERR = 0xfe,
+  /** Event packet. */
+  EV = 0xfd,
+  /** Service request packet. */
+  SERV = 0xfc
+}
+
+/**
+ * Byte order of multi-byte parameters, negotiated in the CONNECT response.
+ * @category XCP
+ */
+export enum ByteOrder {
+  INTEL = 0,
+  MOTOROLA = 1
+}
+
+/**
+ * Address granularity of the slave (smallest addressable element), from CONNECT.
+ * @category XCP
+ */
+export enum AddressGranularity {
+  BYTE = 0,
+  WORD = 1,
+  DWORD = 2
+}
+
+/**
+ * Checksum algorithm returned by BUILD_CHECKSUM.
+ * @category XCP
+ */
+export enum ChecksumType {
+  XCP_ADD_11 = 0x01,
+  XCP_ADD_12 = 0x02,
+  XCP_ADD_14 = 0x03,
+  XCP_ADD_22 = 0x04,
+  XCP_ADD_24 = 0x05,
+  XCP_ADD_44 = 0x06,
+  XCP_CRC_16 = 0x07,
+  XCP_CRC_16_CITT = 0x08,
+  XCP_CRC_32 = 0x09,
+  XCP_USER_DEFINED = 0xff
+}
+
+/**
+ * XCP standard error codes (ERR response second byte).
+ * @category XCP
+ */
+export enum XcpErrorCode {
+  ERR_CMD_SYNCH = 0x00,
+  ERR_CMD_BUSY = 0x10,
+  ERR_DAQ_ACTIVE = 0x11,
+  ERR_PGM_ACTIVE = 0x12,
+  ERR_CMD_UNKNOWN = 0x20,
+  ERR_CMD_SYNTAX = 0x21,
+  ERR_OUT_OF_RANGE = 0x22,
+  ERR_WRITE_PROTECTED = 0x23,
+  ERR_ACCESS_DENIED = 0x24,
+  ERR_ACCESS_LOCKED = 0x25,
+  ERR_PAGE_NOT_VALID = 0x26,
+  ERR_MODE_NOT_VALID = 0x27,
+  ERR_SEGMENT_NOT_VALID = 0x28,
+  ERR_SEQUENCE = 0x29,
+  ERR_DAQ_CONFIG = 0x2a,
+  ERR_MEMORY_OVERFLOW = 0x30,
+  ERR_GENERIC = 0x31,
+  ERR_VERIFY = 0x32,
+  ERR_RESOURCE_TEMPORARY_NOT_ACCESSIBLE = 0x33
+}
+
+const errorMessages: Record<number, string> = {
+  [XcpErrorCode.ERR_CMD_SYNCH]: 'command processor synchronization',
+  [XcpErrorCode.ERR_CMD_BUSY]: 'command was not executed',
+  [XcpErrorCode.ERR_DAQ_ACTIVE]: 'command rejected because DAQ is running',
+  [XcpErrorCode.ERR_PGM_ACTIVE]: 'command rejected because PGM is running',
+  [XcpErrorCode.ERR_CMD_UNKNOWN]: 'unknown command or not implemented',
+  [XcpErrorCode.ERR_CMD_SYNTAX]: 'command syntax invalid',
+  [XcpErrorCode.ERR_OUT_OF_RANGE]: 'command syntax valid but parameter out of range',
+  [XcpErrorCode.ERR_WRITE_PROTECTED]: 'memory location is write protected',
+  [XcpErrorCode.ERR_ACCESS_DENIED]: 'memory access denied',
+  [XcpErrorCode.ERR_ACCESS_LOCKED]: 'selected resource is protected/locked',
+  [XcpErrorCode.ERR_PAGE_NOT_VALID]: 'selected page not available',
+  [XcpErrorCode.ERR_MODE_NOT_VALID]: 'selected page mode not available',
+  [XcpErrorCode.ERR_SEGMENT_NOT_VALID]: 'selected segment not valid',
+  [XcpErrorCode.ERR_SEQUENCE]: 'sequence error',
+  [XcpErrorCode.ERR_DAQ_CONFIG]: 'DAQ configuration not valid',
+  [XcpErrorCode.ERR_MEMORY_OVERFLOW]: 'memory overflow error',
+  [XcpErrorCode.ERR_GENERIC]: 'generic error',
+  [XcpErrorCode.ERR_VERIFY]: 'the slave internal program verify routine detects an error',
+  [XcpErrorCode.ERR_RESOURCE_TEMPORARY_NOT_ACCESSIBLE]: 'resource temporarily not accessible'
+}
+
+/**
+ * Error thrown when the slave answers a command with an ERR (0xFE) response.
+ * @category XCP
+ */
+export class XcpError extends Error {
+  /** Standard XCP error code (second byte of the ERR response). */
+  code: number
+  /** Full raw response packet. */
+  response: Buffer
+  constructor(code: number, response: Buffer) {
+    super(`XCP error 0x${code.toString(16).padStart(2, '0')}: ${errorMessages[code] ?? 'unknown'}`)
+    this.name = 'XcpError'
+    this.code = code
+    this.response = response
+  }
+}
+
+/**
+ * Pack an unsigned integer into `size` bytes using the given byte order.
+ * @category XCP
+ */
+export function packUint(value: number, size: number, byteOrder: ByteOrder): Buffer {
+  const buf = Buffer.alloc(size)
+  if (byteOrder === ByteOrder.MOTOROLA) {
+    buf.writeUIntBE(value, 0, size)
+  } else {
+    buf.writeUIntLE(value, 0, size)
+  }
+  return buf
+}
+
+/**
+ * Unpack an unsigned integer from a buffer slice using the given byte order.
+ * @category XCP
+ */
+export function unpackUint(
+  buf: Buffer,
+  offset: number,
+  size: number,
+  byteOrder: ByteOrder
+): number {
+  return byteOrder === ByteOrder.MOTOROLA
+    ? buf.readUIntBE(offset, size)
+    : buf.readUIntLE(offset, size)
+}
+
+function cmd(code: number, ...rest: number[]): Buffer {
+  return Buffer.from([code & 0xff, ...rest.map((b) => b & 0xff)])
+}
+
+function concat(...parts: (Buffer | number[] | number)[]): Buffer {
+  const bufs = parts.map((p) =>
+    Buffer.isBuffer(p) ? p : Array.isArray(p) ? Buffer.from(p) : Buffer.from([p & 0xff])
+  )
+  return Buffer.concat(bufs)
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Standard (STD) commands                                                    */
+/* -------------------------------------------------------------------------- */
+
+/** Build a CONNECT request. `mode` 0 = normal, 1 = user-defined. @category XCP */
+export function buildConnect(mode = 0): Buffer {
+  return cmd(XcpCommand.CONNECT, mode)
+}
+
+/** Build a DISCONNECT request. @category XCP */
+export function buildDisconnect(): Buffer {
+  return cmd(XcpCommand.DISCONNECT)
+}
+
+/** Build a GET_STATUS request. @category XCP */
+export function buildGetStatus(): Buffer {
+  return cmd(XcpCommand.GET_STATUS)
+}
+
+/** Build a SYNCH request. @category XCP */
+export function buildSynch(): Buffer {
+  return cmd(XcpCommand.SYNCH)
+}
+
+/** Build a GET_COMM_MODE_INFO request. @category XCP */
+export function buildGetCommModeInfo(): Buffer {
+  return cmd(XcpCommand.GET_COMM_MODE_INFO)
+}
+
+/** Build a GET_ID request. @category XCP */
+export function buildGetId(mode: number): Buffer {
+  return cmd(XcpCommand.GET_ID, mode)
+}
+
+/**
+ * Build a SET_REQUEST request. The session configuration id is transmitted MSB
+ * first (Motorola) as mandated by the standard, independent of the slave byte order.
+ * @category XCP
+ */
+export function buildSetRequest(mode: number, sessionConfigurationId: number): Buffer {
+  return concat(
+    XcpCommand.SET_REQUEST,
+    mode,
+    packUint(sessionConfigurationId, 2, ByteOrder.MOTOROLA)
+  )
+}
+
+/** Build a GET_SEED request. @category XCP */
+export function buildGetSeed(mode: number, resource: number): Buffer {
+  return cmd(XcpCommand.GET_SEED, mode, resource)
+}
+
+/** Build an UNLOCK request. @category XCP */
+export function buildUnlock(length: number, key: number[] | Buffer): Buffer {
+  return concat(XcpCommand.UNLOCK, length, Buffer.from(key as number[]))
+}
+
+/** Build a SET_MTA request. @category XCP */
+export function buildSetMta(
+  address: number,
+  addressExtension = 0,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(XcpCommand.SET_MTA, 0, 0, addressExtension, packUint(address, 4, byteOrder))
+}
+
+/** Build an UPLOAD request. @category XCP */
+export function buildUpload(count: number): Buffer {
+  return cmd(XcpCommand.UPLOAD, count)
+}
+
+/** Build a SHORT_UPLOAD request. @category XCP */
+export function buildShortUpload(
+  count: number,
+  address: number,
+  addressExtension = 0,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.SHORT_UPLOAD,
+    count,
+    0,
+    addressExtension,
+    packUint(address, 4, byteOrder)
+  )
+}
+
+/** Build a BUILD_CHECKSUM request. @category XCP */
+export function buildBuildChecksum(blockSize: number, byteOrder = ByteOrder.INTEL): Buffer {
+  return concat(XcpCommand.BUILD_CHECKSUM, 0, 0, 0, packUint(blockSize, 4, byteOrder))
+}
+
+/** Build a TRANSPORT_LAYER_CMD request. @category XCP */
+export function buildTransportLayerCmd(subCommand: number, data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.TRANSPORT_LAYER_CMD, subCommand, Buffer.from(data as number[]))
+}
+
+/** Build a USER_CMD request. @category XCP */
+export function buildUserCmd(subCommand: number, data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.USER_CMD, subCommand, Buffer.from(data as number[]))
+}
+
+/** Build a GET_VERSION request (second command level 0xC0 0x00). @category XCP */
+export function buildGetVersion(): Buffer {
+  return cmd(XcpCommand.GET_VERSION, GET_VERSION_SUB)
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Calibration / paging (CAL_PAG) commands                                    */
+/* -------------------------------------------------------------------------- */
+
+/** Build a DOWNLOAD request. @category XCP */
+export function buildDownload(data: number[] | Buffer): Buffer {
+  const d = Buffer.from(data as number[])
+  return concat(XcpCommand.DOWNLOAD, d.length, d)
+}
+
+/**
+ * Build a DOWNLOAD request in block mode, where `numberOfElements` describes the
+ * total remaining block size rather than the payload length of this packet.
+ * @category XCP
+ */
+export function buildDownloadBlock(numberOfElements: number, data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.DOWNLOAD, numberOfElements, Buffer.from(data as number[]))
+}
+
+/** Build a DOWNLOAD_NEXT request (block mode). @category XCP */
+export function buildDownloadNext(remainingBlockLength: number, data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.DOWNLOAD_NEXT, remainingBlockLength, Buffer.from(data as number[]))
+}
+
+/** Build a DOWNLOAD_MAX request. @category XCP */
+export function buildDownloadMax(data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.DOWNLOAD_MAX, Buffer.from(data as number[]))
+}
+
+/** Build a SHORT_DOWNLOAD request. @category XCP */
+export function buildShortDownload(
+  address: number,
+  addressExtension: number,
+  data: number[] | Buffer,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  const d = Buffer.from(data as number[])
+  return concat(
+    XcpCommand.SHORT_DOWNLOAD,
+    d.length,
+    0,
+    addressExtension,
+    packUint(address, 4, byteOrder),
+    d
+  )
+}
+
+/** Build a MODIFY_BITS request. @category XCP */
+export function buildModifyBits(
+  shiftValue: number,
+  andMask: number,
+  xorMask: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.MODIFY_BITS,
+    shiftValue,
+    packUint(andMask, 2, byteOrder),
+    packUint(xorMask, 2, byteOrder)
+  )
+}
+
+/** Build a SET_CAL_PAGE request. @category XCP */
+export function buildSetCalPage(mode: number, segment: number, page: number): Buffer {
+  return cmd(XcpCommand.SET_CAL_PAGE, mode, segment, page)
+}
+
+/** Build a GET_CAL_PAGE request. @category XCP */
+export function buildGetCalPage(mode: number, segment: number): Buffer {
+  return cmd(XcpCommand.GET_CAL_PAGE, mode, segment)
+}
+
+/** Build a GET_PAG_PROCESSOR_INFO request. @category XCP */
+export function buildGetPagProcessorInfo(): Buffer {
+  return cmd(XcpCommand.GET_PAG_PROCESSOR_INFO)
+}
+
+/** Build a GET_SEGMENT_INFO request. @category XCP */
+export function buildGetSegmentInfo(
+  mode: number,
+  segmentNumber: number,
+  segmentInfo: number,
+  mappingIndex: number
+): Buffer {
+  return cmd(XcpCommand.GET_SEGMENT_INFO, mode, segmentNumber, segmentInfo, mappingIndex)
+}
+
+/** Build a GET_PAGE_INFO request. @category XCP */
+export function buildGetPageInfo(segmentNumber: number, pageNumber: number): Buffer {
+  return cmd(XcpCommand.GET_PAGE_INFO, 0, segmentNumber, pageNumber)
+}
+
+/** Build a SET_SEGMENT_MODE request. @category XCP */
+export function buildSetSegmentMode(mode: number, segmentNumber: number): Buffer {
+  return cmd(XcpCommand.SET_SEGMENT_MODE, mode, segmentNumber)
+}
+
+/** Build a GET_SEGMENT_MODE request. @category XCP */
+export function buildGetSegmentMode(segmentNumber: number): Buffer {
+  return cmd(XcpCommand.GET_SEGMENT_MODE, 0, segmentNumber)
+}
+
+/** Build a COPY_CAL_PAGE request. @category XCP */
+export function buildCopyCalPage(
+  srcSegment: number,
+  srcPage: number,
+  dstSegment: number,
+  dstPage: number
+): Buffer {
+  return cmd(XcpCommand.COPY_CAL_PAGE, srcSegment, srcPage, dstSegment, dstPage)
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Data acquisition (DAQ) commands                                            */
+/* -------------------------------------------------------------------------- */
+
+/** Build a SET_DAQ_PTR request. @category XCP */
+export function buildSetDaqPtr(
+  daqListNumber: number,
+  odtNumber: number,
+  odtEntryNumber: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.SET_DAQ_PTR,
+    0,
+    packUint(daqListNumber, 2, byteOrder),
+    odtNumber,
+    odtEntryNumber
+  )
+}
+
+/** Build a WRITE_DAQ request. @category XCP */
+export function buildWriteDaq(
+  bitOffset: number,
+  size: number,
+  addressExtension: number,
+  address: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.WRITE_DAQ,
+    bitOffset,
+    size,
+    addressExtension,
+    packUint(address, 4, byteOrder)
+  )
+}
+
+/** Build a SET_DAQ_LIST_MODE request. @category XCP */
+export function buildSetDaqListMode(
+  mode: number,
+  daqListNumber: number,
+  eventChannelNumber: number,
+  prescaler: number,
+  priority: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.SET_DAQ_LIST_MODE,
+    mode,
+    packUint(daqListNumber, 2, byteOrder),
+    packUint(eventChannelNumber, 2, byteOrder),
+    prescaler,
+    priority
+  )
+}
+
+/** Build a GET_DAQ_LIST_MODE request. @category XCP */
+export function buildGetDaqListMode(daqListNumber: number, byteOrder = ByteOrder.INTEL): Buffer {
+  return concat(XcpCommand.GET_DAQ_LIST_MODE, 0, packUint(daqListNumber, 2, byteOrder))
+}
+
+/** Build a START_STOP_DAQ_LIST request. @category XCP */
+export function buildStartStopDaqList(
+  mode: number,
+  daqListNumber: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(XcpCommand.START_STOP_DAQ_LIST, mode, packUint(daqListNumber, 2, byteOrder))
+}
+
+/** Build a START_STOP_SYNCH request. @category XCP */
+export function buildStartStopSynch(mode: number): Buffer {
+  return cmd(XcpCommand.START_STOP_SYNCH, mode)
+}
+
+/** Build a GET_DAQ_CLOCK request. @category XCP */
+export function buildGetDaqClock(): Buffer {
+  return cmd(XcpCommand.GET_DAQ_CLOCK)
+}
+
+/** Build a READ_DAQ request. @category XCP */
+export function buildReadDaq(): Buffer {
+  return cmd(XcpCommand.READ_DAQ)
+}
+
+/** Build a GET_DAQ_PROCESSOR_INFO request. @category XCP */
+export function buildGetDaqProcessorInfo(): Buffer {
+  return cmd(XcpCommand.GET_DAQ_PROCESSOR_INFO)
+}
+
+/** Build a GET_DAQ_RESOLUTION_INFO request. @category XCP */
+export function buildGetDaqResolutionInfo(): Buffer {
+  return cmd(XcpCommand.GET_DAQ_RESOLUTION_INFO)
+}
+
+/** Build a GET_DAQ_LIST_INFO request. @category XCP */
+export function buildGetDaqListInfo(daqListNumber: number, byteOrder = ByteOrder.INTEL): Buffer {
+  return concat(XcpCommand.GET_DAQ_LIST_INFO, 0, packUint(daqListNumber, 2, byteOrder))
+}
+
+/** Build a GET_DAQ_EVENT_INFO request. @category XCP */
+export function buildGetDaqEventInfo(
+  eventChannelNumber: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(XcpCommand.GET_DAQ_EVENT_INFO, 0, packUint(eventChannelNumber, 2, byteOrder))
+}
+
+/** Build a CLEAR_DAQ_LIST request. @category XCP */
+export function buildClearDaqList(daqListNumber: number, byteOrder = ByteOrder.INTEL): Buffer {
+  return concat(XcpCommand.CLEAR_DAQ_LIST, 0, packUint(daqListNumber, 2, byteOrder))
+}
+
+/** Build a FREE_DAQ request. @category XCP */
+export function buildFreeDaq(): Buffer {
+  return cmd(XcpCommand.FREE_DAQ)
+}
+
+/** Build an ALLOC_DAQ request. @category XCP */
+export function buildAllocDaq(daqCount: number, byteOrder = ByteOrder.INTEL): Buffer {
+  return concat(XcpCommand.ALLOC_DAQ, 0, packUint(daqCount, 2, byteOrder))
+}
+
+/** Build an ALLOC_ODT request. @category XCP */
+export function buildAllocOdt(
+  daqListNumber: number,
+  odtCount: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(XcpCommand.ALLOC_ODT, 0, packUint(daqListNumber, 2, byteOrder), odtCount)
+}
+
+/** Build an ALLOC_ODT_ENTRY request. @category XCP */
+export function buildAllocOdtEntry(
+  daqListNumber: number,
+  odtNumber: number,
+  odtEntriesCount: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.ALLOC_ODT_ENTRY,
+    0,
+    packUint(daqListNumber, 2, byteOrder),
+    odtNumber,
+    odtEntriesCount
+  )
+}
+
+/**
+ * A single element for {@link buildWriteDaqMultiple}.
+ * @category XCP
+ */
+export interface DaqElement {
+  bitOffset: number
+  size: number
+  address: number
+  addressExt: number
+}
+
+/** Build a WRITE_DAQ_MULTIPLE request. @category XCP */
+export function buildWriteDaqMultiple(elements: DaqElement[], byteOrder = ByteOrder.INTEL): Buffer {
+  const parts: Buffer[] = [Buffer.from([XcpCommand.WRITE_DAQ_MULTIPLE, elements.length & 0xff])]
+  for (const e of elements) {
+    parts.push(concat(e.bitOffset, e.size, packUint(e.address, 4, byteOrder), e.addressExt, 0))
+  }
+  return Buffer.concat(parts)
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Programming (PGM) commands                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** Build a PROGRAM_START request. @category XCP */
+export function buildProgramStart(): Buffer {
+  return cmd(XcpCommand.PROGRAM_START)
+}
+
+/** Build a PROGRAM_CLEAR request. @category XCP */
+export function buildProgramClear(
+  mode: number,
+  clearRange: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(XcpCommand.PROGRAM_CLEAR, mode, 0, 0, packUint(clearRange, 4, byteOrder))
+}
+
+/** Build a PROGRAM request. @category XCP */
+export function buildProgram(numberOfElements: number, data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.PROGRAM, numberOfElements, Buffer.from(data as number[]))
+}
+
+/** Build a PROGRAM_RESET request. @category XCP */
+export function buildProgramReset(): Buffer {
+  return cmd(XcpCommand.PROGRAM_RESET)
+}
+
+/** Build a GET_PGM_PROCESSOR_INFO request. @category XCP */
+export function buildGetPgmProcessorInfo(): Buffer {
+  return cmd(XcpCommand.GET_PGM_PROCESSOR_INFO)
+}
+
+/** Build a GET_SECTOR_INFO request. @category XCP */
+export function buildGetSectorInfo(mode: number, sectorNumber: number): Buffer {
+  return cmd(XcpCommand.GET_SECTOR_INFO, mode, sectorNumber)
+}
+
+/** Build a PROGRAM_PREPARE request. @category XCP */
+export function buildProgramPrepare(codeSize: number, byteOrder = ByteOrder.INTEL): Buffer {
+  return concat(XcpCommand.PROGRAM_PREPARE, 0, packUint(codeSize, 2, byteOrder))
+}
+
+/** Build a PROGRAM_FORMAT request. @category XCP */
+export function buildProgramFormat(
+  compressionMethod: number,
+  encryptionMethod: number,
+  programmingMethod: number,
+  accessMethod: number
+): Buffer {
+  return cmd(
+    XcpCommand.PROGRAM_FORMAT,
+    compressionMethod,
+    encryptionMethod,
+    programmingMethod,
+    accessMethod
+  )
+}
+
+/** Build a PROGRAM_NEXT request. @category XCP */
+export function buildProgramNext(remainingBlockLength: number, data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.PROGRAM_NEXT, remainingBlockLength, Buffer.from(data as number[]))
+}
+
+/** Build a PROGRAM_MAX request. @category XCP */
+export function buildProgramMax(data: number[] | Buffer): Buffer {
+  return concat(XcpCommand.PROGRAM_MAX, Buffer.from(data as number[]))
+}
+
+/** Build a PROGRAM_VERIFY request. @category XCP */
+export function buildProgramVerify(
+  mode: number,
+  verificationType: number,
+  verificationValue: number,
+  byteOrder = ByteOrder.INTEL
+): Buffer {
+  return concat(
+    XcpCommand.PROGRAM_VERIFY,
+    mode,
+    packUint(verificationType, 2, byteOrder),
+    packUint(verificationValue, 4, byteOrder)
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Response parsing                                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Validate a response packet: throw {@link XcpError} on an ERR (0xFE) packet,
+ * otherwise return the payload (bytes after the response PID).
+ * @category XCP
+ */
+export function checkResponse(response: Buffer): Buffer {
+  if (response.length === 0) {
+    throw new Error('empty XCP response')
+  }
+  if (response[0] === XcpResponse.ERR) {
+    throw new XcpError(response[1] ?? 0, response)
+  }
+  return response.subarray(1)
+}
+
+/** Parsed CONNECT response. @category XCP */
+export interface ConnectResponse {
+  resource: { calpag: boolean; daq: boolean; stim: boolean; pgm: boolean; dbg: boolean }
+  commModeBasic: {
+    optional: boolean
+    slaveBlockMode: boolean
+    addressGranularity: AddressGranularity
+    byteOrder: ByteOrder
+  }
+  maxCto: number
+  maxDto: number
+  protocolLayerVersion: number
+  transportLayerVersion: number
+}
+
+/** Parse a CONNECT response packet. @category XCP */
+export function parseConnectResponse(response: Buffer): ConnectResponse {
+  const payload = checkResponse(response)
+  const resourceByte = payload[0]
+  const commModeBasic = payload[1]
+  const byteOrder: ByteOrder = commModeBasic & 0x01 ? ByteOrder.MOTOROLA : ByteOrder.INTEL
+  const addressGranularity: AddressGranularity = (commModeBasic >> 1) & 0x03
+  return {
+    resource: {
+      calpag: !!(resourceByte & 0x01),
+      daq: !!(resourceByte & 0x04),
+      stim: !!(resourceByte & 0x08),
+      pgm: !!(resourceByte & 0x10),
+      dbg: !!(resourceByte & 0x20)
+    },
+    commModeBasic: {
+      optional: !!(commModeBasic & 0x80),
+      slaveBlockMode: !!(commModeBasic & 0x40),
+      addressGranularity,
+      byteOrder
+    },
+    maxCto: payload[2],
+    maxDto: unpackUint(payload, 3, 2, byteOrder),
+    protocolLayerVersion: payload[5],
+    transportLayerVersion: payload[6]
+  }
+}
+
+/** Resource protection / resource availability bit field. @category XCP */
+export interface ResourceFlags {
+  calpag: boolean
+  daq: boolean
+  stim: boolean
+  pgm: boolean
+}
+
+function parseResourceFlags(byte: number): ResourceFlags {
+  return {
+    calpag: !!(byte & 0x01),
+    daq: !!(byte & 0x04),
+    stim: !!(byte & 0x08),
+    pgm: !!(byte & 0x10)
+  }
+}
+
+/** Parsed GET_STATUS response. @category XCP */
+export interface GetStatusResponse {
+  sessionStatus: {
+    storeCalRequest: boolean
+    storeDaqRequest: boolean
+    clearDaqRequest: boolean
+    daqRunning: boolean
+    resume: boolean
+  }
+  resourceProtectionStatus: ResourceFlags
+  sessionConfigurationId: number
+}
+
+/** Parse a GET_STATUS response packet. @category XCP */
+export function parseGetStatusResponse(
+  response: Buffer,
+  byteOrder = ByteOrder.INTEL
+): GetStatusResponse {
+  const payload = checkResponse(response)
+  const sessionStatus = payload[0]
+  return {
+    sessionStatus: {
+      storeCalRequest: !!(sessionStatus & 0x01),
+      storeDaqRequest: !!(sessionStatus & 0x04),
+      clearDaqRequest: !!(sessionStatus & 0x08),
+      daqRunning: !!(sessionStatus & 0x40),
+      resume: !!(sessionStatus & 0x80)
+    },
+    resourceProtectionStatus: parseResourceFlags(payload[1]),
+    sessionConfigurationId: unpackUint(payload, 3, 2, byteOrder)
+  }
+}
+
+/** Parsed GET_COMM_MODE_INFO response. @category XCP */
+export interface GetCommModeInfoResponse {
+  commModeOptional: { masterBlockMode: boolean; interleavedMode: boolean }
+  maxBs: number
+  minSt: number
+  queueSize: number
+  xcpDriverVersionNumber: number
+}
+
+/** Parse a GET_COMM_MODE_INFO response packet. @category XCP */
+export function parseGetCommModeInfoResponse(response: Buffer): GetCommModeInfoResponse {
+  const payload = checkResponse(response)
+  const commModeOptional = payload[1]
+  return {
+    commModeOptional: {
+      masterBlockMode: !!(commModeOptional & 0x01),
+      interleavedMode: !!(commModeOptional & 0x02)
+    },
+    maxBs: payload[3],
+    minSt: payload[4],
+    queueSize: payload[5],
+    xcpDriverVersionNumber: payload[6]
+  }
+}
+
+/** Parsed GET_VERSION response. @category XCP */
+export interface GetVersionResponse {
+  protocolMajor: number
+  protocolMinor: number
+  transportMajor: number
+  transportMinor: number
+}
+
+/** Parse a GET_VERSION response packet. @category XCP */
+export function parseGetVersionResponse(response: Buffer): GetVersionResponse {
+  const payload = checkResponse(response)
+  return {
+    protocolMajor: payload[1],
+    protocolMinor: payload[2],
+    transportMajor: payload[3],
+    transportMinor: payload[4]
+  }
+}
+
+/** Parsed GET_ID response (header only; the identifier bytes follow via UPLOAD). @category XCP */
+export interface GetIdResponse {
+  mode: number
+  length: number
+}
+
+/** Parse a GET_ID response packet. @category XCP */
+export function parseGetIdResponse(response: Buffer, byteOrder = ByteOrder.INTEL): GetIdResponse {
+  const payload = checkResponse(response)
+  return {
+    mode: payload[0],
+    length: unpackUint(payload, 3, 4, byteOrder)
+  }
+}
+
+/** Parsed GET_SEED response. @category XCP */
+export interface GetSeedResponse {
+  length: number
+  seed: number[]
+}
+
+/** Parse a GET_SEED response packet. @category XCP */
+export function parseGetSeedResponse(response: Buffer): GetSeedResponse {
+  const payload = checkResponse(response)
+  const length = payload[0]
+  return {
+    length,
+    seed: Array.from(payload.subarray(1, 1 + length))
+  }
+}
+
+/** Parse an UNLOCK response packet into the current resource protection status. @category XCP */
+export function parseUnlockResponse(response: Buffer): ResourceFlags {
+  const payload = checkResponse(response)
+  return parseResourceFlags(payload[0])
+}
+
+/** Parsed BUILD_CHECKSUM response. @category XCP */
+export interface BuildChecksumResponse {
+  checksumType: ChecksumType
+  checksum: number
+}
+
+/** Parse a BUILD_CHECKSUM response packet. @category XCP */
+export function parseBuildChecksumResponse(
+  response: Buffer,
+  byteOrder = ByteOrder.INTEL
+): BuildChecksumResponse {
+  const payload = checkResponse(response)
+  return {
+    checksumType: payload[0],
+    checksum: unpackUint(payload, 3, 4, byteOrder)
+  }
+}
+
+/** Parse a GET_CAL_PAGE response packet into the logical data page number. @category XCP */
+export function parseGetCalPageResponse(response: Buffer): number {
+  const payload = checkResponse(response)
+  return payload[2]
+}
+
+/** Parsed START_STOP_DAQ_LIST response. @category XCP */
+export interface StartStopDaqListResponse {
+  firstPid: number
+}
+
+/** Parse a START_STOP_DAQ_LIST response packet. @category XCP */
+export function parseStartStopDaqListResponse(response: Buffer): StartStopDaqListResponse {
+  const payload = checkResponse(response)
+  return { firstPid: payload[0] }
+}
+
+/** Parse a GET_DAQ_CLOCK response packet into the receive timestamp. @category XCP */
+export function parseGetDaqClockResponse(response: Buffer, byteOrder = ByteOrder.INTEL): number {
+  const payload = checkResponse(response)
+  return unpackUint(payload, 3, 4, byteOrder)
+}

--- a/test/docan/socketcan.test.ts
+++ b/test/docan/socketcan.test.ts
@@ -1,0 +1,254 @@
+/**
+ * SocketCAN tests.
+ *
+ * 1. Frame codec vs Linux `struct can_frame` / `struct canfd_frame` (always).
+ * 2. Two independent sockets on one bus (always; vcan when AF_CAN exists).
+ * 3. Kernel AF_CAN smoke test (skipped when this kernel has no CONFIG_CAN).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { spawnSync } from 'child_process'
+import { platform } from 'os'
+import { CAN_ERROR_ID, CAN_ID_TYPE, CanError } from '../../src/main/share/can'
+import {
+  CAN_EFF_FLAG,
+  CAN_MTU,
+  CAN_RTR_FLAG,
+  CANFD_BRS,
+  CANFD_MTU,
+  packCanFrame,
+  unpackCanFrame
+} from '../helpers/socketcanFrame'
+import {
+  createSocketcanTestBus,
+  probeLinuxSocketcan,
+  SocketcanTestBus,
+  SocketcanTestCan,
+  socketcanTestInfo
+} from '../helpers/socketcanCan'
+
+function pyPack(expr: string): Buffer {
+  const r = spawnSync('python3', ['-c', expr], { encoding: 'utf8', timeout: 5000 })
+  if (r.status !== 0) {
+    throw new Error(r.stderr || 'python pack failed')
+  }
+  return Buffer.from(r.stdout.trim(), 'hex')
+}
+
+describe('SocketCAN frame codec (Linux ABI)', () => {
+  it('packs a classic standard frame as struct can_frame (16 bytes)', () => {
+    const data = Buffer.from([0x01, 0x02, 0x03, 0x04])
+    const packed = packCanFrame(
+      0x123,
+      { idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: false },
+      data
+    )
+    expect(packed.length).toBe(CAN_MTU)
+    expect(packed.readUInt32LE(0)).toBe(0x123)
+    expect(packed.readUInt8(4)).toBe(4)
+    expect(packed.subarray(8, 12)).toEqual(data)
+  })
+
+  it('matches Python struct.pack of a standard frame', () => {
+    const data = Buffer.from([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22])
+    const packed = packCanFrame(
+      0x7e0,
+      { idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: false },
+      data
+    )
+    const py = pyPack(
+      'import struct; print(struct.pack("=IB3x8s", 0x7e0, 8, bytes([0xaa,0xbb,0xcc,0xdd,0xee,0xff,0x11,0x22])).hex())'
+    )
+    expect(packed).toEqual(py)
+  })
+
+  it('sets CAN_EFF_FLAG for extended IDs and matches Python', () => {
+    const data = Buffer.from([0x01])
+    const packed = packCanFrame(
+      0x18da0201,
+      { idType: CAN_ID_TYPE.EXTENDED, brs: false, canfd: false, remote: false },
+      data
+    )
+    expect(packed.readUInt32LE(0)).toBe((0x18da0201 | CAN_EFF_FLAG) >>> 0)
+    const py = pyPack(
+      `import struct; print(struct.pack("=IB3x8s", 0x18da0201 | 0x80000000, 1, bytes([1]).ljust(8, b"\\0")).hex())`
+    )
+    expect(packed).toEqual(py)
+  })
+
+  it('sets CAN_RTR_FLAG for remote frames', () => {
+    const packed = packCanFrame(
+      0x100,
+      { idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: true },
+      Buffer.alloc(0)
+    )
+    expect(packed.readUInt32LE(0)).toBe((0x100 | CAN_RTR_FLAG) >>> 0)
+  })
+
+  it('packs CAN-FD frames as struct canfd_frame (72 bytes)', () => {
+    const data = Buffer.alloc(64, 0x5a)
+    const packed = packCanFrame(
+      0x42,
+      { idType: CAN_ID_TYPE.STANDARD, brs: true, canfd: true, remote: false },
+      data
+    )
+    expect(packed.length).toBe(CANFD_MTU)
+    expect(packed.readUInt8(4)).toBe(64)
+    expect(packed.readUInt8(5)).toBe(CANFD_BRS)
+    expect(packed.subarray(8, 72)).toEqual(data)
+  })
+
+  it('round-trips pack/unpack for standard, extended and CAN-FD', () => {
+    const cases = [
+      {
+        id: 0x123,
+        msgType: { idType: CAN_ID_TYPE.STANDARD, brs: false, canfd: false, remote: false },
+        data: Buffer.from([1, 2, 3])
+      },
+      {
+        id: 0x1abcdeff,
+        msgType: { idType: CAN_ID_TYPE.EXTENDED, brs: false, canfd: false, remote: false },
+        data: Buffer.from([0xff, 0x00])
+      },
+      {
+        id: 0x55,
+        msgType: { idType: CAN_ID_TYPE.STANDARD, brs: true, canfd: true, remote: false },
+        data: Buffer.alloc(12, 7)
+      }
+    ] as const
+    for (const c of cases) {
+      const parsed = unpackCanFrame(packCanFrame(c.id, c.msgType, c.data))
+      expect(parsed.id).toBe(c.id)
+      expect(parsed.msgType).toEqual(c.msgType)
+      expect(parsed.data).toEqual(c.data)
+    }
+  })
+})
+
+describe('SocketCAN two-socket bus', () => {
+  let bus: SocketcanTestBus
+  let a: SocketcanTestCan
+  let b: SocketcanTestCan
+
+  beforeAll(async () => {
+    bus = await createSocketcanTestBus()
+    console.log(`SocketCAN I/O tests using ${bus.kind} bus on ${bus.iface}`)
+    a = new SocketcanTestCan(socketcanTestInfo('socketcan-a', bus.iface), bus)
+    b = new SocketcanTestCan(socketcanTestInfo('socketcan-b', bus.iface), bus)
+    await a.open()
+    await b.open()
+  })
+
+  afterAll(() => {
+    a.close()
+    b.close()
+  })
+
+  it('delivers a standard frame from A to B', async () => {
+    const data = Buffer.from([0x11, 0x22, 0x33, 0x44])
+    const msgType = {
+      idType: CAN_ID_TYPE.STANDARD,
+      brs: false,
+      canfd: false,
+      remote: false
+    }
+    const pending = b.readBase(0x123, msgType, 1000)
+    await a.writeBase(0x123, msgType, data)
+    const rx = await pending
+    expect(rx.data).toEqual(data)
+    expect(typeof rx.ts).toBe('number')
+  })
+
+  it('delivers an extended frame from B to A', async () => {
+    const data = Buffer.from([0xde, 0xad, 0xbe, 0xef])
+    const msgType = {
+      idType: CAN_ID_TYPE.EXTENDED,
+      brs: false,
+      canfd: false,
+      remote: false
+    }
+    const pending = a.readBase(0x18da0201, msgType, 1000)
+    await b.writeBase(0x18da0201, msgType, data)
+    const rx = await pending
+    expect(rx.data).toEqual(data)
+  })
+
+  it('fans a frame out to every other socket on the bus', async () => {
+    const c = new SocketcanTestCan(socketcanTestInfo('socketcan-c', bus.iface), bus)
+    await c.open()
+    try {
+      const msgType = {
+        idType: CAN_ID_TYPE.STANDARD,
+        brs: false,
+        canfd: false,
+        remote: false
+      }
+      const data = Buffer.from([0x99])
+      const pb = b.readBase(0x321, msgType, 1000)
+      const pc = c.readBase(0x321, msgType, 1000)
+      await a.writeBase(0x321, msgType, data)
+      expect((await pb).data).toEqual(data)
+      expect((await pc).data).toEqual(data)
+    } finally {
+      c.close()
+    }
+  })
+
+  it('times out when no matching frame arrives', async () => {
+    const msgType = {
+      idType: CAN_ID_TYPE.STANDARD,
+      brs: false,
+      canfd: false,
+      remote: false
+    }
+    await expect(b.readBase(0x7e0, msgType, 50)).rejects.toMatchObject({
+      errorId: CAN_ERROR_ID.CAN_READ_TIMEOUT
+    })
+  })
+
+  it('rejects classic CAN payloads longer than 8 bytes', async () => {
+    const msgType = {
+      idType: CAN_ID_TYPE.STANDARD,
+      brs: false,
+      canfd: false,
+      remote: false
+    }
+    await expect(
+      Promise.resolve().then(() => a.writeBase(0x1, msgType, Buffer.alloc(9)))
+    ).rejects.toBeInstanceOf(CanError)
+  })
+})
+
+describe.skipIf(platform() !== 'linux' || !probeLinuxSocketcan().ok)(
+  'Linux SocketCAN kernel (vcan)',
+  () => {
+    it('probe reports a usable can/vcan interface', () => {
+      const probe = probeLinuxSocketcan()
+      expect(probe.ok).toBe(true)
+      expect(probe.iface).toMatch(/can/)
+    })
+
+    it('two AF_CAN sockets exchange a frame on the kernel bus', async () => {
+      const bus = await createSocketcanTestBus()
+      expect(bus.kind).toBe('vcan')
+      const a = new SocketcanTestCan(socketcanTestInfo('k-a', bus.iface), bus)
+      const b = new SocketcanTestCan(socketcanTestInfo('k-b', bus.iface), bus)
+      await a.open()
+      await b.open()
+      try {
+        const msgType = {
+          idType: CAN_ID_TYPE.STANDARD,
+          brs: false,
+          canfd: false,
+          remote: false
+        }
+        const data = Buffer.from([0x42, 0x43])
+        const pending = b.readBase(0x42, msgType, 1000)
+        await a.writeBase(0x42, msgType, data)
+        expect((await pending).data).toEqual(data)
+      } finally {
+        a.close()
+        b.close()
+      }
+    })
+  }
+)

--- a/test/helpers/socketcanCan.ts
+++ b/test/helpers/socketcanCan.ts
@@ -1,0 +1,400 @@
+/**
+ * Test-only SocketCAN CanBase.
+ *
+ * Prefers a real Linux AF_CAN socket on a vcan/can interface. When the kernel
+ * has no CONFIG_CAN (common in stripped CI kernels), falls back to an
+ * in-process bus that still ships packed `struct can_frame` buffers between
+ * independent sockets — the same isolation model as SocketCAN
+ * (CAN_RAW_RECV_OWN_MSGS off).
+ */
+import { spawn, spawnSync, ChildProcessWithoutNullStreams } from 'child_process'
+import { EventEmitter } from 'events'
+import { readdirSync, readFileSync } from 'fs'
+import { platform } from 'os'
+import path from 'path'
+import { CanBase } from '../../src/main/docan/base'
+import { CanLOG } from '../../src/main/log'
+import {
+  CAN_ERROR_ID,
+  CAN_ID_TYPE,
+  CanBaseInfo,
+  CanError,
+  CanMessage,
+  CanMsgType,
+  getTsUs
+} from '../../src/main/share/can'
+import { CAN_MAX_DLEN, CANFD_MAX_DLEN, packCanFrame, unpackCanFrame } from './socketcanFrame'
+
+const workerPath = path.join(process.cwd(), 'test/helpers/socketcan_worker.py')
+
+export type SocketcanBusKind = 'vcan' | 'memory'
+
+export interface SocketcanTestBus {
+  kind: SocketcanBusKind
+  iface: string
+  attach(node: SocketcanTestCan): Promise<void>
+  detach(node: SocketcanTestCan): void
+  send(node: SocketcanTestCan, frame: Buffer): Promise<void>
+}
+
+export interface LinuxSocketcanProbe {
+  ok: boolean
+  reason?: string
+  iface?: string
+}
+
+function listCanIfaces(): string[] {
+  try {
+    const names = readdirSync('/sys/class/net')
+    return names.filter((name) => {
+      try {
+        const t = readFileSync(`/sys/class/net/${name}/type`, 'utf8').trim()
+        // ARPHRD_CAN = 280
+        return t === '280' || /^(v?)can\d+$/.test(name)
+      } catch {
+        return /^(v?)can\d+$/.test(name)
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
+export function probeLinuxSocketcan(): LinuxSocketcanProbe {
+  if (platform() !== 'linux') {
+    return { ok: false, reason: `SocketCAN is Linux-only (platform=${platform()})` }
+  }
+  const probe = spawnSync(
+    'python3',
+    [
+      '-c',
+      'import socket; s=socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW); s.close(); print("ok")'
+    ],
+    { encoding: 'utf8', timeout: 5000 }
+  )
+  if (probe.status !== 0) {
+    const err = (probe.stderr || probe.stdout || '').trim()
+    const reason = /Address family not supported/i.test(err)
+      ? 'kernel has no CONFIG_CAN (AF_CAN EAFNOSUPPORT)'
+      : err || `exit ${probe.status}`
+    return { ok: false, reason: `AF_CAN not available: ${reason}` }
+  }
+  const ifaces = listCanIfaces()
+  if (ifaces.length === 0) {
+    return {
+      ok: false,
+      reason:
+        'AF_CAN works but no can/vcan interface is up. Create one with: sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0'
+    }
+  }
+  const vcan = ifaces.find((n) => n.startsWith('vcan')) || ifaces[0]
+  return { ok: true, iface: vcan }
+}
+
+class MemorySocketcanBus implements SocketcanTestBus {
+  kind: SocketcanBusKind = 'memory'
+  iface: string
+  private nodes = new Set<SocketcanTestCan>()
+  constructor(iface = 'vcan-memory') {
+    this.iface = iface
+  }
+  async attach(node: SocketcanTestCan) {
+    this.nodes.add(node)
+  }
+  detach(node: SocketcanTestCan) {
+    this.nodes.delete(node)
+  }
+  async send(node: SocketcanTestCan, frame: Buffer) {
+    const others = [...this.nodes].filter((n) => n !== node)
+    setImmediate(() => {
+      for (const peer of others) {
+        peer.injectRx(frame)
+      }
+    })
+  }
+}
+
+class LinuxSocketcanBus implements SocketcanTestBus {
+  kind: SocketcanBusKind = 'vcan'
+  iface: string
+  private workers = new Map<SocketcanTestCan, LinuxWorker>()
+  constructor(iface: string) {
+    this.iface = iface
+  }
+  async attach(node: SocketcanTestCan) {
+    const worker = new LinuxWorker(this.iface, (frame) => node.injectRx(frame))
+    await worker.ready
+    this.workers.set(node, worker)
+  }
+  detach(node: SocketcanTestCan) {
+    const worker = this.workers.get(node)
+    if (worker) {
+      worker.close()
+      this.workers.delete(node)
+    }
+  }
+  async send(node: SocketcanTestCan, frame: Buffer) {
+    const worker = this.workers.get(node)
+    if (!worker) {
+      throw new Error('SocketCAN worker not attached')
+    }
+    await worker.send(frame)
+  }
+}
+
+class LinuxWorker {
+  ready: Promise<void>
+  private proc: ChildProcessWithoutNullStreams
+  private pending: Array<{ resolve: () => void; reject: (e: Error) => void }> = []
+  private closed = false
+  constructor(iface: string, onFrame: (frame: Buffer) => void) {
+    this.proc = spawn('python3', ['-u', workerPath, iface], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let readyResolve: () => void
+    let readyReject: (e: Error) => void
+    this.ready = new Promise<void>((resolve, reject) => {
+      readyResolve = resolve
+      readyReject = reject
+    })
+    const timer = setTimeout(() => {
+      readyReject(new Error(`SocketCAN worker for ${iface} timed out`))
+    }, 5000)
+    let buf = ''
+    this.proc.stdout.setEncoding('utf8')
+    this.proc.stdout.on('data', (chunk: string) => {
+      buf += chunk
+      let nl: number
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim()
+        buf = buf.slice(nl + 1)
+        if (!line) continue
+        let msg: any
+        try {
+          msg = JSON.parse(line)
+        } catch {
+          continue
+        }
+        if (msg.evt === 'ready') {
+          clearTimeout(timer)
+          readyResolve()
+        } else if (msg.evt === 'ok') {
+          this.pending.shift()?.resolve()
+        } else if (msg.evt === 'err') {
+          const err = new Error(String(msg.msg || 'socketcan worker error'))
+          if (this.pending.length) {
+            this.pending.shift()?.reject(err)
+          } else {
+            readyReject(err)
+          }
+        } else if (msg.evt === 'rx') {
+          const packed = packCanFrame(
+            msg.id,
+            {
+              idType: msg.ext ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+              remote: !!msg.rtr,
+              canfd: !!msg.canfd,
+              brs: !!msg.brs
+            },
+            Buffer.from(msg.data || '', 'hex')
+          )
+          onFrame(packed)
+        }
+      }
+    })
+    this.proc.stderr.setEncoding('utf8')
+    this.proc.on('exit', (code) => {
+      if (!this.closed) {
+        const err = new Error(`SocketCAN worker exited (${code})`)
+        while (this.pending.length) {
+          this.pending.shift()?.reject(err)
+        }
+        readyReject(err)
+      }
+    })
+  }
+  send(frame: Buffer): Promise<void> {
+    const parsed = unpackCanFrame(frame)
+    const payload = JSON.stringify({
+      cmd: 'send',
+      id: parsed.id,
+      ext: parsed.msgType.idType === CAN_ID_TYPE.EXTENDED,
+      rtr: parsed.msgType.remote,
+      canfd: parsed.msgType.canfd,
+      brs: parsed.msgType.brs,
+      data: parsed.data.toString('hex')
+    })
+    return new Promise<void>((resolve, reject) => {
+      this.pending.push({ resolve, reject })
+      this.proc.stdin.write(payload + '\n')
+    })
+  }
+  close() {
+    this.closed = true
+    try {
+      this.proc.stdin.write(JSON.stringify({ cmd: 'close' }) + '\n')
+    } catch {
+      /* ignore */
+    }
+    this.proc.kill()
+  }
+}
+
+export async function createSocketcanTestBus(): Promise<SocketcanTestBus> {
+  const probe = probeLinuxSocketcan()
+  if (probe.ok && probe.iface) {
+    return new LinuxSocketcanBus(probe.iface)
+  }
+  return new MemorySocketcanBus()
+}
+
+export class SocketcanTestCan extends CanBase {
+  event = new EventEmitter()
+  info: CanBaseInfo
+  log: CanLOG
+  private closed = false
+  private cnt = 0
+  private startTime = getTsUs()
+  private readAbort = new AbortController()
+  private rejectBaseMap = new Map<
+    number,
+    {
+      reject: (reason: CanError) => void
+      msgType: CanMsgType
+    }
+  >()
+
+  constructor(
+    info: CanBaseInfo,
+    private bus: SocketcanTestBus
+  ) {
+    super()
+    this.info = info
+    this.log = new CanLOG('SOCKETCAN', info.name, info.id, this.event)
+    this.attachCanMessage(this.busloadCb)
+  }
+
+  async open() {
+    await this.bus.attach(this)
+  }
+
+  injectRx(frame: Buffer) {
+    if (this.closed) return
+    const parsed = unpackCanFrame(frame)
+    const ts = getTsUs() - this.startTime
+    const message: CanMessage = {
+      dir: 'IN',
+      id: parsed.id,
+      data: parsed.data,
+      ts,
+      msgType: parsed.msgType,
+      device: this.info.name,
+      database: this.info.database
+    }
+    this.log.canBase(message)
+    this.event.emit(this.getReadBaseId(parsed.id, parsed.msgType), message)
+  }
+
+  setOption(cmd: string, val: any): any {
+    return this._setOption(cmd, val)
+  }
+
+  close() {
+    this.readAbort.abort()
+    this.closed = true
+    for (const [, val] of this.rejectBaseMap) {
+      val.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, val.msgType))
+    }
+    this.rejectBaseMap.clear()
+    this.bus.detach(this)
+    this.log.close()
+    this._close()
+  }
+
+  getReadBaseId(id: number, msgType: CanMsgType): string {
+    return `${id}-${msgType.canfd ? msgType.brs : false}-${msgType.remote}-${msgType.canfd}-${msgType.idType}`
+  }
+
+  writeBase(
+    id: number,
+    msgType: CanMsgType,
+    data: Buffer,
+    extra?: { database?: string; name?: string }
+  ): Promise<number> {
+    const maxLen = msgType.canfd ? CANFD_MAX_DLEN : CAN_MAX_DLEN
+    if (data.length > maxLen) {
+      throw new CanError(CAN_ERROR_ID.CAN_PARAM_ERROR, msgType, data)
+    }
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType, data))
+    }
+    const packed = packCanFrame(id, msgType, data)
+    return this.bus.send(this, packed).then(() => {
+      const ts = getTsUs() - this.startTime
+      const message: CanMessage = {
+        dir: 'OUT',
+        id,
+        data,
+        ts,
+        msgType,
+        device: this.info.name,
+        database: extra?.database,
+        name: extra?.name
+      }
+      this.log.canBase(message)
+      this.event.emit(this.getReadBaseId(id, msgType), message)
+      return ts
+    })
+  }
+
+  readBase(
+    id: number,
+    msgType: CanMsgType,
+    timeout: number
+  ): Promise<{ data: Buffer; ts: number }> {
+    return new Promise<{ data: Buffer; ts: number }>((resolve, reject) => {
+      const cmdId = this.getReadBaseId(id, msgType)
+      const cnt = this.cnt++
+      this.rejectBaseMap.set(cnt, { reject, msgType })
+
+      this.readAbort.signal.addEventListener('abort', () => {
+        if (this.rejectBaseMap.has(cnt)) {
+          this.rejectBaseMap.delete(cnt)
+          reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType))
+        }
+        this.event.off(cmdId, readCb)
+      })
+
+      const readCb = (val: any) => {
+        clearTimeout(timer)
+        if (this.rejectBaseMap.has(cnt)) {
+          if (val instanceof CanError) {
+            reject(val)
+          } else {
+            resolve({ data: val.data, ts: val.ts })
+          }
+          this.rejectBaseMap.delete(cnt)
+        }
+      }
+      const timer = setTimeout(() => {
+        this.event.off(cmdId, readCb)
+        if (this.rejectBaseMap.has(cnt)) {
+          this.rejectBaseMap.delete(cnt)
+          reject(new CanError(CAN_ERROR_ID.CAN_READ_TIMEOUT, msgType))
+        }
+      }, timeout)
+      this.event.once(cmdId, readCb)
+    })
+  }
+}
+
+export function socketcanTestInfo(name: string, handle: string): CanBaseInfo {
+  return {
+    id: name,
+    name,
+    handle,
+    vendor: 'simulate',
+    canfd: false,
+    bitrate: { freq: 500000, timeSeg1: 0, timeSeg2: 0, sjw: 0, preScaler: 0 }
+  }
+}

--- a/test/helpers/socketcanFrame.ts
+++ b/test/helpers/socketcanFrame.ts
@@ -1,0 +1,79 @@
+/**
+ * Linux SocketCAN wire format (uapi/linux/can.h).
+ *
+ * Classic `struct can_frame` is 16 bytes; CAN-FD `struct canfd_frame` is 72.
+ * Multi-byte fields use native endianness (little-endian on x86_64 / aarch64).
+ */
+
+import { CAN_ID_TYPE, CanMsgType } from '../../src/main/share/can'
+
+export const CAN_EFF_FLAG = 0x80000000
+export const CAN_RTR_FLAG = 0x40000000
+export const CAN_ERR_FLAG = 0x20000000
+export const CAN_SFF_MASK = 0x7ff
+export const CAN_EFF_MASK = 0x1fffffff
+
+export const CAN_MAX_DLEN = 8
+export const CANFD_MAX_DLEN = 64
+export const CAN_MTU = 16
+export const CANFD_MTU = 72
+export const CANFD_BRS = 0x01
+export const CANFD_ESI = 0x02
+
+export interface SocketcanFrame {
+  id: number
+  msgType: CanMsgType
+  data: Buffer
+}
+
+export function packCanFrame(id: number, msgType: CanMsgType, data: Buffer): Buffer {
+  const mask = msgType.idType === CAN_ID_TYPE.EXTENDED ? CAN_EFF_MASK : CAN_SFF_MASK
+  const canId =
+    (id & mask) |
+    (msgType.idType === CAN_ID_TYPE.EXTENDED ? CAN_EFF_FLAG : 0) |
+    (msgType.remote ? CAN_RTR_FLAG : 0)
+
+  if (msgType.canfd) {
+    if (data.length > CANFD_MAX_DLEN) {
+      throw new Error(`CAN-FD payload too long: ${data.length}`)
+    }
+    const buf = Buffer.alloc(CANFD_MTU)
+    buf.writeUInt32LE(canId >>> 0, 0)
+    buf.writeUInt8(data.length, 4)
+    buf.writeUInt8(msgType.brs ? CANFD_BRS : 0, 5)
+    data.copy(buf, 8)
+    return buf
+  }
+
+  if (data.length > CAN_MAX_DLEN) {
+    throw new Error(`Classic CAN payload too long: ${data.length}`)
+  }
+  const buf = Buffer.alloc(CAN_MTU)
+  buf.writeUInt32LE(canId >>> 0, 0)
+  buf.writeUInt8(data.length, 4)
+  data.copy(buf, 8)
+  return buf
+}
+
+export function unpackCanFrame(buf: Buffer): SocketcanFrame {
+  if (buf.length !== CAN_MTU && buf.length !== CANFD_MTU) {
+    throw new Error(`Invalid SocketCAN frame length: ${buf.length}`)
+  }
+  const canId = buf.readUInt32LE(0)
+  const canfd = buf.length === CANFD_MTU
+  const dlc = buf.readUInt8(4)
+  const flags = canfd ? buf.readUInt8(5) : 0
+  const dataOff = 8
+  const max = canfd ? CANFD_MAX_DLEN : CAN_MAX_DLEN
+  const len = Math.min(dlc, max)
+  return {
+    id: canId & CAN_EFF_MASK,
+    msgType: {
+      idType: canId & CAN_EFF_FLAG ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+      remote: !!(canId & CAN_RTR_FLAG),
+      canfd,
+      brs: !!(flags & CANFD_BRS)
+    },
+    data: Buffer.from(buf.subarray(dataOff, dataOff + len))
+  }
+}

--- a/test/helpers/socketcan_worker.py
+++ b/test/helpers/socketcan_worker.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Line-oriented SocketCAN worker used by the Vitest helper.
+
+Each process owns one AF_CAN / CAN_RAW socket bound to the given interface.
+stdin:  JSON {"cmd":"send","id":...,"ext":bool,"rtr":bool,"canfd":bool,"brs":bool,"data":"hex"}
+stdout: JSON {"evt":"rx", ...} / {"evt":"ok"} / {"evt":"err","msg":...}
+"""
+from __future__ import annotations
+
+import json
+import os
+import select
+import socket
+import struct
+import sys
+import threading
+
+CAN_EFF_FLAG = 0x80000000
+CAN_RTR_FLAG = 0x40000000
+CAN_RAW = 1
+CAN_RAW_FD_FRAMES = 5
+SOL_CAN_RAW = 101
+CAN_MTU = 16
+CANFD_MTU = 72
+
+CLASSIC_FMT = "=IB3x8s"
+FD_FMT = "=IBB2x64s"
+
+
+def pack_frame(msg: dict) -> bytes:
+    can_id = int(msg["id"])
+    if msg.get("ext"):
+        can_id |= CAN_EFF_FLAG
+    if msg.get("rtr"):
+        can_id |= CAN_RTR_FLAG
+    data = bytes.fromhex(msg.get("data") or "")
+    if msg.get("canfd"):
+        flags = 0x01 if msg.get("brs") else 0
+        return struct.pack(FD_FMT, can_id, len(data), flags, data.ljust(64, b"\0"))
+    return struct.pack(CLASSIC_FMT, can_id, len(data), data.ljust(8, b"\0"))
+
+
+def unpack_frame(raw: bytes) -> dict:
+    if len(raw) == CANFD_MTU:
+        can_id, dlc, flags, data = struct.unpack(FD_FMT, raw)
+        payload = data[:dlc]
+        canfd = True
+        brs = bool(flags & 0x01)
+    else:
+        can_id, dlc, data = struct.unpack(CLASSIC_FMT, raw[:CAN_MTU])
+        payload = data[:dlc]
+        canfd = False
+        brs = False
+    return {
+        "evt": "rx",
+        "id": can_id & 0x1FFFFFFF,
+        "ext": bool(can_id & CAN_EFF_FLAG),
+        "rtr": bool(can_id & CAN_RTR_FLAG),
+        "canfd": canfd,
+        "brs": brs,
+        "data": payload.hex(),
+    }
+
+
+def emit(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        emit({"evt": "err", "msg": "usage: socketcan_worker.py <iface>"})
+        return 2
+    iface = sys.argv[1]
+    try:
+        sock = socket.socket(socket.AF_CAN, socket.SOCK_RAW, CAN_RAW)
+        try:
+            sock.setsockopt(SOL_CAN_RAW, CAN_RAW_FD_FRAMES, 1)
+        except OSError:
+            pass
+        sock.bind((iface,))
+    except OSError as exc:
+        emit({"evt": "err", "msg": f"open {iface}: {exc}"})
+        return 1
+
+    emit({"evt": "ready", "iface": iface, "pid": os.getpid()})
+
+    stop = threading.Event()
+
+    def reader() -> None:
+        while not stop.is_set():
+            try:
+                r, _, _ = select.select([sock], [], [], 0.2)
+            except OSError:
+                break
+            if not r:
+                continue
+            try:
+                raw = sock.recv(CANFD_MTU)
+            except OSError:
+                break
+            if not raw:
+                break
+            emit(unpack_frame(raw))
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError as exc:
+                emit({"evt": "err", "msg": str(exc)})
+                continue
+            cmd = msg.get("cmd")
+            if cmd == "close":
+                break
+            if cmd != "send":
+                emit({"evt": "err", "msg": f"unknown cmd {cmd}"})
+                continue
+            try:
+                sock.send(pack_frame(msg))
+                emit({"evt": "ok"})
+            except OSError as exc:
+                emit({"evt": "err", "msg": str(exc)})
+    finally:
+        stop.set()
+        try:
+            sock.close()
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/xcp/xcp.test.ts
+++ b/test/xcp/xcp.test.ts
@@ -1,0 +1,536 @@
+/**
+ * XCP protocol / master tests.
+ *
+ * The byte-level expectations are ported from the test suite of the mature
+ * open-source XCP master pyXCP (https://github.com/christoph2/pyxcp,
+ * pyxcp/tests/test_master.py). pyXCP's `_mock_send` assertions include the
+ * 4-byte XCP-on-Ethernet header (LEN[2] + CTR[2]); here we compare against the
+ * raw XCP packet only (the header is a transport concern), so every expectation
+ * below equals the pyXCP vector with its first 4 header bytes removed.
+ */
+import { describe, it, expect } from 'vitest'
+import * as P from 'src/main/xcp/xcpProtocol'
+import { ByteOrder, ChecksumType } from 'src/main/xcp/xcpProtocol'
+import { XcpMaster, XcpTransport } from 'src/main/xcp/xcpMaster'
+
+const hex = (s: string): Buffer => Buffer.from(s.replace(/\s+/g, ''), 'hex')
+const bytes = (arr: number[]): Buffer => Buffer.from(arr)
+
+/** In-memory transport: records requests and replays queued responses. */
+class MockTransport implements XcpTransport {
+  sent: Buffer[] = []
+  private responses: Buffer[] = []
+
+  pushResponse(packet: string | number[]): void {
+    this.responses.push(typeof packet === 'string' ? hex(packet) : bytes(packet))
+  }
+  get last(): Buffer {
+    return this.sent[this.sent.length - 1]
+  }
+  async request(request: Buffer): Promise<Buffer> {
+    this.sent.push(request)
+    const r = this.responses.shift()
+    if (!r) throw new Error('MockTransport: no response queued')
+    return r
+  }
+  async send(request: Buffer): Promise<void> {
+    this.sent.push(request)
+  }
+  close(): void {}
+}
+
+/** Default CONNECT response used across pyXCP tests (INTEL byte order). */
+const DEFAULT_CONNECT_RESPONSE = 'FF 1D C0 FF DC 05 01 01'
+
+function connectedMaster(): { master: XcpMaster; mock: MockTransport } {
+  const mock = new MockTransport()
+  const master = new XcpMaster(mock)
+  return { master, mock }
+}
+
+describe('XCP protocol codec — command builders', () => {
+  it('CONNECT', () => {
+    expect(P.buildConnect(0)).toEqual(bytes([0xff, 0x00]))
+  })
+  it('DISCONNECT', () => {
+    expect(P.buildDisconnect()).toEqual(bytes([0xfe]))
+  })
+  it('GET_STATUS', () => {
+    expect(P.buildGetStatus()).toEqual(bytes([0xfd]))
+  })
+  it('SYNCH', () => {
+    expect(P.buildSynch()).toEqual(bytes([0xfc]))
+  })
+  it('GET_COMM_MODE_INFO', () => {
+    expect(P.buildGetCommModeInfo()).toEqual(bytes([0xfb]))
+  })
+  it('GET_VERSION', () => {
+    expect(P.buildGetVersion()).toEqual(bytes([0xc0, 0x00]))
+  })
+  it('GET_ID', () => {
+    expect(P.buildGetId(0x01)).toEqual(bytes([0xfa, 0x01]))
+  })
+  it('SET_REQUEST (session id is MSB-first)', () => {
+    expect(P.buildSetRequest(0x15, 0x1234)).toEqual(bytes([0xf9, 0x15, 0x12, 0x34]))
+  })
+  it('GET_SEED', () => {
+    expect(P.buildGetSeed(0x00, 0x00)).toEqual(bytes([0xf8, 0x00, 0x00]))
+  })
+  it('UNLOCK', () => {
+    expect(P.buildUnlock(0x04, [0x12, 0x34, 0x56, 0x78])).toEqual(
+      bytes([0xf7, 0x04, 0x12, 0x34, 0x56, 0x78])
+    )
+  })
+  it('SET_MTA', () => {
+    expect(P.buildSetMta(0x12345678, 0x55)).toEqual(
+      bytes([0xf6, 0x00, 0x00, 0x55, 0x78, 0x56, 0x34, 0x12])
+    )
+  })
+  it('UPLOAD', () => {
+    expect(P.buildUpload(8)).toEqual(bytes([0xf5, 0x08]))
+  })
+  it('SHORT_UPLOAD', () => {
+    expect(P.buildShortUpload(8, 0xcafebabe, 1)).toEqual(
+      bytes([0xf4, 0x08, 0x00, 0x01, 0xbe, 0xba, 0xfe, 0xca])
+    )
+  })
+  it('BUILD_CHECKSUM', () => {
+    expect(P.buildBuildChecksum(1024)).toEqual(
+      bytes([0xf3, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00])
+    )
+  })
+  it('USER_CMD', () => {
+    expect(P.buildUserCmd(0x55, [0xbe, 0xef])).toEqual(bytes([0xf1, 0x55, 0xbe, 0xef]))
+  })
+  it('TRANSPORT_LAYER_CMD', () => {
+    expect(P.buildTransportLayerCmd(0x55, [0xbe, 0xef])).toEqual(bytes([0xf2, 0x55, 0xbe, 0xef]))
+  })
+
+  it('DOWNLOAD', () => {
+    expect(P.buildDownload([0xca, 0xfe, 0xba, 0xbe])).toEqual(
+      bytes([0xf0, 0x04, 0xca, 0xfe, 0xba, 0xbe])
+    )
+  })
+  it('DOWNLOAD_NEXT', () => {
+    expect(P.buildDownloadNext(42, [0xca, 0xfe, 0xba, 0xbe])).toEqual(
+      bytes([0xef, 42, 0xca, 0xfe, 0xba, 0xbe])
+    )
+  })
+  it('DOWNLOAD_MAX', () => {
+    expect(P.buildDownloadMax([0xca, 0xfe, 0xba, 0xbe])).toEqual(
+      bytes([0xee, 0xca, 0xfe, 0xba, 0xbe])
+    )
+  })
+  it('SHORT_DOWNLOAD', () => {
+    expect(P.buildShortDownload(0x12345678, 0x55, [0xca, 0xfe, 0xba, 0xbe])).toEqual(
+      bytes([0xed, 0x04, 0x00, 0x55, 0x78, 0x56, 0x34, 0x12, 0xca, 0xfe, 0xba, 0xbe])
+    )
+  })
+  it('MODIFY_BITS', () => {
+    expect(P.buildModifyBits(0xff, 0x1234, 0xabcd)).toEqual(
+      bytes([0xec, 0xff, 0x34, 0x12, 0xcd, 0xab])
+    )
+  })
+  it('SET_CAL_PAGE', () => {
+    expect(P.buildSetCalPage(0x03, 0x12, 0x34)).toEqual(bytes([0xeb, 0x03, 0x12, 0x34]))
+  })
+  it('GET_CAL_PAGE', () => {
+    expect(P.buildGetCalPage(0x02, 0x44)).toEqual(bytes([0xea, 0x02, 0x44]))
+  })
+  it('GET_PAG_PROCESSOR_INFO', () => {
+    expect(P.buildGetPagProcessorInfo()).toEqual(bytes([0xe9]))
+  })
+  it('GET_SEGMENT_INFO', () => {
+    expect(P.buildGetSegmentInfo(0, 5, 1, 0)).toEqual(bytes([0xe8, 0x00, 0x05, 0x01, 0x00]))
+  })
+  it('GET_PAGE_INFO', () => {
+    expect(P.buildGetPageInfo(0x12, 0x34)).toEqual(bytes([0xe7, 0x00, 0x12, 0x34]))
+  })
+  it('SET_SEGMENT_MODE', () => {
+    expect(P.buildSetSegmentMode(0x01, 0x23)).toEqual(bytes([0xe6, 0x01, 0x23]))
+  })
+  it('GET_SEGMENT_MODE', () => {
+    expect(P.buildGetSegmentMode(0x23)).toEqual(bytes([0xe5, 0x00, 0x23]))
+  })
+  it('COPY_CAL_PAGE', () => {
+    expect(P.buildCopyCalPage(0x12, 0x34, 0x56, 0x78)).toEqual(
+      bytes([0xe4, 0x12, 0x34, 0x56, 0x78])
+    )
+  })
+
+  it('SET_DAQ_PTR', () => {
+    expect(P.buildSetDaqPtr(2, 3, 4)).toEqual(bytes([0xe2, 0x00, 0x02, 0x00, 0x03, 0x04]))
+  })
+  it('WRITE_DAQ', () => {
+    expect(P.buildWriteDaq(31, 15, 1, 0x12345678)).toEqual(
+      bytes([0xe1, 0x1f, 0x0f, 0x01, 0x78, 0x56, 0x34, 0x12])
+    )
+  })
+  it('SET_DAQ_LIST_MODE', () => {
+    expect(P.buildSetDaqListMode(0x3b, 256, 512, 1, 0xff)).toEqual(
+      bytes([0xe0, 0x3b, 0x00, 0x01, 0x00, 0x02, 0x01, 0xff])
+    )
+  })
+  it('START_STOP_DAQ_LIST', () => {
+    expect(P.buildStartStopDaqList(1, 512)).toEqual(bytes([0xde, 0x01, 0x00, 0x02]))
+  })
+  it('START_STOP_SYNCH', () => {
+    expect(P.buildStartStopSynch(3)).toEqual(bytes([0xdd, 0x03]))
+  })
+  it('READ_DAQ', () => {
+    expect(P.buildReadDaq()).toEqual(bytes([0xdb]))
+  })
+  it('GET_DAQ_CLOCK', () => {
+    expect(P.buildGetDaqClock()).toEqual(bytes([0xdc]))
+  })
+  it('GET_DAQ_LIST_MODE', () => {
+    expect(P.buildGetDaqListMode(256)).toEqual(bytes([0xdf, 0x00, 0x00, 0x01]))
+  })
+  it('GET_DAQ_EVENT_INFO', () => {
+    expect(P.buildGetDaqEventInfo(256)).toEqual(bytes([0xd7, 0x00, 0x00, 0x01]))
+  })
+  it('CLEAR_DAQ_LIST', () => {
+    expect(P.buildClearDaqList(256)).toEqual(bytes([0xe3, 0x00, 0x00, 0x01]))
+  })
+  it('GET_DAQ_LIST_INFO', () => {
+    expect(P.buildGetDaqListInfo(256)).toEqual(bytes([0xd8, 0x00, 0x00, 0x01]))
+  })
+  it('FREE_DAQ', () => {
+    expect(P.buildFreeDaq()).toEqual(bytes([0xd6]))
+  })
+  it('ALLOC_DAQ', () => {
+    expect(P.buildAllocDaq(258)).toEqual(bytes([0xd5, 0x00, 0x02, 0x01]))
+  })
+  it('ALLOC_ODT', () => {
+    expect(P.buildAllocOdt(258, 3)).toEqual(bytes([0xd4, 0x00, 0x02, 0x01, 0x03]))
+  })
+  it('ALLOC_ODT_ENTRY', () => {
+    expect(P.buildAllocOdtEntry(258, 3, 4)).toEqual(bytes([0xd3, 0x00, 0x02, 0x01, 0x03, 0x04]))
+  })
+  it('WRITE_DAQ_MULTIPLE', () => {
+    expect(
+      P.buildWriteDaqMultiple([
+        { bitOffset: 1, size: 2, address: 3, addressExt: 4 },
+        { bitOffset: 5, size: 6, address: 0x12345678, addressExt: 7 }
+      ])
+    ).toEqual(
+      bytes([
+        0xc7, 0x02, 0x01, 0x02, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x05, 0x06, 0x78, 0x56, 0x34,
+        0x12, 0x07, 0x00
+      ])
+    )
+  })
+
+  it('PROGRAM_START', () => {
+    expect(P.buildProgramStart()).toEqual(bytes([0xd2]))
+  })
+  it('PROGRAM_CLEAR', () => {
+    expect(P.buildProgramClear(0x00, 0xa0000100)).toEqual(
+      bytes([0xd1, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0xa0])
+    )
+  })
+  it('PROGRAM', () => {
+    expect(P.buildProgram(4, [0x01, 0x02, 0x03, 0x04])).toEqual(
+      bytes([0xd0, 0x04, 0x01, 0x02, 0x03, 0x04])
+    )
+  })
+  it('PROGRAM_RESET', () => {
+    expect(P.buildProgramReset()).toEqual(bytes([0xcf]))
+  })
+  it('GET_SECTOR_INFO', () => {
+    expect(P.buildGetSectorInfo(0, 0x12)).toEqual(bytes([0xcd, 0x00, 0x12]))
+  })
+  it('PROGRAM_PREPARE', () => {
+    expect(P.buildProgramPrepare(0x1234)).toEqual(bytes([0xcc, 0x00, 0x34, 0x12]))
+  })
+  it('PROGRAM_FORMAT', () => {
+    expect(P.buildProgramFormat(0x81, 0x82, 0x83, 0x01)).toEqual(
+      bytes([0xcb, 0x81, 0x82, 0x83, 0x01])
+    )
+  })
+  it('PROGRAM_NEXT', () => {
+    expect(P.buildProgramNext(4, [0x01, 0x02, 0x03, 0x04])).toEqual(
+      bytes([0xca, 0x04, 0x01, 0x02, 0x03, 0x04])
+    )
+  })
+  it('PROGRAM_MAX', () => {
+    expect(P.buildProgramMax([0x01, 0x02, 0x03, 0x04])).toEqual(
+      bytes([0xc9, 0x01, 0x02, 0x03, 0x04])
+    )
+  })
+  it('PROGRAM_VERIFY', () => {
+    expect(P.buildProgramVerify(0x01, 0x0004, 0xcafebabe)).toEqual(
+      bytes([0xc8, 0x01, 0x04, 0x00, 0xbe, 0xba, 0xfe, 0xca])
+    )
+  })
+})
+
+describe('XCP protocol codec — response parsers', () => {
+  it('CONNECT response (INTEL)', () => {
+    const r = P.parseConnectResponse(hex(DEFAULT_CONNECT_RESPONSE))
+    expect(r.maxCto).toBe(255)
+    expect(r.maxDto).toBe(1500)
+    expect(r.protocolLayerVersion).toBe(1)
+    expect(r.transportLayerVersion).toBe(1)
+    expect(r.resource).toEqual({ calpag: true, daq: true, stim: true, pgm: true, dbg: false })
+    expect(r.commModeBasic.optional).toBe(true)
+    expect(r.commModeBasic.slaveBlockMode).toBe(true)
+    expect(r.commModeBasic.addressGranularity).toBe(P.AddressGranularity.BYTE)
+    expect(r.commModeBasic.byteOrder).toBe(ByteOrder.INTEL)
+  })
+
+  it('GET_STATUS response (all clear)', () => {
+    const r = P.parseGetStatusResponse(hex('FF 00 1D FF 00 00'))
+    expect(r.sessionConfigurationId).toBe(0)
+    expect(r.sessionStatus).toEqual({
+      storeCalRequest: false,
+      storeDaqRequest: false,
+      clearDaqRequest: false,
+      daqRunning: false,
+      resume: false
+    })
+    expect(r.resourceProtectionStatus).toEqual({ calpag: true, daq: true, stim: true, pgm: true })
+  })
+
+  it('GET_STATUS response (with flags + session id)', () => {
+    const r = P.parseGetStatusResponse(hex('FF 09 1D 00 34 12'))
+    expect(r.sessionStatus.storeCalRequest).toBe(true)
+    expect(r.sessionStatus.clearDaqRequest).toBe(true)
+    expect(r.sessionStatus.storeDaqRequest).toBe(false)
+    expect(r.sessionConfigurationId).toBe(0x1234)
+  })
+
+  it('GET_COMM_MODE_INFO response', () => {
+    const r = P.parseGetCommModeInfoResponse(hex('FF 00 01 FF 02 00 00 19'))
+    expect(r.commModeOptional.masterBlockMode).toBe(true)
+    expect(r.commModeOptional.interleavedMode).toBe(false)
+    expect(r.maxBs).toBe(2)
+    expect(r.minSt).toBe(0)
+    expect(r.queueSize).toBe(0)
+    expect(r.xcpDriverVersionNumber).toBe(25)
+  })
+
+  it('GET_VERSION response', () => {
+    const r = P.parseGetVersionResponse(hex('FF 00 01 05 01 04'))
+    expect(r).toEqual({ protocolMajor: 1, protocolMinor: 5, transportMajor: 1, transportMinor: 4 })
+  })
+
+  it('GET_ID response', () => {
+    const r = P.parseGetIdResponse(hex('FF 00 01 FF 06 00 00 00'))
+    expect(r).toEqual({ mode: 0, length: 6 })
+  })
+
+  it('GET_SEED response', () => {
+    const r = P.parseGetSeedResponse(hex('FF 04 12 34 56 78'))
+    expect(r).toEqual({ length: 4, seed: [0x12, 0x34, 0x56, 0x78] })
+  })
+
+  it('UNLOCK response', () => {
+    const r = P.parseUnlockResponse(hex('FF 10'))
+    expect(r).toEqual({ calpag: false, daq: false, stim: false, pgm: true })
+  })
+
+  it('BUILD_CHECKSUM response', () => {
+    const r = P.parseBuildChecksumResponse(hex('FF 09 00 00 04 05 06 07'))
+    expect(r.checksumType).toBe(ChecksumType.XCP_CRC_32)
+    expect(r.checksum).toBe(0x07060504)
+  })
+
+  it('GET_CAL_PAGE response', () => {
+    expect(P.parseGetCalPageResponse(hex('FF 00 00 55'))).toBe(0x55)
+  })
+
+  it('START_STOP_DAQ_LIST response', () => {
+    expect(P.parseStartStopDaqListResponse(hex('FF 00')).firstPid).toBe(0)
+  })
+
+  it('GET_DAQ_CLOCK response', () => {
+    expect(P.parseGetDaqClockResponse(hex('FF 00 03 04 78 56 34 12'))).toBe(0x12345678)
+  })
+
+  it('ERR response raises XcpError', () => {
+    expect(() => P.checkResponse(hex('FE 20'))).toThrowError(P.XcpError)
+    try {
+      P.checkResponse(hex('FE 22'))
+    } catch (e) {
+      expect((e as P.XcpError).code).toBe(P.XcpErrorCode.ERR_OUT_OF_RANGE)
+    }
+  })
+})
+
+describe('XcpMaster — end-to-end command flow over a mock transport', () => {
+  it('connect negotiates slave properties', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    const res = await master.connect()
+    expect(mock.last).toEqual(bytes([0xff, 0x00]))
+    expect(res.maxCto).toBe(255)
+    expect(res.maxDto).toBe(1500)
+    expect(master.slaveProperties.byteOrder).toBe(ByteOrder.INTEL)
+    expect(master.slaveProperties.maxCto).toBe(255)
+    expect(master.slaveProperties.maxDto).toBe(1500)
+  })
+
+  it('getVersion', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+    mock.pushResponse('FF 00 01 05 01 04')
+    const res = await master.getVersion()
+    expect(mock.last).toEqual(bytes([0xc0, 0x00]))
+    expect(res).toEqual({
+      protocolMajor: 1,
+      protocolMinor: 5,
+      transportMajor: 1,
+      transportMinor: 4
+    })
+  })
+
+  it('getId + upload identifier', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+
+    mock.pushResponse('FF 00 01 FF 06 00 00 00')
+    const gid = await master.getId(0x01)
+    expect(mock.last).toEqual(bytes([0xfa, 0x01]))
+    expect(gid).toEqual({ mode: 0, length: 6 })
+
+    mock.pushResponse('FF 58 43 50 73 69 6D')
+    const data = await master.upload(gid.length)
+    expect(mock.last).toEqual(bytes([0xf5, 0x06]))
+    expect(data.toString('latin1')).toBe('XCPsim')
+  })
+
+  it('setMta', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+    mock.pushResponse('FF')
+    await master.setMta(0x12345678, 0x55)
+    expect(mock.last).toEqual(bytes([0xf6, 0x00, 0x00, 0x55, 0x78, 0x56, 0x34, 0x12]))
+  })
+
+  it('shortUpload', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+    mock.pushResponse('FF 01 02 03 04 05 06 07 08')
+    const data = await master.shortUpload(8, 0xcafebabe, 1)
+    expect(mock.last).toEqual(bytes([0xf4, 0x08, 0x00, 0x01, 0xbe, 0xba, 0xfe, 0xca]))
+    expect(Array.from(data)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  it('buildChecksum', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+    mock.pushResponse('FF 09 00 00 04 05 06 07')
+    const res = await master.buildChecksum(1024)
+    expect(mock.last).toEqual(bytes([0xf3, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00]))
+    expect(res.checksumType).toBe(ChecksumType.XCP_CRC_32)
+    expect(res.checksum).toBe(0x07060504)
+  })
+
+  it('getSeed + unlock', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+
+    mock.pushResponse('FF 04 12 34 56 78')
+    const seed = await master.getSeed(0x00, 0x00)
+    expect(mock.last).toEqual(bytes([0xf8, 0x00, 0x00]))
+    expect(seed).toEqual({ length: 4, seed: [0x12, 0x34, 0x56, 0x78] })
+
+    mock.pushResponse('FF 10')
+    const prot = await master.unlock(0x04, [0x12, 0x34, 0x56, 0x78])
+    expect(mock.last).toEqual(bytes([0xf7, 0x04, 0x12, 0x34, 0x56, 0x78]))
+    expect(prot).toEqual({ calpag: false, daq: false, stim: false, pgm: true })
+  })
+
+  it('download / shortDownload / modifyBits', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+
+    mock.pushResponse('FF')
+    await master.download([0xca, 0xfe, 0xba, 0xbe])
+    expect(mock.last).toEqual(bytes([0xf0, 0x04, 0xca, 0xfe, 0xba, 0xbe]))
+
+    mock.pushResponse('FF')
+    await master.shortDownload(0x12345678, 0x55, [0xca, 0xfe, 0xba, 0xbe])
+    expect(mock.last).toEqual(
+      bytes([0xed, 0x04, 0x00, 0x55, 0x78, 0x56, 0x34, 0x12, 0xca, 0xfe, 0xba, 0xbe])
+    )
+
+    mock.pushResponse('FF')
+    await master.modifyBits(0xff, 0x1234, 0xabcd)
+    expect(mock.last).toEqual(bytes([0xec, 0xff, 0x34, 0x12, 0xcd, 0xab]))
+  })
+
+  it('DAQ configuration sequence', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+
+    mock.pushResponse('FF')
+    await master.setDaqPtr(2, 3, 4)
+    expect(mock.last).toEqual(bytes([0xe2, 0x00, 0x02, 0x00, 0x03, 0x04]))
+
+    mock.pushResponse('FF')
+    await master.writeDaq(31, 15, 1, 0x12345678)
+    expect(mock.last).toEqual(bytes([0xe1, 0x1f, 0x0f, 0x01, 0x78, 0x56, 0x34, 0x12]))
+
+    mock.pushResponse('FF')
+    await master.setDaqListMode(0x3b, 256, 512, 1, 0xff)
+    expect(mock.last).toEqual(bytes([0xe0, 0x3b, 0x00, 0x01, 0x00, 0x02, 0x01, 0xff]))
+
+    mock.pushResponse('FF 00')
+    const ss = await master.startStopDaqList(1, 512)
+    expect(mock.last).toEqual(bytes([0xde, 0x01, 0x00, 0x02]))
+    expect(ss.firstPid).toBe(0)
+
+    mock.pushResponse('FF')
+    await master.startStopSynch(3)
+    expect(mock.last).toEqual(bytes([0xdd, 0x03]))
+
+    mock.pushResponse('FF 00 03 04 78 56 34 12')
+    const ts = await master.getDaqClock()
+    expect(mock.last).toEqual(bytes([0xdc]))
+    expect(ts).toBe(0x12345678)
+  })
+
+  it('PGM sequence', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+
+    mock.pushResponse('FF 00 01 08 2A FF 55')
+    await master.programStart()
+    expect(mock.last).toEqual(bytes([0xd2]))
+
+    mock.pushResponse('FF')
+    await master.programClear(0x00, 0xa0000100)
+    expect(mock.last).toEqual(bytes([0xd1, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0xa0]))
+
+    mock.pushResponse('FF')
+    await master.program(4, [0x01, 0x02, 0x03, 0x04])
+    expect(mock.last).toEqual(bytes([0xd0, 0x04, 0x01, 0x02, 0x03, 0x04]))
+
+    mock.pushResponse('FF')
+    await master.programReset()
+    expect(mock.last).toEqual(bytes([0xcf]))
+
+    mock.pushResponse('FF')
+    await master.programVerify(0x01, 0x0004, 0xcafebabe)
+    expect(mock.last).toEqual(bytes([0xc8, 0x01, 0x04, 0x00, 0xbe, 0xba, 0xfe, 0xca]))
+  })
+
+  it('propagates slave ERR responses as XcpError', async () => {
+    const { master, mock } = connectedMaster()
+    mock.pushResponse(DEFAULT_CONNECT_RESPONSE)
+    await master.connect()
+    mock.pushResponse('FE 22') // ERR_OUT_OF_RANGE
+    await expect(master.upload(8)).rejects.toBeInstanceOf(P.XcpError)
+  })
+})

--- a/test/xcp/xcpCan.test.ts
+++ b/test/xcp/xcpCan.test.ts
@@ -1,0 +1,146 @@
+/**
+ * XCP-on-CAN end-to-end integration test.
+ *
+ * Drives {@link XcpMaster} through the real {@link XcpCanTransport} over the
+ * `simulate` CAN backend (functional on Linux). A tiny simulated XCP slave on
+ * the peer node answers the master's commands, proving the full send/receive
+ * path — command framing, CAN transmission, response reception and parsing —
+ * works together, not just the isolated codec.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { SIMULATE_CAN } from 'src/main/docan/simulate'
+import { CAN_SOCKET, CanBase } from 'src/main/docan/base'
+import { CAN_ID_TYPE, CanMsgType } from 'src/main/share/can'
+import { XcpCanTransport } from 'src/main/xcp/xcpCan'
+import { XcpMaster } from 'src/main/xcp/xcpMaster'
+
+const CMD_ID = 0x7e0
+const RESP_ID = 0x7e1
+
+function makeBase(handle: number): CanBase {
+  return new SIMULATE_CAN({
+    handle,
+    name: 'xcp-sim',
+    vendor: 'simulate',
+    canfd: false,
+    bitrate: { freq: 500000, timeSeg1: 0x0f, timeSeg2: 0x04, sjw: 0x01, preScaler: 0x01 },
+    bitratefd: { freq: 500000, timeSeg1: 0x0f, timeSeg2: 0x04, sjw: 0x01, preScaler: 0x01 },
+    id: 'xcp-bus'
+  } as any) as unknown as CanBase
+}
+
+const msgType: CanMsgType = {
+  idType: CAN_ID_TYPE.STANDARD,
+  brs: false,
+  canfd: false,
+  remote: false
+}
+
+/**
+ * Minimal simulated XCP slave: reads command frames on CMD_ID and writes canned
+ * responses on RESP_ID. Enough behaviour to exercise a realistic master session.
+ */
+function startSlave(base: CanBase): () => void {
+  const reqSock = new CAN_SOCKET(base, CMD_ID, msgType)
+  const respSock = new CAN_SOCKET(base, RESP_ID, msgType)
+  let running = true
+
+  const handle = (req: Buffer): Buffer => {
+    const pid = req[0]
+    switch (pid) {
+      case 0xff: // CONNECT -> resources + INTEL byte order, MAX_CTO 255, MAX_DTO 1500
+        return Buffer.from([0xff, 0x1d, 0xc0, 0xff, 0xdc, 0x05, 0x01, 0x01])
+      case 0xfd: // GET_STATUS
+        return Buffer.from([0xff, 0x00, 0x1d, 0xff, 0x00, 0x00])
+      case 0xf4: {
+        // SHORT_UPLOAD: return `count` incrementing bytes starting at 1
+        const count = req[1]
+        return Buffer.concat([
+          Buffer.from([0xff]),
+          Buffer.from(Array.from({ length: count }, (_, i) => i + 1))
+        ])
+      }
+      case 0xf6: // SET_MTA
+        return Buffer.from([0xff])
+      case 0xfe: // DISCONNECT
+        return Buffer.from([0xff])
+      default:
+        return Buffer.from([0xfe, 0x20]) // ERR_CMD_UNKNOWN
+    }
+  }
+
+  const loop = async () => {
+    while (running) {
+      let req: { data: Buffer; ts: number }
+      try {
+        req = await reqSock.read(3000)
+      } catch {
+        break
+      }
+      if (!running) break
+      await respSock.write(handle(req.data))
+    }
+  }
+  loop()
+
+  return () => {
+    running = false
+    reqSock.close()
+    respSock.close()
+  }
+}
+
+describe('XCP-on-CAN over the simulate backend (end-to-end)', () => {
+  let masterBase: CanBase
+  let slaveBase: CanBase
+  let stopSlave: () => void
+  let master: XcpMaster
+
+  beforeAll(() => {
+    masterBase = makeBase(0)
+    slaveBase = makeBase(1)
+    stopSlave = startSlave(slaveBase)
+    const transport = new XcpCanTransport(masterBase, {
+      name: 'ecu',
+      canIdCmd: CMD_ID,
+      canIdResp: RESP_ID,
+      padding: true
+    })
+    master = new XcpMaster(transport, 3000)
+  })
+
+  afterAll(() => {
+    master.close()
+    stopSlave()
+    masterBase.close()
+    slaveBase.close()
+  })
+
+  it('CONNECT negotiates slave properties over CAN', async () => {
+    const res = await master.connect()
+    expect(res.maxCto).toBe(255)
+    expect(res.maxDto).toBe(1500)
+    expect(res.resource.pgm).toBe(true)
+    expect(master.slaveProperties.byteOrder).toBe(0) // INTEL
+  })
+
+  it('GET_STATUS round-trips over CAN', async () => {
+    const status = await master.getStatus()
+    expect(status.resourceProtectionStatus.pgm).toBe(true)
+    expect(status.sessionConfigurationId).toBe(0)
+  })
+
+  it('SHORT_UPLOAD returns slave memory over CAN', async () => {
+    const data = await master.shortUpload(4, 0x1000, 0)
+    expect(Array.from(data)).toEqual([1, 2, 3, 4])
+  })
+
+  it('SET_MTA acknowledges over CAN', async () => {
+    await expect(master.setMta(0x12345678, 0)).resolves.toBeInstanceOf(Buffer)
+  })
+
+  it('DISCONNECT completes over CAN', async () => {
+    await expect(master.disconnect()).resolves.toBeInstanceOf(Buffer)
+    expect(master.connected).toBe(false)
+  })
+})

--- a/test/xcp/xcpCan.test.ts
+++ b/test/xcp/xcpCan.test.ts
@@ -7,15 +7,12 @@
  * path — command framing, CAN transmission, response reception and parsing —
  * works together, not just the isolated codec.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, beforeAll, afterAll } from 'vitest'
 import { SIMULATE_CAN } from 'src/main/docan/simulate'
-import { CAN_SOCKET, CanBase } from 'src/main/docan/base'
-import { CAN_ID_TYPE, CanMsgType } from 'src/main/share/can'
+import { CanBase } from 'src/main/docan/base'
 import { XcpCanTransport } from 'src/main/xcp/xcpCan'
 import { XcpMaster } from 'src/main/xcp/xcpMaster'
-
-const CMD_ID = 0x7e0
-const RESP_ID = 0x7e1
+import { XCP_CMD_ID, XCP_RESP_ID, startXcpSlave, defineXcpCanSessionTests } from './xcpCanHarness'
 
 function makeBase(handle: number): CanBase {
   return new SIMULATE_CAN({
@@ -29,67 +26,6 @@ function makeBase(handle: number): CanBase {
   } as any) as unknown as CanBase
 }
 
-const msgType: CanMsgType = {
-  idType: CAN_ID_TYPE.STANDARD,
-  brs: false,
-  canfd: false,
-  remote: false
-}
-
-/**
- * Minimal simulated XCP slave: reads command frames on CMD_ID and writes canned
- * responses on RESP_ID. Enough behaviour to exercise a realistic master session.
- */
-function startSlave(base: CanBase): () => void {
-  const reqSock = new CAN_SOCKET(base, CMD_ID, msgType)
-  const respSock = new CAN_SOCKET(base, RESP_ID, msgType)
-  let running = true
-
-  const handle = (req: Buffer): Buffer => {
-    const pid = req[0]
-    switch (pid) {
-      case 0xff: // CONNECT -> resources + INTEL byte order, MAX_CTO 255, MAX_DTO 1500
-        return Buffer.from([0xff, 0x1d, 0xc0, 0xff, 0xdc, 0x05, 0x01, 0x01])
-      case 0xfd: // GET_STATUS
-        return Buffer.from([0xff, 0x00, 0x1d, 0xff, 0x00, 0x00])
-      case 0xf4: {
-        // SHORT_UPLOAD: return `count` incrementing bytes starting at 1
-        const count = req[1]
-        return Buffer.concat([
-          Buffer.from([0xff]),
-          Buffer.from(Array.from({ length: count }, (_, i) => i + 1))
-        ])
-      }
-      case 0xf6: // SET_MTA
-        return Buffer.from([0xff])
-      case 0xfe: // DISCONNECT
-        return Buffer.from([0xff])
-      default:
-        return Buffer.from([0xfe, 0x20]) // ERR_CMD_UNKNOWN
-    }
-  }
-
-  const loop = async () => {
-    while (running) {
-      let req: { data: Buffer; ts: number }
-      try {
-        req = await reqSock.read(3000)
-      } catch {
-        break
-      }
-      if (!running) break
-      await respSock.write(handle(req.data))
-    }
-  }
-  loop()
-
-  return () => {
-    running = false
-    reqSock.close()
-    respSock.close()
-  }
-}
-
 describe('XCP-on-CAN over the simulate backend (end-to-end)', () => {
   let masterBase: CanBase
   let slaveBase: CanBase
@@ -99,11 +35,11 @@ describe('XCP-on-CAN over the simulate backend (end-to-end)', () => {
   beforeAll(() => {
     masterBase = makeBase(0)
     slaveBase = makeBase(1)
-    stopSlave = startSlave(slaveBase)
+    stopSlave = startXcpSlave(slaveBase)
     const transport = new XcpCanTransport(masterBase, {
       name: 'ecu',
-      canIdCmd: CMD_ID,
-      canIdResp: RESP_ID,
+      canIdCmd: XCP_CMD_ID,
+      canIdResp: XCP_RESP_ID,
       padding: true
     })
     master = new XcpMaster(transport, 3000)
@@ -116,31 +52,5 @@ describe('XCP-on-CAN over the simulate backend (end-to-end)', () => {
     slaveBase.close()
   })
 
-  it('CONNECT negotiates slave properties over CAN', async () => {
-    const res = await master.connect()
-    expect(res.maxCto).toBe(255)
-    expect(res.maxDto).toBe(1500)
-    expect(res.resource.pgm).toBe(true)
-    expect(master.slaveProperties.byteOrder).toBe(0) // INTEL
-  })
-
-  it('GET_STATUS round-trips over CAN', async () => {
-    const status = await master.getStatus()
-    expect(status.resourceProtectionStatus.pgm).toBe(true)
-    expect(status.sessionConfigurationId).toBe(0)
-  })
-
-  it('SHORT_UPLOAD returns slave memory over CAN', async () => {
-    const data = await master.shortUpload(4, 0x1000, 0)
-    expect(Array.from(data)).toEqual([1, 2, 3, 4])
-  })
-
-  it('SET_MTA acknowledges over CAN', async () => {
-    await expect(master.setMta(0x12345678, 0)).resolves.toBeInstanceOf(Buffer)
-  })
-
-  it('DISCONNECT completes over CAN', async () => {
-    await expect(master.disconnect()).resolves.toBeInstanceOf(Buffer)
-    expect(master.connected).toBe(false)
-  })
+  defineXcpCanSessionTests(() => master)
 })

--- a/test/xcp/xcpCanHarness.ts
+++ b/test/xcp/xcpCanHarness.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared XCP-on-CAN test slave and session assertions.
+ *
+ * Used by both the in-process `simulate` backend tests and the SocketCAN tests
+ * so the command/response vectors stay identical across transports.
+ */
+import { expect, it } from 'vitest'
+import { CAN_SOCKET, CanBase } from 'src/main/docan/base'
+import { CAN_ID_TYPE, CanMsgType } from 'src/main/share/can'
+import { XcpMaster } from 'src/main/xcp/xcpMaster'
+
+export const XCP_CMD_ID = 0x7e0
+export const XCP_RESP_ID = 0x7e1
+
+export const xcpCanMsgType: CanMsgType = {
+  idType: CAN_ID_TYPE.STANDARD,
+  brs: false,
+  canfd: false,
+  remote: false
+}
+
+/**
+ * Minimal simulated XCP slave: reads command frames on CMD_ID and writes canned
+ * responses on RESP_ID.
+ */
+export function startXcpSlave(base: CanBase): () => void {
+  const reqSock = new CAN_SOCKET(base, XCP_CMD_ID, xcpCanMsgType)
+  const respSock = new CAN_SOCKET(base, XCP_RESP_ID, xcpCanMsgType)
+  let running = true
+
+  const handle = (req: Buffer): Buffer => {
+    const pid = req[0]
+    switch (pid) {
+      case 0xff: // CONNECT -> resources + INTEL byte order, MAX_CTO 255, MAX_DTO 1500
+        return Buffer.from([0xff, 0x1d, 0xc0, 0xff, 0xdc, 0x05, 0x01, 0x01])
+      case 0xfd: // GET_STATUS
+        return Buffer.from([0xff, 0x00, 0x1d, 0xff, 0x00, 0x00])
+      case 0xf4: {
+        // SHORT_UPLOAD: return `count` incrementing bytes starting at 1
+        const count = req[1]
+        return Buffer.concat([
+          Buffer.from([0xff]),
+          Buffer.from(Array.from({ length: count }, (_, i) => i + 1))
+        ])
+      }
+      case 0xf6: // SET_MTA
+        return Buffer.from([0xff])
+      case 0xfe: // DISCONNECT
+        return Buffer.from([0xff])
+      default:
+        return Buffer.from([0xfe, 0x20]) // ERR_CMD_UNKNOWN
+    }
+  }
+
+  const loop = async () => {
+    while (running) {
+      let req: { data: Buffer; ts: number }
+      try {
+        req = await reqSock.read(3000)
+      } catch {
+        break
+      }
+      if (!running) break
+      await respSock.write(handle(req.data))
+    }
+  }
+  loop()
+
+  return () => {
+    running = false
+    reqSock.close()
+    respSock.close()
+  }
+}
+
+export function defineXcpCanSessionTests(getMaster: () => XcpMaster) {
+  it('CONNECT negotiates slave properties over CAN', async () => {
+    const res = await getMaster().connect()
+    expect(res.maxCto).toBe(255)
+    expect(res.maxDto).toBe(1500)
+    expect(res.resource.pgm).toBe(true)
+    expect(getMaster().slaveProperties.byteOrder).toBe(0) // INTEL
+  })
+
+  it('GET_STATUS round-trips over CAN', async () => {
+    const status = await getMaster().getStatus()
+    expect(status.resourceProtectionStatus.pgm).toBe(true)
+    expect(status.sessionConfigurationId).toBe(0)
+  })
+
+  it('SHORT_UPLOAD returns slave memory over CAN', async () => {
+    const data = await getMaster().shortUpload(4, 0x1000, 0)
+    expect(Array.from(data)).toEqual([1, 2, 3, 4])
+  })
+
+  it('SET_MTA acknowledges over CAN', async () => {
+    await expect(getMaster().setMta(0x12345678, 0)).resolves.toBeInstanceOf(Buffer)
+  })
+
+  it('DISCONNECT completes over CAN', async () => {
+    await expect(getMaster().disconnect()).resolves.toBeInstanceOf(Buffer)
+    expect(getMaster().connected).toBe(false)
+  })
+}

--- a/test/xcp/xcpCanSocketcan.test.ts
+++ b/test/xcp/xcpCanSocketcan.test.ts
@@ -1,0 +1,57 @@
+/**
+ * XCP-on-CAN over SocketCAN.
+ *
+ * Two independent CAN nodes share one bus (a real vcan/can interface when the
+ * kernel provides AF_CAN, otherwise an in-process bus that still exchanges
+ * packed `struct can_frame` buffers). This matches SocketCAN's isolation model
+ * (separate sockets, no self-echo) rather than the global simulate bus.
+ */
+import { describe, beforeAll, afterAll } from 'vitest'
+import { XcpCanTransport } from 'src/main/xcp/xcpCan'
+import { XcpMaster } from 'src/main/xcp/xcpMaster'
+import {
+  createSocketcanTestBus,
+  SocketcanTestBus,
+  SocketcanTestCan,
+  socketcanTestInfo,
+  probeLinuxSocketcan
+} from '../helpers/socketcanCan'
+import { XCP_CMD_ID, XCP_RESP_ID, startXcpSlave, defineXcpCanSessionTests } from './xcpCanHarness'
+
+describe('XCP-on-CAN over SocketCAN (end-to-end)', () => {
+  let bus: SocketcanTestBus
+  let masterBase: SocketcanTestCan
+  let slaveBase: SocketcanTestCan
+  let stopSlave: () => void
+  let master: XcpMaster
+
+  beforeAll(async () => {
+    const probe = probeLinuxSocketcan()
+    bus = await createSocketcanTestBus()
+    console.log(
+      `SocketCAN XCP tests using ${bus.kind} bus on ${bus.iface}` +
+        (probe.ok ? '' : ` (kernel: ${probe.reason})`)
+    )
+    masterBase = new SocketcanTestCan(socketcanTestInfo('xcp-socketcan-master', bus.iface), bus)
+    slaveBase = new SocketcanTestCan(socketcanTestInfo('xcp-socketcan-slave', bus.iface), bus)
+    await masterBase.open()
+    await slaveBase.open()
+    stopSlave = startXcpSlave(slaveBase)
+    const transport = new XcpCanTransport(masterBase, {
+      name: 'ecu',
+      canIdCmd: XCP_CMD_ID,
+      canIdResp: XCP_RESP_ID,
+      padding: true
+    })
+    master = new XcpMaster(transport, 3000)
+  })
+
+  afterAll(() => {
+    master.close()
+    stopSlave()
+    masterBase.close()
+    slaveBase.close()
+  })
+
+  defineXcpCanSessionTests(() => master)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **XCP (ASAM MCD-1 XCP) master** to EcuBus-Pro, following the existing CAN-TP architecture, and exposes it to user scripts. This is the first iteration: it adds the main-process implementation plus the worker/script API surface (no renderer/UI yet).

The protocol codec is implemented **test-first**, constrained by the byte-level test vectors of the mature open-source XCP master [pyXCP](https://github.com/christoph2/pyxcp) (`pyxcp/tests/test_master.py`). The byte encodings are dictated by the ASAM XCP standard; the ported vectors act as a correctness oracle.

## What's included

Mirrors the CAN-TP layering (`worker/cantp.ts` → `nodeItem.canApi` → `docan/cantp.ts`):

- `src/main/xcp/xcpProtocol.ts` — pure, transport-agnostic command builders and response parsers. Covers STD, calibration/paging (CAL_PAG), DAQ and programming (PGM) commands, with Intel/Motorola byte-order handling negotiated at `CONNECT`.
- `src/main/xcp/xcpMaster.ts` — `XcpMaster`, a high-level master over a pluggable `XcpTransport`, tracking slave properties (byte order, MAX_CTO/MAX_DTO, resources).
- `src/main/xcp/xcpCan.ts` — `XcpCanTransport`, XCP-on-CAN binding on the existing `CAN_SOCKET`/`CanBase` layer.
- `src/main/worker/xcp.ts` — worker script API (`XcpCreateConnection`, `XcpConnect`, `XcpGetStatus`, `XcpShortUpload`, `XcpSetMta`, DAQ/PGM helpers, ...) bridged via a new `xcpApi` RPC, mirroring the CAN-TP worker API. Re-exported from `worker/index.ts`.
- `src/main/nodeItem.ts` — `xcpApi` handler that opens/closes connections and dispatches whitelisted `XcpMaster` methods.
- `src/main/worker/node.d.ts` — ambient `*?asset` / `*?asset&asarUnpack` module declarations. This is a **pre-existing gap** that prevented `npm run worker:js` from emitting the worker bundle (ts-loader `TS2307` on those asset imports, unrelated to XCP); adding the shims — identical in spirit to the existing `*.node` / `*.html?raw` shims in the same file — unblocks the mandated worker rebuild.

### Example script usage
```ts
import { XcpCreateConnection, XcpConnect, XcpShortUpload, XcpCloseConnection } from 'ecubus-worker'

Util.Init(async () => {
  const handle = await XcpCreateConnection({ name: 'ecu', canIdCmd: 0x7e0, canIdResp: 0x7e1, padding: true })
  const info = await XcpConnect(handle)
  console.log('MAX_CTO', info.maxCto, 'MAX_DTO', info.maxDto)
  const mem = await XcpShortUpload(handle, 4, 0x1000)
  console.log('mem', mem)
  await XcpCloseConnection(handle)
})
```

## Testing

- `test/xcp/xcp.test.ts` — **79** tests: command builders and response parsers for every STD/CAL_PAG/DAQ/PGM command, plus `XcpMaster` end-to-end flow over a mock transport. Expectations are the pyXCP vectors minus the 4-byte XCP-on-Ethernet transport header.
- `test/xcp/xcpCan.test.ts` — **5** end-to-end tests driving `XcpMaster` through the real `XcpCanTransport` over the `simulate` CAN backend, against a tiny simulated XCP slave (CONNECT / GET_STATUS / SHORT_UPLOAD / SET_MTA / DISCONNECT).
- `test/xcp/xcpCanSocketcan.test.ts` — the same 5 XCP-on-CAN session tests over **SocketCAN**: two independent sockets sharing one bus, exchanging packed Linux `struct can_frame` buffers. Prefers a real `vcan`/`can` interface when `AF_CAN` works; falls back to an in-process bus on kernels without `CONFIG_CAN`.
- `test/docan/socketcan.test.ts` — SocketCAN ABI codec tests (checked against Python `struct.pack` of `can_frame` / `canfd_frame`), two-socket I/O, fan-out, timeout, and kernel vcan smoke tests (skipped when AF_CAN is unavailable).
- Shared slave/session harness: `test/xcp/xcpCanHarness.ts`. Linux AF_CAN worker: `test/helpers/socketcan_worker.py`.
- `npm run test -- --run test/xcp test/docan/socketcan.test.ts` → **100 passed, 2 skipped** (kernel vcan; this Cloud kernel has no `CONFIG_CAN`).
- `npm run typecheck` → clean (node + web). `npm run worker:js` → builds and the bundle + generated worker typings include the XCP API.

To run the real kernel path on a normal Linux host:

```bash
sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0
npm run test -- --run test/docan/socketcan.test.ts test/xcp/xcpCanSocketcan.test.ts
```

## Scope / follow-ups
- First iteration is main + script API only, XCP-on-CAN. Future iterations could add XCP-on-Ethernet, DAQ measurement streaming/decoding, seed & key DLL integration, and renderer UI.
- This does **not** register a production SocketCAN vendor in the Hardware tab (see #87 / #300). The new tests cover the SocketCAN wire format and two-socket isolation model so XCP-on-CAN is proven beyond the in-process simulate bus.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94a551cf-aa07-436e-929a-5baabec2aa65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94a551cf-aa07-436e-929a-5baabec2aa65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

