### PR TITLE
feat(ldf): sync node Protocol when General LIN Version changes

### DIFF
--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -614,7 +614,7 @@
         },
         "dialogs": {
           "syncNodeProtocolTitle": "Sync Node Protocol",
-          "syncNodeProtocol": "A global LIN version change was detected. Sync all node Protocol values to {{version}}? Choose Yes to sync now, or No to change only the global version."
+          "syncNodeProtocol": "Sync all node Protocol values to {{version}}?"
         }
       },
       "index": {

--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -607,6 +607,14 @@
         },
         "tabs": {
           "general": "General"
+        },
+        "buttons": {
+          "yes": "Yes",
+          "no": "No"
+        },
+        "dialogs": {
+          "syncNodeProtocolTitle": "Sync Node Protocol",
+          "syncNodeProtocol": "A global LIN version change was detected. Sync all node Protocol values to {{version}}? Choose Yes to sync now, or No to change only the global version."
         }
       },
       "index": {

--- a/src/renderer/src/database/ldf/general.vue
+++ b/src/renderer/src/database/ldf/general.vue
@@ -140,7 +140,7 @@ watch(
             distinguishCancelAndClose: true,
             type: 'warning',
             buttonSize: 'small',
-            appendTo: `#win${props.editIndex}`
+            appendTo: document.body
           }
         )
       } catch {

--- a/src/renderer/src/database/ldf/general.vue
+++ b/src/renderer/src/database/ldf/general.vue
@@ -103,6 +103,7 @@ import { useDataStore } from '@r/stores/data'
 import { Layout } from '@r/views/uds/layout'
 import { VxeGrid, VxeGridProps } from 'vxe-table'
 import i18next from 'i18next'
+import { getNodeProtocolSyncDecision, syncAllNodeProtocols } from './syncNodeProtocol'
 
 // import { validateLDF } from './validator'
 
@@ -115,6 +116,41 @@ const props = defineProps<{
 }>()
 
 const database = useDataStore()
+
+watch(
+  () => ldfObj.value.global.LIN_protocol_version,
+  async (newVersion, oldVersion) => {
+    if (!newVersion || newVersion === oldVersion) {
+      return
+    }
+
+    const decision = getNodeProtocolSyncDecision(ldfObj.value, newVersion, oldVersion)
+    if (decision === 'none') {
+      return
+    }
+
+    if (decision === 'confirm') {
+      try {
+        await ElMessageBox.confirm(
+          i18next.t('database.ldf.general.dialogs.syncNodeProtocol', { version: newVersion }),
+          i18next.t('database.ldf.general.dialogs.syncNodeProtocolTitle'),
+          {
+            confirmButtonText: i18next.t('database.ldf.general.buttons.yes'),
+            cancelButtonText: i18next.t('database.ldf.general.buttons.no'),
+            distinguishCancelAndClose: true,
+            type: 'warning',
+            buttonSize: 'small',
+            appendTo: `#win${props.editIndex}`
+          }
+        )
+      } catch {
+        return
+      }
+    }
+
+    syncAllNodeProtocols(ldfObj.value, newVersion)
+  }
+)
 
 async function validate() {
   return new Promise((resolve, reject) => {

--- a/src/renderer/src/database/ldf/node.vue
+++ b/src/renderer/src/database/ldf/node.vue
@@ -461,7 +461,7 @@ function addNewSlaveNode() {
     .then(({ value }) => {
       ldfObj.value.node.salveNode.push(value)
       ldfObj.value.nodeAttrs[value] = {
-        LIN_protocol: '',
+        LIN_protocol: ldfObj.value.global.LIN_protocol_version || '',
         configured_NAD: 0,
         initial_NAD: 0,
         supplier_id: 0,

--- a/src/renderer/src/database/ldf/syncNodeProtocol.ts
+++ b/src/renderer/src/database/ldf/syncNodeProtocol.ts
@@ -1,0 +1,61 @@
+import { LDF } from '../ldfParse'
+
+export type NodeProtocolSyncDecision = 'none' | 'auto' | 'confirm'
+
+function nodeAttrEntries(ldf: LDF) {
+  return Object.entries(ldf.nodeAttrs || {})
+}
+
+/**
+ * Returns node names whose Protocol differs from the given LIN version.
+ */
+export function getNodesNeedingProtocolSync(ldf: LDF, version: string): string[] {
+  return nodeAttrEntries(ldf)
+    .filter(([, attr]) => attr && attr.LIN_protocol !== version)
+    .map(([name]) => name)
+}
+
+/**
+ * True when at least one node Protocol is set and differs from `expectedVersion`.
+ * Used to detect nodes that were customized away from the previous global version.
+ */
+export function hasCustomNodeProtocols(ldf: LDF, expectedVersion?: string): boolean {
+  return nodeAttrEntries(ldf).some(
+    ([, attr]) => Boolean(attr?.LIN_protocol) && attr.LIN_protocol !== expectedVersion
+  )
+}
+
+/**
+ * Decide how a global LIN protocol version change should affect node Protocol values.
+ *
+ * - `none`: every node already matches the new version (or there are no nodes)
+ * - `auto`: all nodes still follow the previous global version (or are empty) — sync silently
+ * - `confirm`: at least one node was customized to a different version — ask before overwriting
+ */
+export function getNodeProtocolSyncDecision(
+  ldf: LDF,
+  newVersion: string,
+  previousGlobalVersion?: string
+): NodeProtocolSyncDecision {
+  if (!newVersion) {
+    return 'none'
+  }
+  if (getNodesNeedingProtocolSync(ldf, newVersion).length === 0) {
+    return 'none'
+  }
+  if (hasCustomNodeProtocols(ldf, previousGlobalVersion)) {
+    return 'confirm'
+  }
+  return 'auto'
+}
+
+/**
+ * Set every node's Protocol to `version`.
+ */
+export function syncAllNodeProtocols(ldf: LDF, version: string): void {
+  for (const [, attr] of nodeAttrEntries(ldf)) {
+    if (attr) {
+      attr.LIN_protocol = version
+    }
+  }
+}

--- a/test/ldf/syncNodeProtocol.spec.ts
+++ b/test/ldf/syncNodeProtocol.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { LDF, NodeAttrDef } from '../../src/renderer/src/database/ldfParse'
+import {
+  getNodeProtocolSyncDecision,
+  getNodesNeedingProtocolSync,
+  hasCustomNodeProtocols,
+  syncAllNodeProtocols
+} from '../../src/renderer/src/database/ldf/syncNodeProtocol'
+
+function makeLdf(protocols: Record<string, string>): LDF {
+  const nodeAttrs: Record<string, NodeAttrDef> = {}
+  for (const [name, LIN_protocol] of Object.entries(protocols)) {
+    nodeAttrs[name] = { LIN_protocol } as NodeAttrDef
+  }
+  return { nodeAttrs } as LDF
+}
+
+describe('syncNodeProtocol', () => {
+  it('lists nodes whose Protocol differs from the target version', () => {
+    const ldf = makeLdf({ Motor1: '2.1', Motor2: '2.2', Motor3: '' })
+    expect(getNodesNeedingProtocolSync(ldf, '2.2').sort()).toEqual(['Motor1', 'Motor3'])
+    expect(getNodesNeedingProtocolSync(ldf, '2.1')).toEqual(['Motor2', 'Motor3'])
+  })
+
+  it('treats empty nodeAttrs as nothing to sync', () => {
+    expect(getNodesNeedingProtocolSync({ nodeAttrs: {} } as LDF, '2.2')).toEqual([])
+    expect(getNodeProtocolSyncDecision({ nodeAttrs: {} } as LDF, '2.2', '2.1')).toBe('none')
+  })
+
+  it('detects nodes customized away from the previous global version', () => {
+    expect(hasCustomNodeProtocols(makeLdf({ Motor1: '2.1', Motor2: '2.1' }), '2.1')).toBe(false)
+    expect(hasCustomNodeProtocols(makeLdf({ Motor1: '2.1', Motor2: '' }), '2.1')).toBe(false)
+    expect(hasCustomNodeProtocols(makeLdf({ Motor1: '2.1', Motor2: '2.2' }), '2.1')).toBe(true)
+  })
+
+  it('auto-syncs when every node still follows the previous global version', () => {
+    const ldf = makeLdf({ Motor1: '2.1', Motor2: '2.1' })
+    expect(getNodeProtocolSyncDecision(ldf, '2.2', '2.1')).toBe('auto')
+  })
+
+  it('auto-syncs empty Protocol values together with matching nodes', () => {
+    const ldf = makeLdf({ Motor1: '2.1', Motor2: '' })
+    expect(getNodeProtocolSyncDecision(ldf, '2.2', '2.1')).toBe('auto')
+  })
+
+  it('asks for confirmation when a node Protocol was customized', () => {
+    const ldf = makeLdf({ Motor1: '2.1', Motor2: '2.0' })
+    expect(getNodeProtocolSyncDecision(ldf, '2.2', '2.1')).toBe('confirm')
+  })
+
+  it('does nothing when every node already matches the new version', () => {
+    const ldf = makeLdf({ Motor1: '2.2', Motor2: '2.2' })
+    expect(getNodeProtocolSyncDecision(ldf, '2.2', '2.1')).toBe('none')
+  })
+
+  it('does nothing when the new version is empty', () => {
+    const ldf = makeLdf({ Motor1: '2.1' })
+    expect(getNodeProtocolSyncDecision(ldf, '', '2.1')).toBe('none')
+  })
+
+  it('writes the new version onto every node Protocol', () => {
+    const ldf = makeLdf({ Motor1: '2.1', Motor2: '2.0', Motor3: '' })
+    syncAllNodeProtocols(ldf, '2.2')
+    expect(ldf.nodeAttrs.Motor1.LIN_protocol).toBe('2.2')
+    expect(ldf.nodeAttrs.Motor2.LIN_protocol).toBe('2.2')
+    expect(ldf.nodeAttrs.Motor3.LIN_protocol).toBe('2.2')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/ecubus/EcuBus-Pro/issues/436

Changing **LIN Version** on the LDF Database General tab did not update each node's **Protocol**. After importing an LDF with several slaves, users had to open every node and pick the new version by hand.

## Behavior
- Changing General **LIN Version** (`LIN_protocol_version`) updates every node's `LIN_protocol`.
- If every node still matches the previous global version (or is empty), the sync is automatic.
- If any node was customized to a different Protocol, a confirm dialog asks whether to overwrite all node Protocol values. **Yes** syncs; **No** keeps the node values and only changes the global version.
- The dialog is attached to the app window so Yes/No stay visible above the Message panel.
- New slave nodes inherit the current global LIN protocol version instead of an empty Protocol.

LIN Lang Version is left independent: in LDF it is the file language version, not node Protocol.

## Test plan
- Unit tests in `test/ldf/syncNodeProtocol.spec.ts` cover auto-sync, confirm, and no-op cases (`9` passed).
- Manual in the Electron app: Others → Database → Add LIN → import an LDF with Motor1/Motor2 at 2.1.
  - Change LIN Version 2.1 → 2.2: both node Protocol values become 2.2 with no dialog.
  - Customize one node, change LIN Version again: dialog appears. Yes syncs all nodes; No leaves node Protocol unchanged.

[Confirm dialog with Yes and No visible](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_node_protocol_confirm_dialog.webp)
[Nodes Protocol after auto-sync to 2.2](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnodes_protocol_after_auto_sync.webp)
[Nodes Protocol after Yes sync](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnodes_protocol_after_yes_sync.webp)
[Nodes Protocol after No keeps mixed versions](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnodes_protocol_after_no.webp)

[lin_version_auto_syncs_node_protocol.mp4](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flin_version_auto_syncs_node_protocol.mp4)
[lin_version_confirm_dialog_yes_syncs_protocols.mp4](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flin_version_confirm_dialog_yes_syncs_protocols.mp4)
[lin_version_confirm_no_keeps_node_protocols.mp4](https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flin_version_confirm_no_keeps_node_protocols.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0a9c065-eb45-4f5b-9d47-cf2fffe0fc9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

