### PR TITLE
feat(docan): add VCAN USB and VKGS USB adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
         "vector",
         "slcan",
         "ecubus",
-        "candle"
+        "candle",
+        "vcan_usb",
+        "vkgs_usb"
       ],
       "linux": [
         "simulate",

--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -1132,7 +1132,9 @@
         "toomoss": "TOOMOSS",
         "vector": "VECTOR",
         "slcan": "SLCAN",
-        "candle": "CANDLE"
+        "candle": "CANDLE",
+        "vcan_usb": "VCAN USB",
+        "vkgs_usb": "VKGS USB"
       },
       "canNode": {
         "sections": {

--- a/src/cli/rpc/canService.ts
+++ b/src/cli/rpc/canService.ts
@@ -83,7 +83,9 @@ const VENDORS: CanVendor[] = [
   'vector',
   'slcan',
   'ecubus',
-  'candle'
+  'candle',
+  'vcan_usb',
+  'vkgs_usb'
 ]
 
 function loadNativeCan(): typeof import('src/main/docan/can') {

--- a/src/main/docan/binding.gyp
+++ b/src/main/docan/binding.gyp
@@ -1,6 +1,52 @@
 {
     'targets': [   
         {
+            'target_name': 'usbcan',
+            'conditions': [
+                ['OS=="win"', {
+                    'include_dirs': [
+                        "<!@(node -p \"require('node-addon-api').include\")"
+                    ],
+                    'defines': [
+                        'NAPI_CPP_EXCEPTIONS'
+                    ],
+                    'sources': [
+                        './usbcan/native/transport_win.cpp'
+                    ],
+                    'libraries': [
+                        'winusb.lib',
+                        'setupapi.lib'
+                    ],
+                    'msvs_settings': {
+                        'VCCLCompilerTool': {
+                            'ExceptionHandling': 1
+                        }
+                    }
+                }, 'OS=="linux"', {
+                    'include_dirs': [
+                        "<!@(node -p \"require('node-addon-api').include\")"
+                    ],
+                    'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+                    'cflags!': [ '-fno-exceptions' ],
+                    'cflags_cc!': [ '-fno-exceptions' ],
+                    'sources': [ './fake_linux.cxx' ],
+                    'cflags': [ '-fexceptions' ],
+                    'cflags_cc': [ '-fexceptions' ]
+                }, 'OS=="mac"', {
+                    'include_dirs': [
+                        "<!@(node -p \"require('node-addon-api').include\")"
+                    ],
+                    'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+                    'cflags!': [ '-fno-exceptions' ],
+                    'cflags_cc!': [ '-fno-exceptions' ],
+                    'sources': [ './fake_mac.cxx' ],
+                    'xcode_settings': {
+                        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                    }
+                }]
+            ]
+        },
+        {
             'target_name': 'candle',
             'conditions': [
                 ['OS=="win"', {

--- a/src/main/docan/can.ts
+++ b/src/main/docan/can.ts
@@ -11,6 +11,8 @@ import { CanBaseInfo } from '../share/can'
 import { CanBase } from './base'
 import { SLCAN_CAN } from './slcan'
 import { Candle_CAN } from './candle'
+import { VCAN_USB_CAN } from './vcan_usb'
+import { VKGS_USB_CAN } from './vkgs_usb'
 
 const libPath = path.dirname(dllLib)
 PEAK_TP.loadDllPath(libPath)
@@ -38,6 +40,10 @@ export function openCanDevice(canDevice: CanBaseInfo) {
     canBase = new SLCAN_CAN(canDevice)
   } else if (canDevice.vendor == 'candle') {
     canBase = new Candle_CAN(canDevice)
+  } else if (canDevice.vendor == 'vcan_usb') {
+    canBase = new VCAN_USB_CAN(canDevice)
+  } else if (canDevice.vendor == 'vkgs_usb') {
+    canBase = new VKGS_USB_CAN(canDevice)
   }
 
   return canBase
@@ -61,6 +67,10 @@ export function getCanVersion(vendor: string) {
     return SLCAN_CAN.getLibVersion()
   } else if (vendor === 'CANDLE') {
     return Candle_CAN.getLibVersion()
+  } else if (vendor === 'VCAN_USB') {
+    return VCAN_USB_CAN.getLibVersion()
+  } else if (vendor === 'VKGS_USB') {
+    return VKGS_USB_CAN.getLibVersion()
   } else {
     return 'Not supported'
   }
@@ -84,6 +94,10 @@ export function getCanDevices(vendor: string) {
     return SLCAN_CAN.getValidDevices()
   } else if (vendor === 'CANDLE') {
     return Candle_CAN.getValidDevices()
+  } else if (vendor === 'VCAN_USB') {
+    return VCAN_USB_CAN.getValidDevices()
+  } else if (vendor === 'VKGS_USB') {
+    return VKGS_USB_CAN.getValidDevices()
   } else {
     return []
   }

--- a/src/main/docan/usbcan/device.ts
+++ b/src/main/docan/usbcan/device.ts
@@ -1,0 +1,273 @@
+import { CanBaseInfo, CandleCapability } from '../../share/can'
+import { UsbCanTransport } from './transport'
+import {
+  makeVcanControlPayload,
+  stripVcanControlPayload,
+  USB_CAN_FEATURE_BERR_REPORTING,
+  USB_CAN_FEATURE_BT_CONST_EXT,
+  USB_CAN_FEATURE_FD,
+  USB_CAN_FEATURE_HW_TIMESTAMP,
+  USB_CAN_FEATURE_TERMINATION,
+  USB_CAN_MODE_BERR_REPORTING,
+  USB_CAN_MODE_FD,
+  USB_CAN_MODE_HW_TIMESTAMP,
+  USB_CAN_MODE_LISTEN_ONLY,
+  UsbCanProtocol,
+  VcanDecoder,
+  VkgsDecoder,
+  WireDecoder
+} from './wire'
+
+export const USB_CAN_VID = 0x1d50
+export const VCAN_USB_PID = 0x6080
+export const VKGS_USB_PID = 0x606f
+
+export interface UsbCanDeviceInfo {
+  swVersion: number
+  hwVersion: number
+  uid: number[]
+  uuid: number[]
+}
+
+export interface UsbCanCapabilities {
+  nominal: CandleCapability
+  data?: CandleCapability
+}
+
+const REQUEST = {
+  vcan_usb: {
+    mode: 1,
+    btConst: 16,
+    btConstExt: 17,
+    bitTiming: 24,
+    dataBitTiming: 25,
+    deviceInfo: 33,
+    termination: 37
+  },
+  vkgs_usb: {
+    hostFormat: 0,
+    bitTiming: 1,
+    mode: 2,
+    btConst: 4,
+    deviceConfig: 5,
+    dataBitTiming: 10,
+    btConstExt: 11,
+    fallbackSetTermination: 12,
+    fallbackGetTermination: 13,
+    deviceInfo: 33,
+    termination: 37
+  }
+} as const
+
+const FALLBACK_CAPABILITY: CandleCapability = {
+  feature: USB_CAN_FEATURE_FD | USB_CAN_FEATURE_BT_CONST_EXT,
+  fclk_can: 80_000_000,
+  tseg1_min: 2,
+  tseg1_max: 256,
+  tseg2_min: 1,
+  tseg2_max: 128,
+  sjw_max: 128,
+  brp_min: 1,
+  brp_max: 512,
+  brp_inc: 1
+}
+
+function sleep(milliseconds: number) {
+  if (milliseconds <= 0) return
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+}
+
+function readCapabilityFields(buffer: Buffer, offset: number, feature: number, clock: number) {
+  if (buffer.length < offset + 32) throw new Error('USB CAN capability response is too short')
+  return {
+    feature,
+    fclk_can: clock || 80_000_000,
+    tseg1_min: buffer.readUInt32LE(offset),
+    tseg1_max: buffer.readUInt32LE(offset + 4),
+    tseg2_min: buffer.readUInt32LE(offset + 8),
+    tseg2_max: buffer.readUInt32LE(offset + 12),
+    sjw_max: buffer.readUInt32LE(offset + 16),
+    brp_min: buffer.readUInt32LE(offset + 20),
+    brp_max: buffer.readUInt32LE(offset + 24),
+    brp_inc: buffer.readUInt32LE(offset + 28)
+  }
+}
+
+export class UsbCanProtocolDevice {
+  readonly channel: number
+  readonly protocol: UsbCanProtocol
+  readonly transport: UsbCanTransport
+  private capabilities?: UsbCanCapabilities
+  timestampsEnabled = false
+  fdMode = false
+
+  constructor(protocol: UsbCanProtocol, transport: UsbCanTransport, channel: number) {
+    this.protocol = protocol
+    this.transport = transport
+    this.channel = channel
+    if (transport.interfaceNumber !== channel) {
+      throw new Error(
+        `USB interface mismatch: selected channel ${channel}, opened ${transport.interfaceNumber}`
+      )
+    }
+  }
+
+  private setControl(request: number, payload: Buffer) {
+    if (this.protocol === 'vcan_usb') {
+      this.transport.controlOut(
+        request,
+        0,
+        this.channel,
+        makeVcanControlPayload(this.channel, request, payload)
+      )
+    } else {
+      this.transport.controlOut(request, this.channel, this.channel, payload)
+      sleep(5)
+    }
+  }
+
+  private getControl(request: number, payloadLength: number): Buffer {
+    if (this.protocol === 'vcan_usb') {
+      const response = this.transport.controlIn(request | 0x80, 0, this.channel, payloadLength + 8)
+      return stripVcanControlPayload(this.channel, request, response)
+    }
+    return this.transport.controlIn(request, 0, this.channel, payloadLength)
+  }
+
+  readCapabilities(): UsbCanCapabilities {
+    if (this.capabilities) return this.capabilities
+    const request = REQUEST[this.protocol]
+    const response = this.getControl(request.btConst, 40)
+    const feature = response.readUInt32LE(0)
+    const clock = response.readUInt32LE(4)
+    const nominal = readCapabilityFields(response, 8, feature, clock)
+    let data: CandleCapability | undefined
+    if (feature & USB_CAN_FEATURE_FD && feature & USB_CAN_FEATURE_BT_CONST_EXT) {
+      const extended = this.getControl(request.btConstExt, 72)
+      const extendedFeature = extended.readUInt32LE(0)
+      const extendedClock = extended.readUInt32LE(4)
+      data = readCapabilityFields(extended, 40, extendedFeature, extendedClock)
+    }
+    this.capabilities = { nominal, data }
+    return this.capabilities
+  }
+
+  readDeviceInfo(): UsbCanDeviceInfo {
+    const response = this.getControl(REQUEST[this.protocol].deviceInfo, 40)
+    return {
+      swVersion: response.readUInt32LE(0),
+      hwVersion: response.readUInt32LE(4),
+      uid: Array.from({ length: 4 }, (_, index) => response.readUInt32LE(8 + index * 4)),
+      uuid: Array.from({ length: 4 }, (_, index) => response.readUInt32LE(24 + index * 4))
+    }
+  }
+
+  getTermination(): boolean {
+    try {
+      return this.getControl(REQUEST[this.protocol].termination, 4).readUInt32LE(0) !== 0
+    } catch (error) {
+      if (this.protocol !== 'vkgs_usb') throw error
+      return this.getControl(REQUEST.vkgs_usb.fallbackGetTermination, 4).readUInt32LE(0) !== 0
+    }
+  }
+
+  setTermination(enabled: boolean) {
+    const payload = Buffer.alloc(4)
+    payload.writeUInt32LE(enabled ? 1 : 0)
+    try {
+      this.setControl(REQUEST[this.protocol].termination, payload)
+    } catch (error) {
+      if (this.protocol !== 'vkgs_usb') throw error
+      this.setControl(REQUEST.vkgs_usb.fallbackSetTermination, payload)
+    }
+  }
+
+  private setBitTiming(info: CanBaseInfo, dataPhase: boolean) {
+    const timing = dataPhase ? info.bitratefd : info.bitrate
+    if (!timing) throw new Error('CAN FD data timing is not configured')
+    if (Math.min(timing.preScaler, timing.timeSeg1, timing.timeSeg2, timing.sjw) < 1) {
+      throw new Error('CAN timing values must be at least 1')
+    }
+    const payload = Buffer.alloc(20)
+    payload.writeUInt32LE(0, 0)
+    payload.writeUInt32LE(timing.timeSeg1 - 1, 4)
+    payload.writeUInt32LE(timing.timeSeg2 - 1, 8)
+    payload.writeUInt32LE(timing.sjw - 1, 12)
+    payload.writeUInt32LE(timing.preScaler - 1, 16)
+    const request = dataPhase
+      ? REQUEST[this.protocol].dataBitTiming
+      : REQUEST[this.protocol].bitTiming
+    this.setControl(request, payload)
+  }
+
+  private setMode(mode: number, flags: number) {
+    const payload = Buffer.alloc(8)
+    payload.writeUInt32LE(mode, 0)
+    payload.writeUInt32LE(flags, 4)
+    this.setControl(REQUEST[this.protocol].mode, payload)
+    if (this.protocol === 'vkgs_usb') sleep(150)
+  }
+
+  configure(info: CanBaseInfo, termination: boolean): WireDecoder {
+    const capabilities = this.readCapabilities()
+    const configuredClock = Number(info.bitrate.clock) * 1_000_000
+    if (!Number.isFinite(configuredClock) || configuredClock !== capabilities.nominal.fclk_can) {
+      throw new Error(
+        `CAN clock mismatch: configured ${configuredClock || 0} Hz, device reports ${capabilities.nominal.fclk_can} Hz`
+      )
+    }
+    if (info.canfd && !(capabilities.nominal.feature & USB_CAN_FEATURE_FD)) {
+      throw new Error('CAN FD is enabled, but the selected USB CAN device does not support CAN FD')
+    }
+
+    this.setMode(0, 0)
+    if (this.protocol === 'vkgs_usb') {
+      const hostFormat = Buffer.alloc(4)
+      hostFormat.writeUInt32LE(0x0000beef)
+      this.setControl(REQUEST.vkgs_usb.hostFormat, hostFormat)
+    }
+    this.setBitTiming(info, false)
+    if (info.canfd) this.setBitTiming(info, true)
+    try {
+      this.setTermination(termination)
+    } catch (error) {
+      if (termination || capabilities.nominal.feature & USB_CAN_FEATURE_TERMINATION) {
+        throw error
+      }
+    }
+
+    let flags = info.silent ? USB_CAN_MODE_LISTEN_ONLY : 0
+    if (info.canfd) flags |= USB_CAN_MODE_FD
+    if (capabilities.nominal.feature & USB_CAN_FEATURE_BERR_REPORTING) {
+      flags |= USB_CAN_MODE_BERR_REPORTING
+    }
+    if (
+      this.protocol === 'vkgs_usb' &&
+      capabilities.nominal.feature & USB_CAN_FEATURE_HW_TIMESTAMP
+    ) {
+      flags |= USB_CAN_MODE_HW_TIMESTAMP
+      this.timestampsEnabled = true
+    }
+    this.fdMode = info.canfd
+    this.setMode(1, flags)
+    return this.protocol === 'vcan_usb'
+      ? new VcanDecoder(this.channel)
+      : new VkgsDecoder(this.timestampsEnabled, this.channel)
+  }
+
+  stop() {
+    this.setMode(0, 0)
+    if (this.protocol === 'vkgs_usb') {
+      const hostFormat = Buffer.alloc(4)
+      hostFormat.writeUInt32LE(0x0000beef)
+      this.setControl(REQUEST.vkgs_usb.hostFormat, hostFormat)
+    }
+  }
+
+  static fallbackCapabilities(): UsbCanCapabilities {
+    return {
+      nominal: { ...FALLBACK_CAPABILITY },
+      data: { ...FALLBACK_CAPABILITY }
+    }
+  }
+}

--- a/src/main/docan/usbcan/index.ts
+++ b/src/main/docan/usbcan/index.ts
@@ -1,0 +1,518 @@
+import { EventEmitter } from 'events'
+import { cloneDeep } from 'lodash'
+import {
+  CAN_ERROR_ID,
+  CAN_ID_TYPE,
+  CanBaseInfo,
+  CanDevice,
+  CanError,
+  CanMessage,
+  CanMsgType,
+  getTsUs
+} from '../../share/can'
+import { CanLOG } from '../../log'
+import { CanBase } from '../base'
+import {
+  USB_CAN_VID,
+  UsbCanCapabilities,
+  UsbCanDeviceInfo,
+  UsbCanProtocolDevice,
+  VCAN_USB_PID,
+  VKGS_USB_PID
+} from './device'
+import { NativeTransportError, UsbCanTransport } from './transport'
+import {
+  encodeVcanFrame,
+  encodeVkgsFrame,
+  normalizeCanData,
+  USB_CAN_FEATURE_FD,
+  USB_CAN_FEATURE_TERMINATION,
+  UsbCanEvent,
+  UsbCanFrame,
+  UsbCanProtocol,
+  WireDecoder
+} from './wire'
+
+interface PendingTransmit {
+  resolve: (timestamp: number) => void
+  reject: (error: CanError) => void
+  id: number
+  msgType: CanMsgType
+  data: Buffer
+  extra?: { database?: string; name?: string }
+}
+
+interface PendingRead {
+  reject: (error: CanError) => void
+  msgType: CanMsgType
+  eventName: string
+  listener: (message: CanMessage | CanError) => void
+  timer: NodeJS.Timeout
+}
+
+const STATE_NAMES = [
+  'error-active',
+  'error-warning',
+  'error-passive',
+  'bus-off',
+  'stopped',
+  'sleeping'
+]
+
+const ERROR_NAMES = ['none', 'stuff', 'form', 'ack', 'bit1', 'bit0', 'crc']
+
+function splitHandle(handle: unknown): { path: string; channel: number } {
+  const value = String(handle)
+  const separator = value.lastIndexOf('|')
+  if (separator <= 0) throw new Error('invalid USB CAN handle')
+  const channel = Number(value.slice(separator + 1))
+  if (!Number.isInteger(channel) || channel < 0 || channel > 255) {
+    throw new Error(`invalid USB CAN channel in handle: ${value}`)
+  }
+  return { path: value.slice(0, separator), channel }
+}
+
+function pidFor(protocol: UsbCanProtocol) {
+  return protocol === 'vcan_usb' ? VCAN_USB_PID : VKGS_USB_PID
+}
+
+function formatVersion(version: number) {
+  return `${(version >>> 24) & 0xff}.${(version >>> 16) & 0xff}.${
+    (version >>> 8) & 0xff
+  }.${version & 0xff}`
+}
+
+function makeExtra(
+  protocol: UsbCanProtocol,
+  capabilities: UsbCanCapabilities,
+  deviceInfo?: UsbCanDeviceInfo,
+  termination?: boolean
+) {
+  return {
+    usbCan: {
+      protocol,
+      cap: capabilities.nominal,
+      dataCap: capabilities.data,
+      fdSupported: !!(capabilities.nominal.feature & USB_CAN_FEATURE_FD),
+      Res:
+        !!(capabilities.nominal.feature & USB_CAN_FEATURE_TERMINATION) || termination !== undefined,
+      termination,
+      swVersion: deviceInfo?.swVersion,
+      hwVersion: deviceInfo?.hwVersion
+    }
+  }
+}
+
+export function getUsbCanDevices(protocol: UsbCanProtocol): CanDevice[] {
+  const interfaces = UsbCanTransport.listDevices(USB_CAN_VID, pidFor(protocol))
+  return interfaces.map((item, index) => {
+    let capabilities = UsbCanProtocolDevice.fallbackCapabilities()
+    let deviceInfo: UsbCanDeviceInfo | undefined
+    let termination: boolean | undefined
+    let busy = item.busy
+
+    if (!busy) {
+      let transport: UsbCanTransport | undefined
+      try {
+        transport = UsbCanTransport.open(
+          item.path,
+          () => {},
+          () => {},
+          () => {}
+        )
+        const device = new UsbCanProtocolDevice(protocol, transport, item.interfaceNumber)
+        capabilities = device.readCapabilities()
+        try {
+          deviceInfo = device.readDeviceInfo()
+        } catch (error) {
+          sysLog.warn(
+            `${protocol} device-info query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+        try {
+          termination = device.getTermination()
+        } catch (error) {
+          sysLog.warn(
+            `${protocol} termination query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      } catch (error) {
+        busy = true
+        sysLog.warn(
+          `${protocol} probe failed for channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      } finally {
+        transport?.close()
+      }
+    }
+
+    return {
+      label: `${item.label} CH${item.interfaceNumber}`,
+      id: `${protocol}-${index}-ch${item.interfaceNumber}`,
+      handle: `${item.path}|${item.interfaceNumber}`,
+      serialNumber: item.path,
+      busy,
+      extra: makeExtra(protocol, capabilities, deviceInfo, termination)
+    }
+  })
+}
+
+export abstract class UsbCanBase extends CanBase {
+  readonly event = new EventEmitter()
+  readonly info: CanBaseInfo
+  readonly log: CanLOG
+  readonly protocol: UsbCanProtocol
+  closed = false
+
+  private readonly transport: UsbCanTransport
+  private readonly device: UsbCanProtocolDevice
+  private readonly decoder: WireDecoder
+  private readonly startTime = getTsUs()
+  private timestampOffset?: number
+  private nextToken = 1
+  private nextRead = 1
+  private lastState = -1
+  private fatalTransportError = false
+  private readonly pendingTransmits = new Map<number, PendingTransmit>()
+  private readonly pendingReads = new Map<number, PendingRead>()
+
+  protected constructor(info: CanBaseInfo, protocol: UsbCanProtocol) {
+    super()
+    this.info = cloneDeep(info)
+    this.protocol = protocol
+    this.log = new CanLOG(protocol.toUpperCase(), info.name, info.id, this.event)
+    const { path, channel } = splitHandle(info.handle)
+    this.transport = UsbCanTransport.open(
+      path,
+      (data) => this.receive(data),
+      (error) => this.transportError(error),
+      (result) => this.transmitComplete(result)
+    )
+    this.device = new UsbCanProtocolDevice(protocol, this.transport, channel)
+    try {
+      const capabilities = this.device.readCapabilities()
+      this.validateTiming(info, capabilities)
+      try {
+        const deviceInfo = this.device.readDeviceInfo()
+        sysLog.info(
+          `${protocol} ${info.name}: SW ${formatVersion(deviceInfo.swVersion)}, HW ${formatVersion(deviceInfo.hwVersion)}, channel ${channel}`
+        )
+      } catch (error) {
+        sysLog.warn(
+          `${protocol} ${info.name}: device-info query unavailable: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+      const termination = protocol === 'vcan_usb' ? info.vcanUsbRes : info.vkgsUsbRes
+      this.decoder = this.device.configure(info, !!termination)
+      this.transport.startReceive()
+      this.attachCanMessage(this.busloadCb)
+    } catch (error) {
+      try {
+        this.device.stop()
+      } catch {
+        // Preserve the original configuration/open error.
+      }
+      this.transport.close()
+      this.log.close()
+      throw error
+    }
+  }
+
+  private validateTiming(info: CanBaseInfo, capabilities: UsbCanCapabilities) {
+    const validate = (
+      name: string,
+      timing: CanBaseInfo['bitrate'],
+      cap: typeof capabilities.nominal
+    ) => {
+      const clock = Number(timing.clock) * 1_000_000
+      const calculated = Math.floor(
+        clock / (timing.preScaler * (1 + timing.timeSeg1 + timing.timeSeg2))
+      )
+      if (clock !== cap.fclk_can) {
+        throw new Error(`${name} clock must be ${cap.fclk_can / 1_000_000} MHz`)
+      }
+      if (Math.abs(calculated - timing.freq) / timing.freq > 0.01) {
+        throw new Error(`${name} timing calculates ${calculated} Hz, expected ${timing.freq} Hz`)
+      }
+      if (timing.timeSeg1 < cap.tseg1_min || timing.timeSeg1 > cap.tseg1_max) {
+        throw new Error(`${name} timeSeg1 is outside ${cap.tseg1_min}..${cap.tseg1_max}`)
+      }
+      if (timing.timeSeg2 < cap.tseg2_min || timing.timeSeg2 > cap.tseg2_max) {
+        throw new Error(`${name} timeSeg2 is outside ${cap.tseg2_min}..${cap.tseg2_max}`)
+      }
+      if (timing.sjw < 1 || timing.sjw > cap.sjw_max) {
+        throw new Error(`${name} sjw is outside 1..${cap.sjw_max}`)
+      }
+      if (timing.preScaler < cap.brp_min || timing.preScaler > cap.brp_max) {
+        throw new Error(`${name} prescaler is outside ${cap.brp_min}..${cap.brp_max}`)
+      }
+      if ((timing.preScaler - cap.brp_min) % Math.max(1, cap.brp_inc) !== 0) {
+        throw new Error(`${name} prescaler does not match the device increment ${cap.brp_inc}`)
+      }
+    }
+
+    validate('CAN', info.bitrate, capabilities.nominal)
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('CAN FD data timing is required')
+      validate('CAN FD', info.bitratefd, capabilities.data || capabilities.nominal)
+    }
+  }
+
+  private receive(transfer: Buffer) {
+    if (this.closed) return
+    try {
+      const decoded = this.decoder.push(transfer)
+      for (const event of decoded.events) this.handleWireEvent(event)
+      for (const frame of decoded.frames) this.handleFrame(frame)
+    } catch (error) {
+      this.decoder.reset()
+      this.log.error(
+        getTsUs() - this.startTime,
+        `USB receive framing error: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  private handleFrame(frame: UsbCanFrame) {
+    let timestamp = getTsUs() - this.startTime
+    if (frame.timestampUs > 0) {
+      if (this.timestampOffset === undefined) {
+        this.timestampOffset = frame.timestampUs - timestamp
+      }
+      timestamp = frame.timestampUs - this.timestampOffset
+    }
+    const msgType: CanMsgType = {
+      idType: frame.extended ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+      canfd: frame.fd,
+      brs: frame.brs,
+      remote: frame.remote
+    }
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'IN',
+      id: frame.id,
+      data: frame.remote ? Buffer.alloc(0) : frame.data,
+      ts: timestamp,
+      msgType,
+      database: this.info.database
+    }
+    this.log.canBase(message)
+    this.event.emit(this.getReadBaseId(frame.id, msgType), message)
+  }
+
+  private handleWireEvent(event: UsbCanEvent) {
+    if (event.kind === 'state') {
+      if (event.state === this.lastState) return
+      this.lastState = event.state
+      if (event.state !== 0) {
+        this.log.error(
+          event.timestampUs || getTsUs() - this.startTime,
+          `CAN state ${STATE_NAMES[event.state] || event.state}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+        )
+      }
+      return
+    }
+    if (event.errorCode !== 0) {
+      this.log.error(
+        getTsUs() - this.startTime,
+        `CAN bus error ${ERROR_NAMES[event.errorCode] || event.errorCode}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+      )
+    }
+  }
+
+  private transmitComplete(result: { token: number; ok: boolean; error?: string }) {
+    const pending = this.pendingTransmits.get(result.token)
+    if (!pending) return
+    this.pendingTransmits.delete(result.token)
+    if (!result.ok) {
+      pending.reject(
+        new CanError(CAN_ERROR_ID.CAN_INTERNAL_ERROR, pending.msgType, pending.data, result.error)
+      )
+      return
+    }
+    const timestamp = getTsUs() - this.startTime
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'OUT',
+      id: pending.id,
+      data: pending.data,
+      ts: timestamp,
+      msgType: pending.msgType,
+      database: pending.extra?.database,
+      name: pending.extra?.name
+    }
+    this.log.canBase(message)
+    pending.resolve(timestamp)
+  }
+
+  private transportError(error: NativeTransportError) {
+    if (this.closed) return
+    this.fatalTransportError = true
+    this.log.error(getTsUs() - this.startTime, error.message)
+    this.rejectAll(CAN_ERROR_ID.CAN_INTERNAL_ERROR, error)
+    setImmediate(() => this.close())
+  }
+
+  private rejectAll(errorId: CAN_ERROR_ID, cause?: unknown) {
+    for (const pending of this.pendingTransmits.values()) {
+      pending.reject(
+        new CanError(
+          errorId,
+          pending.msgType,
+          pending.data,
+          cause instanceof Error ? cause.message : cause === undefined ? undefined : String(cause)
+        )
+      )
+    }
+    this.pendingTransmits.clear()
+    for (const pending of this.pendingReads.values()) {
+      clearTimeout(pending.timer)
+      this.event.off(pending.eventName, pending.listener)
+      pending.reject(new CanError(errorId, pending.msgType))
+    }
+    this.pendingReads.clear()
+  }
+
+  setOption(cmd: string, value: unknown): unknown {
+    return this._setOption(cmd, value)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    this.rejectAll(CAN_ERROR_ID.CAN_BUS_CLOSED)
+    if (!this.fatalTransportError) {
+      try {
+        this.device.stop()
+      } catch (error) {
+        sysLog.warn(
+          `${this.protocol} stop failed: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    this.transport.close()
+    this.detachCanMessage(this.busloadCb)
+    this.log.close()
+    this._close()
+  }
+
+  writeBase(
+    id: number,
+    msgType: CanMsgType,
+    data: Buffer,
+    extra?: { database?: string; name?: string }
+  ): Promise<number> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType, data))
+    }
+    const maximumId = msgType.idType === CAN_ID_TYPE.EXTENDED ? 0x1fffffff : 0x7ff
+    if (!Number.isInteger(id) || id < 0 || id > maximumId || (msgType.brs && !msgType.canfd)) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_PARAM_ERROR, msgType, data))
+    }
+
+    let normalized: Buffer
+    try {
+      normalized = normalizeCanData(data, msgType.canfd)
+    } catch (error) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          msgType,
+          data,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    const frame: UsbCanFrame = {
+      id,
+      data: normalized,
+      fd: msgType.canfd,
+      brs: msgType.brs,
+      extended: msgType.idType === CAN_ID_TYPE.EXTENDED,
+      remote: msgType.remote,
+      timestampUs: 0
+    }
+    const packet =
+      this.protocol === 'vcan_usb'
+        ? encodeVcanFrame(this.device.channel, frame)
+        : encodeVkgsFrame(this.device.channel, frame, this.device.fdMode)
+
+    return new Promise<number>((resolve, reject) => {
+      const token = this.nextTransmitToken()
+      this.pendingTransmits.set(token, { resolve, reject, id, msgType, data: normalized, extra })
+      try {
+        const queued = this.transport.write(
+          packet,
+          token,
+          this.protocol === 'vkgs_usb' ? 5 : 0,
+          this.protocol === 'vkgs_usb' ? 10 : 0
+        )
+        if (!queued) {
+          this.pendingTransmits.delete(token)
+          reject(
+            new CanError(
+              CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+              msgType,
+              normalized,
+              'USB transmit queue is full'
+            )
+          )
+        }
+      } catch (error) {
+        this.pendingTransmits.delete(token)
+        reject(
+          new CanError(
+            CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+            msgType,
+            normalized,
+            error instanceof Error ? error.message : String(error)
+          )
+        )
+      }
+    })
+  }
+
+  private nextTransmitToken() {
+    while (this.pendingTransmits.has(this.nextToken)) {
+      this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    }
+    const token = this.nextToken
+    this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    return token
+  }
+
+  readBase(
+    id: number,
+    msgType: CanMsgType,
+    timeout: number
+  ): Promise<{ data: Buffer; ts: number }> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType))
+    }
+    const eventName = this.getReadBaseId(id, msgType)
+    const readId = this.nextRead++
+    return new Promise((resolve, reject) => {
+      const listener = (value: CanMessage | CanError) => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        clearTimeout(pending.timer)
+        this.pendingReads.delete(readId)
+        if (value instanceof CanError) reject(value)
+        else resolve({ data: value.data, ts: value.ts! })
+      }
+      const timer = setTimeout(() => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        this.pendingReads.delete(readId)
+        this.event.off(eventName, listener)
+        reject(new CanError(CAN_ERROR_ID.CAN_READ_TIMEOUT, msgType))
+      }, timeout)
+      this.pendingReads.set(readId, { reject, msgType, eventName, listener, timer })
+      this.event.once(eventName, listener)
+    })
+  }
+
+  getReadBaseId(id: number, msgType: CanMsgType): string {
+    return `${id}-${msgType.canfd ? msgType.brs : false}-${msgType.remote}-${msgType.canfd}-${msgType.idType}`
+  }
+}

--- a/src/main/docan/usbcan/native/transport_win.cpp
+++ b/src/main/docan/usbcan/native/transport_win.cpp
@@ -1,0 +1,761 @@
+#include <napi.h>
+
+#include <windows.h>
+#include <setupapi.h>
+#include <winusb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cwctype>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr size_t kTransferSize = 512;
+constexpr size_t kTxQueueLimit = 512;
+constexpr DWORD kIoTimeoutMs = 2000;
+constexpr DWORD kRxPollMs = 100;
+
+struct InterfaceInfo {
+  std::wstring path;
+  std::wstring label;
+  uint8_t number = 0;
+  uint8_t endpointIn = 0;
+  uint8_t endpointOut = 0;
+  bool busy = false;
+};
+
+struct TxJob {
+  uint32_t token = 0;
+  std::vector<uint8_t> bytes;
+  uint32_t delayBeforeMs = 0;
+  uint32_t delayAfterMs = 0;
+};
+
+struct TxResult {
+  uint32_t token = 0;
+  bool ok = false;
+  std::string error;
+};
+
+struct ErrorResult {
+  DWORD code = ERROR_SUCCESS;
+  std::string operation;
+  std::string detail;
+};
+
+std::mutex gDevicesMutex;
+std::map<uint32_t, std::shared_ptr<class UsbTransport>> gDevices;
+std::atomic<uint32_t> gNextHandle{1};
+
+std::wstring ToLower(std::wstring value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](wchar_t ch) { return static_cast<wchar_t>(std::towlower(ch)); });
+  return value;
+}
+
+std::wstring Utf8ToWide(const std::string& value) {
+  if (value.empty()) return {};
+  const int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+                                         static_cast<int>(value.size()), nullptr, 0);
+  if (length <= 0) throw std::runtime_error("invalid UTF-8 device path");
+  std::wstring result(static_cast<size_t>(length), L'\0');
+  MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+                      static_cast<int>(value.size()), result.data(), length);
+  return result;
+}
+
+std::string WideToUtf8(const std::wstring& value) {
+  if (value.empty()) return {};
+  const int length = WideCharToMultiByte(CP_UTF8, 0, value.data(),
+                                         static_cast<int>(value.size()), nullptr, 0,
+                                         nullptr, nullptr);
+  if (length <= 0) return {};
+  std::string result(static_cast<size_t>(length), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()),
+                      result.data(), length, nullptr, nullptr);
+  return result;
+}
+
+std::string WindowsError(const std::string& operation, DWORD code = GetLastError()) {
+  LPWSTR message = nullptr;
+  const DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                      FORMAT_MESSAGE_IGNORE_INSERTS;
+  FormatMessageW(flags, nullptr, code, 0, reinterpret_cast<LPWSTR>(&message), 0, nullptr);
+  std::wstring detail = message ? message : L"unknown error";
+  if (message) LocalFree(message);
+  while (!detail.empty() && (detail.back() == L'\r' || detail.back() == L'\n' ||
+                             detail.back() == L' ')) {
+    detail.pop_back();
+  }
+  std::ostringstream text;
+  text << operation << " failed (WinError " << code << "): " << WideToUtf8(detail);
+  return text.str();
+}
+
+GUID ParseGuid(const wchar_t* text) {
+  GUID guid{};
+  if (CLSIDFromString(text, &guid) != NOERROR) {
+    throw std::runtime_error("invalid device interface GUID");
+  }
+  return guid;
+}
+
+uint8_t InterfaceNumberFromPath(const std::wstring& path) {
+  const std::wstring lower = ToLower(path);
+  const size_t marker = lower.find(L"&mi_");
+  if (marker == std::wstring::npos || marker + 7 > lower.size()) return 0;
+  wchar_t* end = nullptr;
+  const unsigned long value = std::wcstoul(lower.c_str() + marker + 4, &end, 16);
+  return value <= 0xff ? static_cast<uint8_t>(value) : 0;
+}
+
+std::wstring PhysicalInterfaceKey(const std::wstring& path) {
+  const std::wstring lower = ToLower(path);
+  const size_t suffix = lower.rfind(L"#{");
+  return suffix == std::wstring::npos ? lower : lower.substr(0, suffix);
+}
+
+std::vector<InterfaceInfo> EnumerateGuid(const GUID& guid) {
+  std::vector<InterfaceInfo> result;
+  HDEVINFO set = SetupDiGetClassDevsW(&guid, nullptr, nullptr,
+                                      DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+  if (set == INVALID_HANDLE_VALUE) {
+    throw std::runtime_error(WindowsError("SetupDiGetClassDevsW"));
+  }
+
+  for (DWORD index = 0;; ++index) {
+    SP_DEVICE_INTERFACE_DATA interfaceData{};
+    interfaceData.cbSize = sizeof(interfaceData);
+    if (!SetupDiEnumDeviceInterfaces(set, nullptr, &guid, index, &interfaceData)) {
+      const DWORD error = GetLastError();
+      if (error == ERROR_NO_MORE_ITEMS) break;
+      SetupDiDestroyDeviceInfoList(set);
+      throw std::runtime_error(WindowsError("SetupDiEnumDeviceInterfaces", error));
+    }
+
+    DWORD required = 0;
+    SP_DEVINFO_DATA deviceData{};
+    deviceData.cbSize = sizeof(deviceData);
+    SetupDiGetDeviceInterfaceDetailW(set, &interfaceData, nullptr, 0, &required,
+                                     &deviceData);
+    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || required == 0) continue;
+
+    std::vector<uint8_t> detailStorage(required);
+    auto* detail = reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA_W*>(detailStorage.data());
+    detail->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W);
+    if (!SetupDiGetDeviceInterfaceDetailW(set, &interfaceData, detail, required, nullptr,
+                                          &deviceData)) {
+      continue;
+    }
+
+    wchar_t friendlyName[256]{};
+    DWORD propertyType = 0;
+    DWORD propertySize = 0;
+    if (!SetupDiGetDeviceRegistryPropertyW(set, &deviceData, SPDRP_FRIENDLYNAME,
+                                           &propertyType,
+                                           reinterpret_cast<PBYTE>(friendlyName),
+                                           sizeof(friendlyName), &propertySize)) {
+      SetupDiGetDeviceRegistryPropertyW(set, &deviceData, SPDRP_DEVICEDESC,
+                                        &propertyType,
+                                        reinterpret_cast<PBYTE>(friendlyName),
+                                        sizeof(friendlyName), &propertySize);
+    }
+
+    InterfaceInfo item;
+    item.path = detail->DevicePath;
+    item.label = friendlyName[0] ? friendlyName : L"USB CAN interface";
+    item.number = InterfaceNumberFromPath(item.path);
+    result.push_back(std::move(item));
+  }
+
+  SetupDiDestroyDeviceInfoList(set);
+  return result;
+}
+
+bool QueryEndpoints(InterfaceInfo& item) {
+  HANDLE file = CreateFileW(item.path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
+  if (file == INVALID_HANDLE_VALUE) {
+    item.busy = true;
+    return false;
+  }
+
+  WINUSB_INTERFACE_HANDLE usb = nullptr;
+  if (!WinUsb_Initialize(file, &usb)) {
+    item.busy = true;
+    CloseHandle(file);
+    return false;
+  }
+
+  USB_INTERFACE_DESCRIPTOR descriptor{};
+  bool valid = WinUsb_QueryInterfaceSettings(usb, 0, &descriptor) != FALSE;
+  if (valid) {
+    item.number = descriptor.bInterfaceNumber;
+    for (uint8_t index = 0; index < descriptor.bNumEndpoints; ++index) {
+      WINUSB_PIPE_INFORMATION pipe{};
+      if (!WinUsb_QueryPipe(usb, 0, index, &pipe)) {
+        valid = false;
+        break;
+      }
+      if (pipe.PipeType != UsbdPipeTypeBulk) continue;
+      if (USB_ENDPOINT_DIRECTION_IN(pipe.PipeId)) {
+        item.endpointIn = pipe.PipeId;
+      } else {
+        item.endpointOut = pipe.PipeId;
+      }
+    }
+    valid = valid && item.endpointIn != 0 && item.endpointOut != 0;
+  }
+
+  WinUsb_Free(usb);
+  CloseHandle(file);
+  return valid;
+}
+
+std::vector<InterfaceInfo> EnumerateInterfaces(uint16_t vid, uint16_t pid) {
+  // The first GUID is the system WinUSB class. The second is retained for
+  // compatibility with candle/INF installations that expose only that class.
+  const GUID guids[] = {
+      ParseGuid(L"{dee824ef-729b-4a0e-9c14-b7117d33a817}"),
+      ParseGuid(L"{c15b4308-04d3-11e6-b3ea-6057189e6443}"),
+  };
+
+  wchar_t identityBuffer[64]{};
+  swprintf_s(identityBuffer, L"vid_%04x&pid_%04x", vid, pid);
+  const std::wstring identity = ToLower(identityBuffer);
+  std::map<std::wstring, InterfaceInfo> unique;
+
+  for (const GUID& guid : guids) {
+    for (auto& item : EnumerateGuid(guid)) {
+      if (ToLower(item.path).find(identity) == std::wstring::npos) continue;
+      unique.emplace(PhysicalInterfaceKey(item.path), std::move(item));
+    }
+  }
+
+  std::vector<InterfaceInfo> result;
+  result.reserve(unique.size());
+  for (auto& [key, item] : unique) {
+    (void)key;
+    QueryEndpoints(item);
+    result.push_back(std::move(item));
+  }
+  std::sort(result.begin(), result.end(), [](const auto& left, const auto& right) {
+    if (left.path == right.path) return left.number < right.number;
+    return left.path < right.path;
+  });
+  return result;
+}
+
+class UsbTransport : public std::enable_shared_from_this<UsbTransport> {
+ public:
+  UsbTransport(Napi::Env env, const std::wstring& path, Napi::Function rxCallback,
+               Napi::Function errorCallback, Napi::Function txCallback)
+      : path_(path),
+        rxTsfn_(Napi::ThreadSafeFunction::New(env, rxCallback, "usbcan-rx", 4096, 1)),
+        errorTsfn_(Napi::ThreadSafeFunction::New(env, errorCallback, "usbcan-error", 8, 1)),
+        txTsfn_(Napi::ThreadSafeFunction::New(env, txCallback, "usbcan-tx", 1024, 1)) {}
+
+  ~UsbTransport() { Close(); }
+
+  void Open() {
+    file_ = CreateFileW(path_.c_str(), GENERIC_READ | GENERIC_WRITE,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+                        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
+    if (file_ == INVALID_HANDLE_VALUE) {
+      throw std::runtime_error(WindowsError("CreateFileW"));
+    }
+    if (!WinUsb_Initialize(file_, &usb_)) {
+      const std::string error = WindowsError("WinUsb_Initialize");
+      CloseHandle(file_);
+      file_ = INVALID_HANDLE_VALUE;
+      throw std::runtime_error(error);
+    }
+
+    USB_INTERFACE_DESCRIPTOR descriptor{};
+    if (!WinUsb_QueryInterfaceSettings(usb_, 0, &descriptor)) {
+      const std::string error = WindowsError("WinUsb_QueryInterfaceSettings");
+      CloseHandles();
+      throw std::runtime_error(error);
+    }
+    interfaceNumber_ = descriptor.bInterfaceNumber;
+    for (uint8_t index = 0; index < descriptor.bNumEndpoints; ++index) {
+      WINUSB_PIPE_INFORMATION pipe{};
+      if (!WinUsb_QueryPipe(usb_, 0, index, &pipe)) {
+        const std::string error = WindowsError("WinUsb_QueryPipe");
+        CloseHandles();
+        throw std::runtime_error(error);
+      }
+      if (pipe.PipeType != UsbdPipeTypeBulk) continue;
+      if (USB_ENDPOINT_DIRECTION_IN(pipe.PipeId)) {
+        endpointIn_ = pipe.PipeId;
+      } else {
+        endpointOut_ = pipe.PipeId;
+      }
+    }
+    if (endpointIn_ == 0 || endpointOut_ == 0) {
+      CloseHandles();
+      throw std::runtime_error("WinUSB interface has no bulk IN/OUT endpoint pair");
+    }
+
+    UCHAR enabled = TRUE;
+    WinUsb_SetPipePolicy(usb_, endpointIn_, ALLOW_PARTIAL_READS, sizeof(enabled), &enabled);
+    WinUsb_SetPipePolicy(usb_, endpointIn_, AUTO_CLEAR_STALL, sizeof(enabled), &enabled);
+    WinUsb_SetPipePolicy(usb_, endpointOut_, AUTO_CLEAR_STALL, sizeof(enabled), &enabled);
+    txThread_ = std::thread(&UsbTransport::TxLoop, this);
+  }
+
+  uint8_t InterfaceNumber() const { return interfaceNumber_; }
+
+  void StartRx() {
+    bool expected = false;
+    if (!rxStarted_.compare_exchange_strong(expected, true)) return;
+    rxThread_ = std::thread(&UsbTransport::RxLoop, this);
+  }
+
+  std::vector<uint8_t> ControlIn(uint8_t requestType, uint8_t request,
+                                 uint16_t value, uint16_t index, uint16_t length) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    std::vector<uint8_t> result(length);
+    WINUSB_SETUP_PACKET setup{requestType, request, value, index, length};
+    ULONG transferred = 0;
+    if (!WinUsb_ControlTransfer(usb_, setup, result.data(), length, &transferred, nullptr)) {
+      throw std::runtime_error(WindowsError("WinUsb_ControlTransfer(IN)"));
+    }
+    if (transferred != length) {
+      std::ostringstream error;
+      error << "short control read: " << transferred << '/' << length;
+      throw std::runtime_error(error.str());
+    }
+    return result;
+  }
+
+  void ControlOut(uint8_t requestType, uint8_t request, uint16_t value,
+                  uint16_t index, const std::vector<uint8_t>& bytes) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    WINUSB_SETUP_PACKET setup{requestType, request, value, index,
+                              static_cast<USHORT>(bytes.size())};
+    ULONG transferred = 0;
+    auto* data = const_cast<uint8_t*>(bytes.data());
+    if (!WinUsb_ControlTransfer(usb_, setup, data, static_cast<ULONG>(bytes.size()),
+                                &transferred, nullptr)) {
+      throw std::runtime_error(WindowsError("WinUsb_ControlTransfer(OUT)"));
+    }
+    if (transferred != bytes.size()) {
+      std::ostringstream error;
+      error << "short control write: " << transferred << '/' << bytes.size();
+      throw std::runtime_error(error.str());
+    }
+  }
+
+  bool Enqueue(uint32_t token, const uint8_t* data, size_t length,
+               uint32_t delayBeforeMs, uint32_t delayAfterMs) {
+    std::lock_guard<std::mutex> lock(txMutex_);
+    if (closing_ || txQueue_.size() >= kTxQueueLimit) return false;
+    txQueue_.push_back(TxJob{token, std::vector<uint8_t>(data, data + length),
+                             delayBeforeMs, delayAfterMs});
+    txCondition_.notify_one();
+    return true;
+  }
+
+  void Close() {
+    bool expected = false;
+    if (!closing_.compare_exchange_strong(expected, true)) return;
+    txCondition_.notify_all();
+    if (file_ != INVALID_HANDLE_VALUE) CancelIoEx(file_, nullptr);
+    if (rxThread_.joinable()) rxThread_.join();
+    if (txThread_.joinable()) txThread_.join();
+    CloseHandles();
+    rxTsfn_.Release();
+    errorTsfn_.Release();
+    txTsfn_.Release();
+  }
+
+ private:
+  void EnsureOpen() const {
+    if (closing_ || file_ == INVALID_HANDLE_VALUE || usb_ == nullptr) {
+      throw std::runtime_error("WinUSB transport is closed");
+    }
+  }
+
+  void CloseHandles() {
+    if (usb_ != nullptr) {
+      WinUsb_Free(usb_);
+      usb_ = nullptr;
+    }
+    if (file_ != INVALID_HANDLE_VALUE) {
+      CloseHandle(file_);
+      file_ = INVALID_HANDLE_VALUE;
+    }
+  }
+
+  bool ReadOnce(HANDLE event, OVERLAPPED& overlapped, std::vector<uint8_t>& output,
+                DWORD& errorCode) {
+    ResetEvent(event);
+    ZeroMemory(&overlapped, sizeof(overlapped));
+    overlapped.hEvent = event;
+    ULONG transferred = 0;
+    BOOL started = WinUsb_ReadPipe(usb_, endpointIn_, output.data(),
+                                   static_cast<ULONG>(output.size()), &transferred,
+                                   &overlapped);
+    if (started) {
+      output.resize(transferred);
+      return true;
+    }
+    errorCode = GetLastError();
+    if (errorCode != ERROR_IO_PENDING) return false;
+
+    while (!closing_) {
+      const DWORD wait = WaitForSingleObject(event, kRxPollMs);
+      if (wait == WAIT_TIMEOUT) continue;
+      if (wait != WAIT_OBJECT_0) {
+        errorCode = GetLastError();
+        return false;
+      }
+      if (!WinUsb_GetOverlappedResult(usb_, &overlapped, &transferred, FALSE)) {
+        errorCode = GetLastError();
+        return false;
+      }
+      output.resize(transferred);
+      return true;
+    }
+    CancelIoEx(file_, &overlapped);
+    ULONG ignored = 0;
+    WinUsb_GetOverlappedResult(usb_, &overlapped, &ignored, TRUE);
+    errorCode = ERROR_OPERATION_ABORTED;
+    return false;
+  }
+
+  bool WriteOnce(HANDLE event, OVERLAPPED& overlapped,
+                 const std::vector<uint8_t>& bytes, DWORD& errorCode) {
+    ResetEvent(event);
+    ZeroMemory(&overlapped, sizeof(overlapped));
+    overlapped.hEvent = event;
+    ULONG transferred = 0;
+    BOOL started = WinUsb_WritePipe(usb_, endpointOut_,
+                                    const_cast<uint8_t*>(bytes.data()),
+                                    static_cast<ULONG>(bytes.size()), &transferred,
+                                    &overlapped);
+    if (!started) {
+      errorCode = GetLastError();
+      if (errorCode != ERROR_IO_PENDING) return false;
+      const DWORD wait = WaitForSingleObject(event, kIoTimeoutMs);
+      if (wait == WAIT_TIMEOUT) {
+        CancelIoEx(file_, &overlapped);
+        ULONG ignored = 0;
+        WinUsb_GetOverlappedResult(usb_, &overlapped, &ignored, TRUE);
+        errorCode = WAIT_TIMEOUT;
+        return false;
+      }
+      if (wait != WAIT_OBJECT_0 ||
+          !WinUsb_GetOverlappedResult(usb_, &overlapped, &transferred, FALSE)) {
+        errorCode = GetLastError();
+        return false;
+      }
+    }
+    if (transferred != bytes.size()) {
+      errorCode = ERROR_WRITE_FAULT;
+      return false;
+    }
+    return true;
+  }
+
+  void RxLoop() {
+    HANDLE event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (event == nullptr) {
+      ReportError("CreateEventW(RX)", GetLastError());
+      return;
+    }
+    OVERLAPPED overlapped{};
+    while (!closing_) {
+      std::vector<uint8_t> bytes(kTransferSize);
+      DWORD error = ERROR_SUCCESS;
+      if (!ReadOnce(event, overlapped, bytes, error)) {
+        if (!closing_ && error != ERROR_OPERATION_ABORTED) {
+          ReportError("WinUsb_ReadPipe", error);
+        }
+        break;
+      }
+      if (bytes.empty()) continue;
+      auto* payload = new std::vector<uint8_t>(std::move(bytes));
+      const napi_status status = rxTsfn_.NonBlockingCall(
+          payload, [](Napi::Env env, Napi::Function callback,
+                      std::vector<uint8_t>* value) {
+            callback.Call({Napi::Buffer<uint8_t>::Copy(env, value->data(), value->size())});
+            delete value;
+          });
+      if (status != napi_ok) {
+        delete payload;
+        if (!closing_ && status != napi_closing) {
+          ReportError("RX callback queue", ERROR_NOT_ENOUGH_MEMORY);
+        }
+      }
+    }
+    CloseHandle(event);
+  }
+
+  void TxLoop() {
+    HANDLE event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (event == nullptr) {
+      ReportError("CreateEventW(TX)", GetLastError());
+      return;
+    }
+    OVERLAPPED overlapped{};
+    while (true) {
+      TxJob job;
+      {
+        std::unique_lock<std::mutex> lock(txMutex_);
+        txCondition_.wait(lock, [&] { return closing_ || !txQueue_.empty(); });
+        if (closing_ && txQueue_.empty()) break;
+        job = std::move(txQueue_.front());
+        txQueue_.pop_front();
+      }
+      if (!closing_ && job.delayBeforeMs > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(job.delayBeforeMs));
+      }
+
+      DWORD error = ERROR_SUCCESS;
+      const bool ok = !closing_ && WriteOnce(event, overlapped, job.bytes, error);
+      if (ok && job.delayAfterMs > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(job.delayAfterMs));
+      }
+      auto* result = new TxResult{job.token, ok,
+                                  ok ? std::string{} : WindowsError("WinUsb_WritePipe", error)};
+      const napi_status status = txTsfn_.NonBlockingCall(
+          result, [](Napi::Env env, Napi::Function callback, TxResult* value) {
+            Napi::Object object = Napi::Object::New(env);
+            object.Set("token", Napi::Number::New(env, value->token));
+            object.Set("ok", Napi::Boolean::New(env, value->ok));
+            if (!value->ok) object.Set("error", Napi::String::New(env, value->error));
+            callback.Call({object});
+            delete value;
+          });
+      if (status != napi_ok) delete result;
+    }
+
+    std::deque<TxJob> abandoned;
+    {
+      std::lock_guard<std::mutex> lock(txMutex_);
+      abandoned.swap(txQueue_);
+    }
+    for (const auto& job : abandoned) {
+      auto* result = new TxResult{job.token, false, "WinUSB transport is closed"};
+      const napi_status status = txTsfn_.NonBlockingCall(
+          result, [](Napi::Env env, Napi::Function callback, TxResult* value) {
+            Napi::Object object = Napi::Object::New(env);
+            object.Set("token", Napi::Number::New(env, value->token));
+            object.Set("ok", Napi::Boolean::New(env, false));
+            object.Set("error", Napi::String::New(env, value->error));
+            callback.Call({object});
+            delete value;
+          });
+      if (status != napi_ok) delete result;
+    }
+    CloseHandle(event);
+  }
+
+  void ReportError(const std::string& operation, DWORD code) {
+    auto* result = new ErrorResult{code, operation, WindowsError(operation, code)};
+    const napi_status status = errorTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, ErrorResult* value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("operation", Napi::String::New(env, value->operation));
+          object.Set("code", Napi::Number::New(env, value->code));
+          object.Set("message", Napi::String::New(env, value->detail));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok) delete result;
+  }
+
+  std::wstring path_;
+  HANDLE file_ = INVALID_HANDLE_VALUE;
+  WINUSB_INTERFACE_HANDLE usb_ = nullptr;
+  uint8_t interfaceNumber_ = 0;
+  uint8_t endpointIn_ = 0;
+  uint8_t endpointOut_ = 0;
+  std::atomic<bool> closing_{false};
+  std::atomic<bool> rxStarted_{false};
+  std::thread rxThread_;
+  std::thread txThread_;
+  std::mutex controlMutex_;
+  std::mutex txMutex_;
+  std::condition_variable txCondition_;
+  std::deque<TxJob> txQueue_;
+  Napi::ThreadSafeFunction rxTsfn_;
+  Napi::ThreadSafeFunction errorTsfn_;
+  Napi::ThreadSafeFunction txTsfn_;
+};
+
+std::shared_ptr<UsbTransport> Lookup(uint32_t handle) {
+  std::lock_guard<std::mutex> lock(gDevicesMutex);
+  const auto found = gDevices.find(handle);
+  if (found == gDevices.end()) throw std::runtime_error("invalid WinUSB transport handle");
+  return found->second;
+}
+
+Napi::Value ListDevices(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsNumber()) {
+    throw Napi::TypeError::New(env, "listDevices expects vid and pid");
+  }
+  try {
+    const auto interfaces = EnumerateInterfaces(
+        static_cast<uint16_t>(info[0].As<Napi::Number>().Uint32Value()),
+        static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value()));
+    Napi::Array output = Napi::Array::New(env, interfaces.size());
+    for (size_t index = 0; index < interfaces.size(); ++index) {
+      const auto& item = interfaces[index];
+      Napi::Object object = Napi::Object::New(env);
+      object.Set("path", Napi::String::New(env, WideToUtf8(item.path)));
+      object.Set("label", Napi::String::New(env, WideToUtf8(item.label)));
+      object.Set("interfaceNumber", Napi::Number::New(env, item.number));
+      object.Set("endpointIn", Napi::Number::New(env, item.endpointIn));
+      object.Set("endpointOut", Napi::Number::New(env, item.endpointOut));
+      object.Set("busy", Napi::Boolean::New(env, item.busy));
+      output.Set(index, object);
+    }
+    return output;
+  } catch (const std::exception& error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Open(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 4 || !info[0].IsString() || !info[1].IsFunction() ||
+      !info[2].IsFunction() || !info[3].IsFunction()) {
+    throw Napi::TypeError::New(env, "open expects path, rx callback, error callback, tx callback");
+  }
+  try {
+    auto device = std::make_shared<UsbTransport>(
+        env, Utf8ToWide(info[0].As<Napi::String>().Utf8Value()),
+        info[1].As<Napi::Function>(), info[2].As<Napi::Function>(),
+        info[3].As<Napi::Function>());
+    device->Open();
+    const uint32_t handle = gNextHandle.fetch_add(1);
+    {
+      std::lock_guard<std::mutex> lock(gDevicesMutex);
+      gDevices.emplace(handle, device);
+    }
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("handle", Napi::Number::New(env, handle));
+    result.Set("interfaceNumber", Napi::Number::New(env, device->InterfaceNumber()));
+    return result;
+  } catch (const std::exception& error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value StartRx(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(info[0].As<Napi::Number>().Uint32Value())->StartRx();
+    return env.Undefined();
+  } catch (const std::exception& error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Control(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 6) {
+    throw Napi::TypeError::New(env, "control expects handle, type, request, value, index, data/length");
+  }
+  try {
+    auto device = Lookup(info[0].As<Napi::Number>().Uint32Value());
+    const uint8_t requestType = static_cast<uint8_t>(info[1].As<Napi::Number>().Uint32Value());
+    const uint8_t request = static_cast<uint8_t>(info[2].As<Napi::Number>().Uint32Value());
+    const uint16_t value = static_cast<uint16_t>(info[3].As<Napi::Number>().Uint32Value());
+    const uint16_t index = static_cast<uint16_t>(info[4].As<Napi::Number>().Uint32Value());
+    if ((requestType & 0x80) != 0) {
+      const uint16_t length = static_cast<uint16_t>(info[5].As<Napi::Number>().Uint32Value());
+      const auto bytes = device->ControlIn(requestType, request, value, index, length);
+      return Napi::Buffer<uint8_t>::Copy(env, bytes.data(), bytes.size());
+    }
+    if (!info[5].IsBuffer()) {
+      throw std::runtime_error("control OUT payload must be a Buffer");
+    }
+    const auto input = info[5].As<Napi::Buffer<uint8_t>>();
+    device->ControlOut(requestType, request, value, index,
+                       std::vector<uint8_t>(input.Data(), input.Data() + input.Length()));
+    return env.Undefined();
+  } catch (const std::exception& error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Write(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 5 || !info[1].IsBuffer()) {
+    throw Napi::TypeError::New(
+        env, "write expects handle, Buffer, token, delayBeforeMs, delayAfterMs");
+  }
+  try {
+    const auto input = info[1].As<Napi::Buffer<uint8_t>>();
+    const bool queued = Lookup(info[0].As<Napi::Number>().Uint32Value())
+                            ->Enqueue(info[2].As<Napi::Number>().Uint32Value(),
+                                      input.Data(), input.Length(),
+                                      info[3].As<Napi::Number>().Uint32Value(),
+                                      info[4].As<Napi::Number>().Uint32Value());
+    return Napi::Boolean::New(env, queued);
+  } catch (const std::exception& error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Close(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::shared_ptr<UsbTransport> device;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    const uint32_t handle = info[0].As<Napi::Number>().Uint32Value();
+    const auto found = gDevices.find(handle);
+    if (found == gDevices.end()) return env.Undefined();
+    device = found->second;
+    gDevices.erase(found);
+  }
+  device->Close();
+  return env.Undefined();
+}
+
+void Cleanup(void*) {
+  std::map<uint32_t, std::shared_ptr<UsbTransport>> devices;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    devices.swap(gDevices);
+  }
+  for (auto& [handle, device] : devices) {
+    (void)handle;
+    device->Close();
+  }
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("listDevices", Napi::Function::New(env, ListDevices));
+  exports.Set("open", Napi::Function::New(env, Open));
+  exports.Set("startRx", Napi::Function::New(env, StartRx));
+  exports.Set("control", Napi::Function::New(env, Control));
+  exports.Set("write", Napi::Function::New(env, Write));
+  exports.Set("close", Napi::Function::New(env, Close));
+  napi_add_env_cleanup_hook(env, Cleanup, nullptr);
+  return exports;
+}
+
+}  // namespace
+
+NODE_API_MODULE(usbcan, Init)

--- a/src/main/docan/usbcan/transport.ts
+++ b/src/main/docan/usbcan/transport.ts
@@ -1,0 +1,115 @@
+import NativeUsbCan from './../build/Release/usbcan.node'
+
+export interface NativeUsbInterface {
+  path: string
+  label: string
+  interfaceNumber: number
+  endpointIn: number
+  endpointOut: number
+  busy: boolean
+}
+
+interface NativeOpenResult {
+  handle: number
+  interfaceNumber: number
+}
+
+export interface NativeTransportError {
+  operation: string
+  code: number
+  message: string
+}
+
+interface NativeTxResult {
+  token: number
+  ok: boolean
+  error?: string
+}
+
+interface NativeApi {
+  listDevices(vid: number, pid: number): NativeUsbInterface[]
+  open(
+    path: string,
+    onReceive: (data: Buffer) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): NativeOpenResult
+  startRx(handle: number): void
+  control(
+    handle: number,
+    requestType: number,
+    request: number,
+    value: number,
+    index: number,
+    dataOrLength: Buffer | number
+  ): Buffer | undefined
+  write(
+    handle: number,
+    data: Buffer,
+    token: number,
+    delayBeforeMs?: number,
+    delayAfterMs?: number
+  ): boolean
+  close(handle: number): void
+}
+
+const native = NativeUsbCan as NativeApi
+
+export class UsbCanTransport {
+  readonly handle: number
+  readonly interfaceNumber: number
+  private closed = false
+
+  private constructor(result: NativeOpenResult) {
+    this.handle = result.handle
+    this.interfaceNumber = result.interfaceNumber
+  }
+
+  static listDevices(vid: number, pid: number): NativeUsbInterface[] {
+    if (process.platform !== 'win32') return []
+    return native.listDevices(vid, pid)
+  }
+
+  static open(
+    path: string,
+    onReceive: (data: Buffer) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): UsbCanTransport {
+    if (process.platform !== 'win32') throw new Error('USB CAN is only supported on Windows')
+    const result = native.open(path, onReceive, onError, onTransmit)
+    return new UsbCanTransport(result)
+  }
+
+  startReceive() {
+    this.assertOpen()
+    native.startRx(this.handle)
+  }
+
+  controlIn(request: number, value: number, index: number, length: number): Buffer {
+    this.assertOpen()
+    const result = native.control(this.handle, 0xc1, request, value, index, length)
+    if (!Buffer.isBuffer(result)) throw new Error('WinUSB control read returned no data')
+    return result
+  }
+
+  controlOut(request: number, value: number, index: number, data: Buffer) {
+    this.assertOpen()
+    native.control(this.handle, 0x41, request, value, index, data)
+  }
+
+  write(data: Buffer, token: number, delayBeforeMs = 0, delayAfterMs = 0): boolean {
+    this.assertOpen()
+    return native.write(this.handle, data, token, delayBeforeMs, delayAfterMs)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    native.close(this.handle)
+  }
+
+  private assertOpen() {
+    if (this.closed) throw new Error('WinUSB transport is closed')
+  }
+}

--- a/src/main/docan/usbcan/wire.ts
+++ b/src/main/docan/usbcan/wire.ts
@@ -1,0 +1,367 @@
+export type UsbCanProtocol = 'vcan_usb' | 'vkgs_usb'
+
+export interface UsbCanFrame {
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+  timestampUs: number
+}
+
+export interface UsbCanStateEvent {
+  kind: 'state'
+  state: number
+  rxErrorCount: number
+  txErrorCount: number
+  timestampUs: number
+}
+
+export interface UsbCanBusErrorEvent {
+  kind: 'bus-error'
+  errorCode: number
+  rxErrorCount: number
+  txErrorCount: number
+}
+
+export type UsbCanEvent = UsbCanStateEvent | UsbCanBusErrorEvent
+
+export interface DecodeResult {
+  frames: UsbCanFrame[]
+  events: UsbCanEvent[]
+  tail: Buffer
+}
+
+export interface WireDecoder {
+  push(transfer: Buffer): DecodeResult
+  reset(): void
+}
+
+export const USB_CAN_FEATURE_FD = 1 << 8
+export const USB_CAN_FEATURE_BT_CONST_EXT = 1 << 10
+export const USB_CAN_FEATURE_TERMINATION = 1 << 11
+export const USB_CAN_FEATURE_HW_TIMESTAMP = 1 << 4
+export const USB_CAN_FEATURE_BERR_REPORTING = 1 << 12
+
+export const USB_CAN_MODE_LISTEN_ONLY = 1 << 0
+export const USB_CAN_MODE_HW_TIMESTAMP = 1 << 4
+export const USB_CAN_MODE_FD = 1 << 8
+export const USB_CAN_MODE_BERR_REPORTING = 1 << 12
+
+const FLAG_FD = 1 << 1
+const FLAG_BRS = 1 << 2
+const FLAG_EFF = 1 << 4
+const FLAG_RTR = 1 << 5
+
+const CAN_EFF_FLAG = 0x80000000
+const CAN_RTR_FLAG = 0x40000000
+const CAN_ID_MASK = 0x1fffffff
+
+const VCAN_ECHO_TX = 0xa1c95e3d
+const VCAN_ECHO_RX = 0xa2c95e3d
+const VCAN_ECHO_STATE = 0xa4c95e3d
+const VCAN_HEADER_SIZE = 8
+const VCAN_FRAME_DATA_OFFSET = 24
+const VCAN_OPCODE_SIZE_MASK = 0x0fff
+const VCAN_OPCODE_CHANNEL_SHIFT = 12
+const VCAN_STATE_REQUEST = 3
+const VCAN_BERR_REQUEST = 2
+
+const VKGS_ECHO_RX = 0xffffffff
+const VKGS_ECHO_LOAD = 0xa3c95e3d
+const VKGS_ECHO_STATE = 0xa4c95e3d
+const VKGS_ECHO_BERR = 0xa6c95e3d
+const VKGS_HEADER_SIZE = 12
+const VKGS_STATE_SIZE = 28
+const VKGS_BERR_SIZE = 16
+const VKGS_LOAD_SIZE = 28
+
+const FD_DLC_LENGTHS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]
+
+export function lengthToDlc(length: number, fd: boolean): number {
+  const maximum = fd ? 64 : 8
+  if (!Number.isInteger(length) || length < 0 || length > maximum) {
+    throw new RangeError(`CAN payload length must be 0..${maximum}`)
+  }
+  if (!fd) return length
+  const dlc = FD_DLC_LENGTHS.findIndex((candidate) => candidate >= length)
+  if (dlc < 0) throw new RangeError('CAN FD payload exceeds 64 bytes')
+  return dlc
+}
+
+export function dlcToLength(dlc: number, fd: boolean): number {
+  const normalized = dlc & 0x0f
+  return fd ? FD_DLC_LENGTHS[normalized] : Math.min(normalized, 8)
+}
+
+export function normalizeCanData(data: Buffer, fd: boolean): Buffer {
+  const wireLength = dlcToLength(lengthToDlc(data.length, fd), fd)
+  if (wireLength === data.length) return Buffer.from(data)
+  return Buffer.concat([data, Buffer.alloc(wireLength - data.length)])
+}
+
+function readTimestamp(buffer: Buffer, offset: number): number {
+  const timestamp = buffer.readBigUInt64LE(offset)
+  if (timestamp > BigInt(Number.MAX_SAFE_INTEGER)) return 0
+  return Number(timestamp)
+}
+
+function vcanOpcode(channel: number, size: number): number {
+  return ((channel & 0x0f) << VCAN_OPCODE_CHANNEL_SHIFT) | (size & VCAN_OPCODE_SIZE_MASK)
+}
+
+export function makeVcanControlPayload(
+  channel: number,
+  request: number,
+  payload: Buffer = Buffer.alloc(0)
+): Buffer {
+  const result = Buffer.alloc(VCAN_HEADER_SIZE + payload.length)
+  result.writeUInt32LE(0xa5c95e3d, 0)
+  result.writeUInt16LE(vcanOpcode(channel, result.length), 4)
+  result.writeUInt16LE(request, 6)
+  payload.copy(result, VCAN_HEADER_SIZE)
+  return result
+}
+
+export function stripVcanControlPayload(
+  channel: number,
+  request: number,
+  response: Buffer
+): Buffer {
+  if (response.length < VCAN_HEADER_SIZE) throw new Error('VCAN control response is too short')
+  const opcode = response.readUInt16LE(4)
+  if (
+    response.readUInt32LE(0) !== 0xa5c95e3d ||
+    (opcode & VCAN_OPCODE_SIZE_MASK) !== response.length ||
+    ((opcode >> VCAN_OPCODE_CHANNEL_SHIFT) & 0x0f) !== channel ||
+    (response.readUInt16LE(6) & 0x7f) !== request
+  ) {
+    throw new Error('VCAN control response header is invalid')
+  }
+  return response.subarray(VCAN_HEADER_SIZE)
+}
+
+export function encodeVcanFrame(channel: number, frame: UsbCanFrame): Buffer {
+  const data = normalizeCanData(frame.data, frame.fd)
+  const width = frame.fd ? 64 : 8
+  const size = VCAN_FRAME_DATA_OFFSET + width
+  const packet = Buffer.alloc(size)
+  let flags = frame.fd ? FLAG_FD : 0
+  if (frame.brs) flags |= FLAG_BRS
+  if (frame.extended) flags |= FLAG_EFF
+  if (frame.remote) flags |= FLAG_RTR
+  packet.writeUInt32LE(VCAN_ECHO_TX, 0)
+  packet.writeUInt16LE(vcanOpcode(channel, size), 4)
+  packet.writeUInt16LE(flags, 6)
+  packet.writeUInt32LE(frame.id & CAN_ID_MASK, 8)
+  packet.writeUInt8(lengthToDlc(data.length, frame.fd), 12)
+  data.copy(packet, VCAN_FRAME_DATA_OFFSET)
+  return packet
+}
+
+export class VcanDecoder implements WireDecoder {
+  private tail = Buffer.alloc(0)
+
+  constructor(private readonly expectedChannel?: number) {}
+
+  reset() {
+    this.tail = Buffer.alloc(0)
+  }
+
+  push(transfer: Buffer): DecodeResult {
+    const buffer = this.tail.length ? Buffer.concat([this.tail, transfer]) : transfer
+    this.tail = Buffer.alloc(0)
+    const frames: UsbCanFrame[] = []
+    const events: UsbCanEvent[] = []
+    let offset = 0
+
+    while (offset + VCAN_HEADER_SIZE <= buffer.length) {
+      const echoId = buffer.readUInt32LE(offset)
+      if (echoId === 0) break
+      const opcode = buffer.readUInt16LE(offset + 4)
+      const flags = buffer.readUInt16LE(offset + 6)
+      const frameSize = opcode & VCAN_OPCODE_SIZE_MASK
+      if (frameSize < VCAN_HEADER_SIZE || frameSize > 512) {
+        this.reset()
+        throw new Error(`invalid VCAN bulk frame size: ${frameSize}`)
+      }
+      const frameChannel = (opcode >> VCAN_OPCODE_CHANNEL_SHIFT) & 0x0f
+      if (this.expectedChannel !== undefined && frameChannel !== this.expectedChannel) {
+        this.reset()
+        throw new Error(
+          `VCAN bulk frame channel ${frameChannel} does not match interface ${this.expectedChannel}`
+        )
+      }
+      if (offset + frameSize > buffer.length) {
+        this.tail = Buffer.from(buffer.subarray(offset))
+        break
+      }
+
+      if (echoId === VCAN_ECHO_RX && frameSize >= VCAN_FRAME_DATA_OFFSET) {
+        const fd = !!(flags & FLAG_FD)
+        const length = dlcToLength(buffer.readUInt8(offset + 12), fd)
+        if (VCAN_FRAME_DATA_OFFSET + length > frameSize) {
+          this.reset()
+          throw new Error('VCAN frame payload exceeds its declared frame size')
+        }
+        frames.push({
+          id: buffer.readUInt32LE(offset + 8) & CAN_ID_MASK,
+          data: Buffer.from(
+            buffer.subarray(
+              offset + VCAN_FRAME_DATA_OFFSET,
+              offset + VCAN_FRAME_DATA_OFFSET + length
+            )
+          ),
+          fd,
+          brs: !!(flags & FLAG_BRS),
+          extended: !!(flags & FLAG_EFF),
+          remote: !!(flags & FLAG_RTR),
+          timestampUs: readTimestamp(buffer, offset + 16)
+        })
+      } else if (echoId === VCAN_ECHO_STATE) {
+        if (flags === VCAN_STATE_REQUEST && frameSize >= 28) {
+          events.push({
+            kind: 'state',
+            timestampUs: readTimestamp(buffer, offset + 8),
+            state: buffer.readUInt32LE(offset + 16),
+            rxErrorCount: buffer.readUInt32LE(offset + 20),
+            txErrorCount: buffer.readUInt32LE(offset + 24)
+          })
+        } else if (flags === VCAN_BERR_REQUEST && frameSize >= 16) {
+          events.push({
+            kind: 'bus-error',
+            errorCode: buffer.readUInt8(offset + 9),
+            rxErrorCount: buffer.readUInt8(offset + 10),
+            txErrorCount: buffer.readUInt8(offset + 11)
+          })
+        }
+      }
+      offset += frameSize
+    }
+
+    if (!this.tail.length && offset < buffer.length) {
+      const remainder = buffer.subarray(offset)
+      if (remainder.length < VCAN_HEADER_SIZE && remainder.some((value) => value !== 0)) {
+        this.tail = Buffer.from(remainder)
+      }
+    }
+    return { frames, events, tail: Buffer.from(this.tail) }
+  }
+}
+
+export function encodeVkgsFrame(channel: number, frame: UsbCanFrame, fdMode: boolean): Buffer {
+  const data = normalizeCanData(frame.data, frame.fd)
+  const width = fdMode || frame.fd ? 64 : 8
+  const packet = Buffer.alloc(VKGS_HEADER_SIZE + width)
+  let canId = frame.id & CAN_ID_MASK
+  if (frame.extended) canId = (canId | CAN_EFF_FLAG) >>> 0
+  if (frame.remote) canId = (canId | CAN_RTR_FLAG) >>> 0
+  let flags = frame.fd ? FLAG_FD : 0
+  if (frame.brs) flags |= FLAG_BRS
+  packet.writeUInt32LE(0, 0)
+  packet.writeUInt32LE(canId, 4)
+  packet.writeUInt8(lengthToDlc(data.length, frame.fd), 8)
+  packet.writeUInt8(channel, 9)
+  packet.writeUInt8(flags, 10)
+  data.copy(packet, VKGS_HEADER_SIZE)
+  return packet
+}
+
+export class VkgsDecoder implements WireDecoder {
+  private tail = Buffer.alloc(0)
+
+  constructor(
+    private readonly timestampsEnabled: boolean,
+    private readonly expectedChannel?: number
+  ) {}
+
+  reset() {
+    this.tail = Buffer.alloc(0)
+  }
+
+  push(transfer: Buffer): DecodeResult {
+    const buffer = this.tail.length ? Buffer.concat([this.tail, transfer]) : transfer
+    this.tail = Buffer.alloc(0)
+    const frames: UsbCanFrame[] = []
+    const events: UsbCanEvent[] = []
+    let offset = 0
+
+    while (offset < buffer.length) {
+      const remaining = buffer.length - offset
+      if (remaining < 4) {
+        if (buffer.subarray(offset).some((value) => value !== 0)) {
+          this.tail = Buffer.from(buffer.subarray(offset))
+        }
+        break
+      }
+      const echoId = buffer.readUInt32LE(offset)
+      if (echoId === 0) break
+      if (remaining < VKGS_HEADER_SIZE) {
+        this.tail = Buffer.from(buffer.subarray(offset))
+        break
+      }
+
+      let size: number
+      if (echoId === VKGS_ECHO_STATE) size = VKGS_STATE_SIZE
+      else if (echoId === VKGS_ECHO_BERR) size = VKGS_BERR_SIZE
+      else if (echoId === VKGS_ECHO_LOAD) size = VKGS_LOAD_SIZE
+      else if (echoId === VKGS_ECHO_RX) {
+        const flags = buffer.readUInt8(offset + 10)
+        size = VKGS_HEADER_SIZE + (flags & FLAG_FD ? 64 : 8) + (this.timestampsEnabled ? 8 : 0)
+      } else {
+        this.reset()
+        throw new Error(`unknown VKGS bulk frame marker: 0x${echoId.toString(16)}`)
+      }
+
+      const frameChannel = buffer.readUInt8(offset + (echoId === VKGS_ECHO_RX ? 9 : 4))
+      if (this.expectedChannel !== undefined && frameChannel !== this.expectedChannel) {
+        this.reset()
+        throw new Error(
+          `VKGS bulk frame channel ${frameChannel} does not match interface ${this.expectedChannel}`
+        )
+      }
+
+      if (offset + size > buffer.length) {
+        this.tail = Buffer.from(buffer.subarray(offset))
+        break
+      }
+
+      if (echoId === VKGS_ECHO_RX) {
+        const rawId = buffer.readUInt32LE(offset + 4)
+        const flags = buffer.readUInt8(offset + 10)
+        const fd = !!(flags & FLAG_FD)
+        const length = dlcToLength(buffer.readUInt8(offset + 8), fd)
+        frames.push({
+          id: rawId & CAN_ID_MASK,
+          data: Buffer.from(
+            buffer.subarray(offset + VKGS_HEADER_SIZE, offset + VKGS_HEADER_SIZE + length)
+          ),
+          fd,
+          brs: !!(flags & FLAG_BRS),
+          extended: !!(rawId & CAN_EFF_FLAG),
+          remote: !!(rawId & CAN_RTR_FLAG),
+          timestampUs: this.timestampsEnabled ? readTimestamp(buffer, offset + size - 8) : 0
+        })
+      } else if (echoId === VKGS_ECHO_STATE) {
+        events.push({
+          kind: 'state',
+          timestampUs: readTimestamp(buffer, offset + 8),
+          state: buffer.readUInt32LE(offset + 16),
+          rxErrorCount: buffer.readUInt32LE(offset + 20),
+          txErrorCount: buffer.readUInt32LE(offset + 24)
+        })
+      } else if (echoId === VKGS_ECHO_BERR) {
+        events.push({
+          kind: 'bus-error',
+          errorCode: buffer.readUInt8(offset + 9),
+          rxErrorCount: buffer.readUInt8(offset + 10),
+          txErrorCount: buffer.readUInt8(offset + 11)
+        })
+      }
+      offset += size
+    }
+
+    return { frames, events, tail: Buffer.from(this.tail) }
+  }
+}

--- a/src/main/docan/vcan_usb/index.ts
+++ b/src/main/docan/vcan_usb/index.ts
@@ -1,0 +1,16 @@
+import { CanBaseInfo, CanDevice } from '../../share/can'
+import { getUsbCanDevices, UsbCanBase } from '../usbcan'
+
+export class VCAN_USB_CAN extends UsbCanBase {
+  constructor(info: CanBaseInfo) {
+    super(info, 'vcan_usb')
+  }
+
+  static override getValidDevices(): CanDevice[] {
+    return getUsbCanDevices('vcan_usb')
+  }
+
+  static override getLibVersion(): string {
+    return process.platform === 'win32' ? '1.0.0 (WinUSB)' : 'only support windows'
+  }
+}

--- a/src/main/docan/vkgs_usb/index.ts
+++ b/src/main/docan/vkgs_usb/index.ts
@@ -1,0 +1,16 @@
+import { CanBaseInfo, CanDevice } from '../../share/can'
+import { getUsbCanDevices, UsbCanBase } from '../usbcan'
+
+export class VKGS_USB_CAN extends UsbCanBase {
+  constructor(info: CanBaseInfo) {
+    super(info, 'vkgs_usb')
+  }
+
+  static override getValidDevices(): CanDevice[] {
+    return getUsbCanDevices('vkgs_usb')
+  }
+
+  static override getLibVersion(): string {
+    return process.platform === 'win32' ? '1.0.0 (WinUSB)' : 'only support windows'
+  }
+}

--- a/src/main/share/can.ts
+++ b/src/main/share/can.ts
@@ -23,6 +23,8 @@ export type CanVendor =
   | 'slcan'
   | 'ecubus'
   | 'candle'
+  | 'vcan_usb'
+  | 'vkgs_usb'
 export interface CanBaseInfo {
   id: string
   handle: any
@@ -36,6 +38,8 @@ export interface CanBaseInfo {
   toomossRes?: boolean
   zlgRes?: boolean
   candleRes?: boolean
+  vcanUsbRes?: boolean
+  vkgsUsbRes?: boolean
   slcanDelay?: number
 }
 
@@ -495,6 +499,16 @@ export interface CanDevice {
       dataCap?: CandleCapability
       fdSupported?: boolean
       Res?: boolean
+    }
+    usbCan?: {
+      protocol?: 'vcan_usb' | 'vkgs_usb'
+      cap?: CandleCapability
+      dataCap?: CandleCapability
+      fdSupported?: boolean
+      Res?: boolean
+      termination?: boolean
+      swVersion?: number
+      hwVersion?: number
     }
   }
 }

--- a/src/renderer/src/views/uds/hardware/canNode.vue
+++ b/src/renderer/src/views/uds/hardware/canNode.vue
@@ -80,6 +80,28 @@
       </el-select>
     </el-form-item>
     <el-form-item
+      v-else-if="props.vendor == 'vcan_usb' && getSelectedUsbCanDevice()?.extra?.usbCan?.Res"
+      :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
+      prop="vcanUsbRes"
+      :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
+    >
+      <el-select v-model="data.vcanUsbRes" :loading="deviceLoading" style="width: 300px">
+        <el-option :label="i18next.t('uds.hardware.canNode.options.enable')" :value="true" />
+        <el-option :label="i18next.t('uds.hardware.canNode.options.disable')" :value="false" />
+      </el-select>
+    </el-form-item>
+    <el-form-item
+      v-else-if="props.vendor == 'vkgs_usb' && getSelectedUsbCanDevice()?.extra?.usbCan?.Res"
+      :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
+      prop="vkgsUsbRes"
+      :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
+    >
+      <el-select v-model="data.vkgsUsbRes" :loading="deviceLoading" style="width: 300px">
+        <el-option :label="i18next.t('uds.hardware.canNode.options.enable')" :value="true" />
+        <el-option :label="i18next.t('uds.hardware.canNode.options.disable')" :value="false" />
+      </el-select>
+    </el-form-item>
+    <el-form-item
       v-else-if="props.vendor == 'zlg'"
       :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
       prop="zlgRes"
@@ -91,7 +113,9 @@
       </el-select>
     </el-form-item>
     <el-form-item
-      v-else-if="props.vendor == 'kvaser'"
+      v-else-if="
+        props.vendor == 'kvaser' || props.vendor == 'vcan_usb' || props.vendor == 'vkgs_usb'
+      "
       :label="i18next.t('uds.hardware.canNode.labels.silentMode')"
       prop="silent"
       :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
@@ -710,6 +734,19 @@ const configInfo: Record<CanVendor, any> = {
       }
     }
   }
+} as Record<CanVendor, any>
+
+for (const vendor of ['vcan_usb', 'vkgs_usb'] as const) {
+  const config = cloneDeep(configInfo.candle)
+  config.can.clock = [{ clock: '80', name: '80' }]
+  config.canFd.clock = [{ clock: '80', name: '80' }]
+  configInfo[vendor] = config
+}
+
+function getSelectedUsbCanDevice(): CanDevice | undefined {
+  if (props.vendor !== 'vcan_usb' && props.vendor !== 'vkgs_usb') return undefined
+  if (data.value.handle === '' || data.value.handle == null) return undefined
+  return deviceList.value.find((device) => device.handle === data.value.handle)
 }
 
 /** Look up the currently selected candle device from the device list */
@@ -779,6 +816,10 @@ const showCandleTimingTable = computed(() => {
 })
 
 const showCanFdCheckbox = computed(() => {
+  if (props.vendor === 'vcan_usb' || props.vendor === 'vkgs_usb') {
+    const device = getSelectedUsbCanDevice()
+    return !device || !!device.extra?.usbCan?.fdSupported
+  }
   if (props.vendor !== 'candle') return true
   const dev = getSelectedCandleDevice()
   return !!dev?.extra?.candle?.fdSupported
@@ -958,7 +999,9 @@ function getBaudrateSP(speed: CanBitrate, index: number) {
     props.vendor == 'kvaser' ||
     props.vendor == 'toomoss' ||
     props.vendor == 'vector' ||
-    props.vendor == 'candle'
+    props.vendor == 'candle' ||
+    props.vendor == 'vcan_usb' ||
+    props.vendor == 'vkgs_usb'
   ) {
     let f_clock = Number(speed.clock || 80) * 1000000
     if (index == 1) {
@@ -1142,7 +1185,9 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
     props.vendor == 'peak' ||
     props.vendor == 'kvaser' ||
     props.vendor == 'toomoss' ||
-    props.vendor == 'candle'
+    props.vendor == 'candle' ||
+    props.vendor == 'vcan_usb' ||
+    props.vendor == 'vkgs_usb'
   ) {
     if (data.value.bitrate.clock == undefined) {
       callback(new Error(i18next.t('uds.hardware.canNode.validation.selectClock')))
@@ -1272,7 +1317,9 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
       props.vendor == 'kvaser' ||
       props.vendor == 'toomoss' ||
       props.vendor == 'peak' ||
-      props.vendor == 'candle'
+      props.vendor == 'candle' ||
+      props.vendor == 'vcan_usb' ||
+      props.vendor == 'vkgs_usb'
     ) {
       const calcFreq =
         (Number(data.value.bitrate.clock || 40) * 1000000) /

--- a/src/renderer/src/views/uds/hardware/index.vue
+++ b/src/renderer/src/views/uds/hardware/index.vue
@@ -566,6 +566,18 @@ async function buildTree() {
     t.push(candle)
     addSubTree('candle', candle, deviceIndexMap)
   }
+  for (const vendor of ['vcan_usb', 'vkgs_usb'] as const) {
+    if (!vendors.includes(vendor)) continue
+    const usbCan: tree = {
+      label: i18next.t(`uds.hardware.vendors.${vendor}`),
+      vendor,
+      append: false,
+      id: vendor.toUpperCase(),
+      children: []
+    }
+    t.push(usbCan)
+    addSubTree(vendor, usbCan, deviceIndexMap)
+  }
 
   tData.value = t
 }

--- a/test/docan/usbcan-wire.test.ts
+++ b/test/docan/usbcan-wire.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'vitest'
+import {
+  dlcToLength,
+  encodeVcanFrame,
+  encodeVkgsFrame,
+  lengthToDlc,
+  makeVcanControlPayload,
+  stripVcanControlPayload,
+  UsbCanFrame,
+  VcanDecoder,
+  VkgsDecoder
+} from '../../src/main/docan/usbcan/wire'
+
+const frame: UsbCanFrame = {
+  id: 0x18daf110,
+  data: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+  fd: true,
+  brs: true,
+  extended: true,
+  remote: false,
+  timestampUs: 0
+}
+
+describe('USB CAN wire codecs', () => {
+  test('maps CAN FD lengths to canonical DLC values', () => {
+    expect(lengthToDlc(9, true)).toBe(9)
+    expect(dlcToLength(9, true)).toBe(12)
+    expect(lengthToDlc(64, true)).toBe(15)
+    expect(() => lengthToDlc(65, true)).toThrow(/0\.\.64/)
+    expect(() => lengthToDlc(9, false)).toThrow(/0\.\.8/)
+  })
+
+  test('builds and validates VCAN control headers', () => {
+    const request = 37
+    const packet = makeVcanControlPayload(1, request, Buffer.from([1, 0, 0, 0]))
+    expect(packet.length).toBe(12)
+    expect(packet.readUInt16LE(4)).toBe(0x100c)
+    expect(stripVcanControlPayload(1, request, packet)).toEqual(Buffer.from([1, 0, 0, 0]))
+
+    const corrupt = Buffer.from(packet)
+    corrupt.writeUInt16LE(0x000c, 4)
+    expect(() => stripVcanControlPayload(1, request, corrupt)).toThrow(/invalid/)
+  })
+
+  test('decodes a VCAN FD frame split across USB transfers', () => {
+    const packet = encodeVcanFrame(1, frame)
+    packet.writeUInt32LE(0xa2c95e3d, 0)
+    packet.writeBigUInt64LE(123456789n, 16)
+    const decoder = new VcanDecoder()
+
+    expect(decoder.push(packet.subarray(0, 17)).frames).toHaveLength(0)
+    const result = decoder.push(packet.subarray(17))
+
+    expect(result.frames).toHaveLength(1)
+    expect(result.frames[0]).toMatchObject({
+      id: frame.id,
+      fd: true,
+      brs: true,
+      extended: true,
+      timestampUs: 123456789
+    })
+    expect(result.frames[0].data).toEqual(Buffer.concat([frame.data, Buffer.alloc(3)]))
+    expect(result.tail).toHaveLength(0)
+  })
+
+  test('decodes aggregated VCAN frames using the opcode length', () => {
+    const first = encodeVcanFrame(0, { ...frame, fd: false, brs: false, data: Buffer.from([1]) })
+    first.writeUInt32LE(0xa2c95e3d, 0)
+    const second = Buffer.from(first)
+    second.writeUInt32LE(0x321, 8)
+
+    const result = new VcanDecoder().push(Buffer.concat([first, second]))
+    expect(result.frames.map((item) => item.id)).toEqual([frame.id, 0x321])
+  })
+
+  test('rejects an invalid VCAN frame length and resets buffered state', () => {
+    const invalid = Buffer.alloc(8)
+    invalid.writeUInt32LE(0xa2c95e3d, 0)
+    invalid.writeUInt16LE(4, 4)
+    const decoder = new VcanDecoder()
+    expect(() => decoder.push(invalid)).toThrow(/frame size/)
+
+    const valid = encodeVcanFrame(0, { ...frame, fd: false, brs: false, data: Buffer.alloc(0) })
+    valid.writeUInt32LE(0xa2c95e3d, 0)
+    expect(decoder.push(valid).frames).toHaveLength(1)
+  })
+
+  test('rejects VCAN frames received on the wrong interface', () => {
+    const packet = encodeVcanFrame(1, { ...frame, fd: false, brs: false, data: Buffer.alloc(0) })
+    packet.writeUInt32LE(0xa2c95e3d, 0)
+    expect(() => new VcanDecoder(0).push(packet)).toThrow(/channel 1.*interface 0/)
+  })
+
+  test('rejects VKGS frames received on the wrong interface', () => {
+    const packet = encodeVkgsFrame(
+      1,
+      { ...frame, fd: false, brs: false, data: Buffer.alloc(0) },
+      false
+    )
+    packet.writeUInt32LE(0xffffffff, 0)
+    expect(() => new VkgsDecoder(false, 0).push(packet)).toThrow(/channel 1.*interface 0/)
+  })
+
+  test('encodes VKGS FD mode with a fixed 64-byte data area', () => {
+    const packet = encodeVkgsFrame(1, frame, true)
+    expect(packet.length).toBe(76)
+    expect(packet.readUInt8(8)).toBe(9)
+    expect(packet.readUInt8(9)).toBe(1)
+    expect(packet.subarray(12, 21)).toEqual(frame.data)
+    expect(packet.subarray(21)).toEqual(Buffer.alloc(55))
+  })
+
+  test('decodes split VKGS frames with hardware timestamps', () => {
+    const packet = encodeVkgsFrame(0, frame, true)
+    packet.writeUInt32LE(0xffffffff, 0)
+    const timestamp = Buffer.alloc(8)
+    timestamp.writeBigUInt64LE(987654321n)
+    const transfer = Buffer.concat([packet, timestamp])
+    const decoder = new VkgsDecoder(true)
+
+    expect(decoder.push(transfer.subarray(0, 25)).frames).toHaveLength(0)
+    const result = decoder.push(transfer.subarray(25))
+    expect(result.frames).toHaveLength(1)
+    expect(result.frames[0].timestampUs).toBe(987654321)
+    expect(result.frames[0].data).toEqual(Buffer.concat([frame.data, Buffer.alloc(3)]))
+  })
+
+  test('decodes VKGS state events without interpreting the event header as CAN data', () => {
+    const state = Buffer.alloc(28)
+    state.writeUInt32LE(0xa4c95e3d, 0)
+    state.writeBigUInt64LE(5000n, 8)
+    state.writeUInt32LE(2, 16)
+    state.writeUInt32LE(7, 20)
+    state.writeUInt32LE(9, 24)
+
+    expect(new VkgsDecoder(false).push(state).events).toEqual([
+      {
+        kind: 'state',
+        timestampUs: 5000,
+        state: 2,
+        rxErrorCount: 7,
+        txErrorCount: 9
+      }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- add a shared Windows WinUSB transport for interface discovery, control transfers, bounded asynchronous RX/TX, and safe cancellation
- add native EcuBus CAN adapters for VCAN USB and VKGS USB, including classic CAN, CAN FD, BRS, RTR, silent mode, termination control, status/error events, and hardware timestamps where supported
- integrate both adapters with device discovery, CLI services, vendor metadata, localization, and the Hardware configuration UI
- validate USB frame boundaries and interface/channel consistency, while keeping optional device-info and termination probes compatible with older firmware
- add protocol codec tests for split/aggregated transfers, CAN FD DLC mapping, control headers, events, and channel mismatch handling

## Validation

- `npm run docan`
- `npm run typecheck:node`
- `npm run typecheck:web`
- `npm run test -- --run test/docan/usbcan-wire.test.ts` (10 tests)
- `npm run build`
- Windows hardware smoke test: discovered two VCAN interfaces and read channel 0 capabilities (`feature=0xdbb`, `clock=80 MHz`)

VKGS was validated through compilation and wire-codec tests; VKGS hardware was not attached during this run.

## Related VCAN resources

For device setup and related software or driver updates:

- [VCAN documentation](http://docs.vseasky.com/projects/vcan/index.html)
- NexuTrace: [GitHub](https://github.com/vseasky/NexuTrace) · [Gitee](https://gitee.com/vseasky/NexuTrace)
- VCANDrive: [GitHub](https://github.com/vseasky/VCANDrive) · [Gitee](https://gitee.com/vseasky/VCANDrive)
