### PR TITLE
feat(docan): add cross-platform VCAN USB and VKGS USB adapters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,7 @@
         "ts-loader": "^9.5.4",
         "typedoc": "^0.27.6",
         "typescript": "^5.3.3",
+        "usb": "2.18.0",
         "viewerjs": "^1.11.6",
         "vite": "^5.4.21",
         "vite-plugin-conditional-compiler": "^0.3.1",
@@ -5518,6 +5519,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
@@ -19108,6 +19116,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.18.0.tgz",
+      "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
       }
     },
     "node_modules/utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -17,15 +17,21 @@
         "vector",
         "slcan",
         "ecubus",
-        "candle"
+        "candle",
+        "vcan_usb",
+        "vkgs_usb"
       ],
       "linux": [
         "simulate",
-        "slcan"
+        "slcan",
+        "vcan_usb",
+        "vkgs_usb"
       ],
       "darwin": [
         "simulate",
-        "slcan"
+        "slcan",
+        "vcan_usb",
+        "vkgs_usb"
       ]
     }
   },
@@ -60,7 +66,7 @@
     "build:linux": "npm run build && electron-builder --linux",
     "native": "npm run docan && npm run dolin && npm run someip",
     "api": "typedoc --tsconfig tsconfig.worker.json --lang en-US",
-    "docan": "cd src/main/docan && npx node-gyp rebuild",
+    "docan": "cd src/main/docan && npx node-gyp rebuild -- -Duse_udev=0",
     "dolin": "cd src/main/dolin && npx node-gyp rebuild",
     "someip": "cd src/main/vsomeip && npx node-gyp rebuild",
     "docs:dev": "vitepress dev",
@@ -178,6 +184,7 @@
     "ts-loader": "^9.5.4",
     "typedoc": "^0.27.6",
     "typescript": "^5.3.3",
+    "usb": "2.18.0",
     "viewerjs": "^1.11.6",
     "vite": "^5.4.21",
     "vite-plugin-conditional-compiler": "^0.3.1",

--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -1132,7 +1132,9 @@
         "toomoss": "TOOMOSS",
         "vector": "VECTOR",
         "slcan": "SLCAN",
-        "candle": "CANDLE"
+        "candle": "CANDLE",
+        "vcan_usb": "VCAN USB",
+        "vkgs_usb": "VKGS USB"
       },
       "canNode": {
         "sections": {

--- a/src/cli/rpc/canService.ts
+++ b/src/cli/rpc/canService.ts
@@ -83,7 +83,9 @@ const VENDORS: CanVendor[] = [
   'vector',
   'slcan',
   'ecubus',
-  'candle'
+  'candle',
+  'vcan_usb',
+  'vkgs_usb'
 ]
 
 function loadNativeCan(): typeof import('src/main/docan/can') {

--- a/src/main/docan/binding.gyp
+++ b/src/main/docan/binding.gyp
@@ -1,5 +1,104 @@
 {
-    'targets': [   
+    'variables': {
+        'use_udev%': 0
+    },
+    'targets': [
+        {
+            'target_name': 'vcan_usb',
+            'include_dirs': [
+                './vcan_usb/api',
+                "<!@(node -p \"require('node-addon-api').include\")"
+            ],
+            'dependencies': [
+                "<!(node -p \"require('node-addon-api').gyp\")",
+                '../../../node_modules/usb/libusb.gypi:libusb'
+            ],
+            'defines': [
+                'NAPI_CPP_EXCEPTIONS'
+            ],
+            'sources': [
+                './vcan_usb/native/transport.cpp',
+                './vcan_usb/api/vcan_usb.cpp'
+            ],
+            'cflags!': [ '-fno-exceptions' ],
+            'cflags_cc!': [ '-fno-exceptions' ],
+            'cflags': [ '-fexceptions' ],
+            'cflags_cc': [ '-fexceptions' ],
+            'conditions': [
+                ['OS=="win"', {
+                    'defines': [
+                        'WIN32_LEAN_AND_MEAN'
+                    ],
+                    'libraries': [
+                        'cfgmgr32.lib'
+                    ],
+                    'msvs_settings': {
+                        'VCCLCompilerTool': {
+                            'ExceptionHandling': 1
+                        }
+                    }
+                }],
+                ['OS=="mac"', {
+                    'xcode_settings': {
+                        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                        'CLANG_CXX_LIBRARY': 'libc++',
+                        'OTHER_LDFLAGS': [
+                            '-framework', 'CoreFoundation',
+                            '-framework', 'IOKit',
+                            '-framework', 'Security'
+                        ]
+                    }
+                }]
+            ]
+        },
+        {
+            'target_name': 'vkgs_usb',
+            'include_dirs': [
+                './vkgs_usb/api',
+                "<!@(node -p \"require('node-addon-api').include\")"
+            ],
+            'dependencies': [
+                "<!(node -p \"require('node-addon-api').gyp\")",
+                '../../../node_modules/usb/libusb.gypi:libusb'
+            ],
+            'defines': [
+                'NAPI_CPP_EXCEPTIONS'
+            ],
+            'sources': [
+                './vkgs_usb/native/transport.cpp',
+                './vkgs_usb/api/vkgs_usb.cpp'
+            ],
+            'cflags!': [ '-fno-exceptions' ],
+            'cflags_cc!': [ '-fno-exceptions' ],
+            'cflags': [ '-fexceptions' ],
+            'cflags_cc': [ '-fexceptions' ],
+            'conditions': [
+                ['OS=="win"', {
+                    'defines': [
+                        'WIN32_LEAN_AND_MEAN'
+                    ],
+                    'libraries': [
+                        'cfgmgr32.lib'
+                    ],
+                    'msvs_settings': {
+                        'VCCLCompilerTool': {
+                            'ExceptionHandling': 1
+                        }
+                    }
+                }],
+                ['OS=="mac"', {
+                    'xcode_settings': {
+                        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                        'CLANG_CXX_LIBRARY': 'libc++',
+                        'OTHER_LDFLAGS': [
+                            '-framework', 'CoreFoundation',
+                            '-framework', 'IOKit',
+                            '-framework', 'Security'
+                        ]
+                    }
+                }]
+            ]
+        },
         {
             'target_name': 'candle',
             'conditions': [

--- a/src/main/docan/can.ts
+++ b/src/main/docan/can.ts
@@ -11,6 +11,8 @@ import { CanBaseInfo } from '../share/can'
 import { CanBase } from './base'
 import { SLCAN_CAN } from './slcan'
 import { Candle_CAN } from './candle'
+import { VCAN_USB_CAN } from './vcan_usb'
+import { VKGS_USB_CAN } from './vkgs_usb'
 
 const libPath = path.dirname(dllLib)
 PEAK_TP.loadDllPath(libPath)
@@ -38,6 +40,10 @@ export function openCanDevice(canDevice: CanBaseInfo) {
     canBase = new SLCAN_CAN(canDevice)
   } else if (canDevice.vendor == 'candle') {
     canBase = new Candle_CAN(canDevice)
+  } else if (canDevice.vendor == 'vcan_usb') {
+    canBase = new VCAN_USB_CAN(canDevice)
+  } else if (canDevice.vendor == 'vkgs_usb') {
+    canBase = new VKGS_USB_CAN(canDevice)
   }
 
   return canBase
@@ -61,6 +67,10 @@ export function getCanVersion(vendor: string) {
     return SLCAN_CAN.getLibVersion()
   } else if (vendor === 'CANDLE') {
     return Candle_CAN.getLibVersion()
+  } else if (vendor === 'VCAN_USB') {
+    return VCAN_USB_CAN.getLibVersion()
+  } else if (vendor === 'VKGS_USB') {
+    return VKGS_USB_CAN.getLibVersion()
   } else {
     return 'Not supported'
   }
@@ -84,6 +94,10 @@ export function getCanDevices(vendor: string) {
     return SLCAN_CAN.getValidDevices()
   } else if (vendor === 'CANDLE') {
     return Candle_CAN.getValidDevices()
+  } else if (vendor === 'VCAN_USB') {
+    return VCAN_USB_CAN.getValidDevices()
+  } else if (vendor === 'VKGS_USB') {
+    return VKGS_USB_CAN.getValidDevices()
   } else {
     return []
   }

--- a/src/main/docan/vcan_usb/api/vcan_usb.cpp
+++ b/src/main/docan/vcan_usb/api/vcan_usb.cpp
@@ -1,0 +1,699 @@
+#include "vcan_usb.h"
+
+#include <libusb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint16_t kDeviceVid = 0x1d50;
+constexpr uint16_t kDevicePid = 0x6080;
+constexpr uint32_t kDefaultTimeoutMs = 2000;
+constexpr uint32_t kDefaultPollMs = 100;
+constexpr size_t kMaxPortDepth = 16;
+constexpr const char *kPathPrefix = "libusb://1d50:6080/";
+
+struct DeviceKey {
+  uint8_t bus = 0;
+  uint8_t address = 0;
+  uint8_t interface_number = 0;
+  std::vector<uint8_t> ports;
+};
+
+struct InterfaceInfo {
+  uint8_t number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+};
+
+struct EnumeratedInterface {
+  std::string path;
+  std::string label;
+  InterfaceInfo interface;
+  bool busy = false;
+};
+
+void CopyText(char *destination, size_t capacity, const std::string &source) {
+  if (destination == nullptr || capacity == 0)
+    return;
+  const size_t length = std::min(capacity - 1, source.size());
+  if (length > 0)
+    std::memcpy(destination, source.data(), length);
+  destination[length] = '\0';
+}
+
+vcan_usb_status_t StatusFromLibusb(int code, bool cancelled) {
+  if (cancelled) {
+    return VCAN_USB_STATUS_CANCELLED;
+  }
+  if (code == LIBUSB_ERROR_INVALID_PARAM) {
+    return VCAN_USB_STATUS_INVALID_ARGUMENT;
+  }
+  if (code == LIBUSB_ERROR_TIMEOUT)
+    return VCAN_USB_STATUS_TIMEOUT;
+  if (code == LIBUSB_ERROR_NOT_FOUND) {
+    return VCAN_USB_STATUS_ENDPOINT_NOT_FOUND;
+  }
+  return VCAN_USB_STATUS_SYSTEM_ERROR;
+}
+
+std::string LibusbMessage(int code) {
+  const char *name = libusb_error_name(code);
+  const char *detail = libusb_strerror(static_cast<libusb_error>(code));
+  std::string message = name != nullptr ? name : "LIBUSB_ERROR_UNKNOWN";
+  if (detail != nullptr && detail[0] != '\0' && message != detail) {
+    message += ": ";
+    message += detail;
+  }
+  return message;
+}
+
+void SetError(vcan_usb_error_t *error, vcan_usb_status_t status,
+              const char *operation, int32_t native_code,
+              const std::string &detail) {
+  if (error == nullptr)
+    return;
+  vcan_usb_error_clear(error);
+  error->status = status;
+  error->native_code = native_code;
+  CopyText(error->operation, sizeof(error->operation),
+           operation != nullptr ? operation : "libusb");
+  CopyText(error->message, sizeof(error->message),
+           detail.empty() ? "operation failed" : detail);
+}
+
+void SetLibusbError(vcan_usb_error_t *error, const char *operation, int code,
+                    bool cancelled = false) {
+  SetError(error, StatusFromLibusb(code, cancelled), operation, code,
+           cancelled ? "USB transfer was cancelled" : LibusbMessage(code));
+}
+
+bool ParseByte(const std::string &text, uint8_t *output) {
+  if (text.empty() || output == nullptr)
+    return false;
+  errno = 0;
+  char *end = nullptr;
+  const unsigned long value = std::strtoul(text.c_str(), &end, 10);
+  if (errno != 0 || end == text.c_str() || *end != '\0' || value > UINT8_MAX) {
+    return false;
+  }
+  *output = static_cast<uint8_t>(value);
+  return true;
+}
+
+std::vector<uint8_t> GetPorts(libusb_device *device) {
+  uint8_t ports[kMaxPortDepth]{};
+  const int count =
+      libusb_get_port_numbers(device, ports, static_cast<int>(kMaxPortDepth));
+  if (count <= 0)
+    return {};
+  return std::vector<uint8_t>(ports, ports + count);
+}
+
+std::string MakePath(libusb_device *device, uint8_t interface_number) {
+  std::ostringstream output;
+  output << kPathPrefix << static_cast<unsigned>(libusb_get_bus_number(device))
+         << '/';
+  const auto ports = GetPorts(device);
+  if (ports.empty()) {
+    output << 'a' << static_cast<unsigned>(libusb_get_device_address(device));
+  } else {
+    output << 'p';
+    for (size_t index = 0; index < ports.size(); ++index) {
+      if (index != 0)
+        output << '.';
+      output << static_cast<unsigned>(ports[index]);
+    }
+  }
+  output << '/' << static_cast<unsigned>(interface_number);
+  return output.str();
+}
+
+bool ParsePath(const char *path, DeviceKey *key) {
+  if (path == nullptr || key == nullptr)
+    return false;
+  const std::string value(path);
+  if (value.compare(0, std::strlen(kPathPrefix), kPathPrefix) != 0)
+    return false;
+  const std::string body = value.substr(std::strlen(kPathPrefix));
+  const size_t first = body.find('/');
+  const size_t second = first == std::string::npos ? std::string::npos
+                                                   : body.find('/', first + 1);
+  if (first == std::string::npos || second == std::string::npos ||
+      body.find('/', second + 1) != std::string::npos) {
+    return false;
+  }
+  DeviceKey parsed;
+  if (!ParseByte(body.substr(0, first), &parsed.bus) ||
+      !ParseByte(body.substr(second + 1), &parsed.interface_number)) {
+    return false;
+  }
+  const std::string location = body.substr(first + 1, second - first - 1);
+  if (location.size() < 2)
+    return false;
+  if (location[0] == 'a') {
+    if (!ParseByte(location.substr(1), &parsed.address))
+      return false;
+  } else if (location[0] == 'p') {
+    size_t start = 1;
+    while (start < location.size()) {
+      const size_t end = location.find('.', start);
+      uint8_t port = 0;
+      if (!ParseByte(location.substr(start, end - start), &port) || port == 0) {
+        return false;
+      }
+      parsed.ports.push_back(port);
+      if (parsed.ports.size() > kMaxPortDepth)
+        return false;
+      if (end == std::string::npos)
+        break;
+      if (end + 1 >= location.size())
+        return false;
+      start = end + 1;
+    }
+    if (parsed.ports.empty())
+      return false;
+  } else {
+    return false;
+  }
+  *key = std::move(parsed);
+  return true;
+}
+
+bool Matches(libusb_device *device, const DeviceKey &key) {
+  if (libusb_get_bus_number(device) != key.bus)
+    return false;
+  if (!key.ports.empty())
+    return GetPorts(device) == key.ports;
+  return libusb_get_device_address(device) == key.address;
+}
+
+bool FindInterface(libusb_device *device, uint8_t interface_number,
+                   InterfaceInfo *result) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return false;
+
+  bool found = false;
+  InterfaceInfo fallback{};
+  bool has_fallback = false;
+  for (uint8_t interface_index = 0;
+       interface_index < config->bNumInterfaces && !found; ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    for (int alternate_index = 0;
+         alternate_index < usb_interface.num_altsetting; ++alternate_index) {
+      const libusb_interface_descriptor &descriptor =
+          usb_interface.altsetting[alternate_index];
+      if (descriptor.bInterfaceNumber != interface_number)
+        continue;
+      InterfaceInfo candidate{};
+      candidate.number = descriptor.bInterfaceNumber;
+      candidate.alternate_setting = descriptor.bAlternateSetting;
+      for (uint8_t endpoint_index = 0;
+           endpoint_index < descriptor.bNumEndpoints; ++endpoint_index) {
+        const libusb_endpoint_descriptor &endpoint =
+            descriptor.endpoint[endpoint_index];
+        if ((endpoint.bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+            LIBUSB_TRANSFER_TYPE_BULK) {
+          continue;
+        }
+        if ((endpoint.bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) ==
+            LIBUSB_ENDPOINT_IN) {
+          candidate.endpoint_in = endpoint.bEndpointAddress;
+        } else {
+          candidate.endpoint_out = endpoint.bEndpointAddress;
+        }
+      }
+      if (candidate.endpoint_in == 0 || candidate.endpoint_out == 0)
+        continue;
+      if (!has_fallback) {
+        fallback = candidate;
+        has_fallback = true;
+      }
+      if (candidate.alternate_setting == 0) {
+        *result = candidate;
+        found = true;
+        break;
+      }
+    }
+  }
+  if (!found && has_fallback) {
+    *result = fallback;
+    found = true;
+  }
+  libusb_free_config_descriptor(config);
+  return found;
+}
+
+std::vector<InterfaceInfo> FindInterfaces(libusb_device *device) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return {};
+  std::vector<InterfaceInfo> output;
+  for (uint8_t interface_index = 0; interface_index < config->bNumInterfaces;
+       ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    if (usb_interface.num_altsetting <= 0)
+      continue;
+    const uint8_t number = usb_interface.altsetting[0].bInterfaceNumber;
+    InterfaceInfo info{};
+    if (FindInterface(device, number, &info))
+      output.push_back(info);
+  }
+  libusb_free_config_descriptor(config);
+  return output;
+}
+
+std::string ReadLabel(libusb_device_handle *handle,
+                      const libusb_device_descriptor &descriptor) {
+  if (handle == nullptr || descriptor.iProduct == 0)
+    return "VCAN USB";
+  unsigned char value[VCAN_USB_LABEL_CAPACITY]{};
+  const int length = libusb_get_string_descriptor_ascii(
+      handle, descriptor.iProduct, value, static_cast<int>(sizeof(value) - 1));
+  return length > 0 ? std::string(reinterpret_cast<char *>(value), length)
+                    : "VCAN USB";
+}
+
+bool ProbeBusy(libusb_device *device, uint8_t interface_number,
+               std::string *label, const libusb_device_descriptor &descriptor) {
+  libusb_device_handle *handle = nullptr;
+  const int open_status = libusb_open(device, &handle);
+  if (open_status != LIBUSB_SUCCESS || handle == nullptr)
+    return true;
+  *label = ReadLabel(handle, descriptor);
+  bool busy = false;
+  const int kernel_active =
+      libusb_kernel_driver_active(handle, interface_number);
+  if (kernel_active != 1) {
+    const int claim_status = libusb_claim_interface(handle, interface_number);
+    busy = claim_status != LIBUSB_SUCCESS;
+    if (!busy)
+      libusb_release_interface(handle, interface_number);
+  }
+  libusb_close(handle);
+  return busy;
+}
+
+bool ValidateOpen(vcan_usb_device_t *device, vcan_usb_error_t *error,
+                  const char *operation);
+
+} // namespace
+
+struct vcan_usb_device {
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  uint8_t interface_number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+  bool claimed = false;
+  bool manually_detached = false;
+  std::atomic<bool> cancelled{false};
+};
+
+namespace {
+
+bool ValidateOpen(vcan_usb_device_t *device, vcan_usb_error_t *error,
+                  const char *operation) {
+  if (device != nullptr && device->handle != nullptr && device->claimed) {
+    return true;
+  }
+  SetError(error, VCAN_USB_STATUS_NOT_OPEN, operation, LIBUSB_ERROR_NO_DEVICE,
+           "VCAN USB device is not open");
+  return false;
+}
+
+bool ControlTransfer(vcan_usb_device_t *device, uint8_t request_type,
+                     uint8_t request, uint16_t value, uint16_t index,
+                     uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                     vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "libusb_control_transfer"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_control_transfer", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  const int transferred = libusb_control_transfer(
+      device->handle, request_type, request, value, index, data, length,
+      timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+  if (transferred < 0) {
+    SetLibusbError(error, "libusb_control_transfer", transferred,
+                   device->cancelled.load());
+    return false;
+  }
+  if (transferred != length) {
+    char detail[96]{};
+    std::snprintf(detail, sizeof(detail), "short control transfer: %d/%u",
+                  transferred, length);
+    SetError(error, VCAN_USB_STATUS_SHORT_TRANSFER, "libusb_control_transfer",
+             LIBUSB_ERROR_IO, detail);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+void vcan_usb_error_clear(vcan_usb_error_t *error) {
+  if (error == nullptr)
+    return;
+  std::memset(error, 0, sizeof(*error));
+  error->status = VCAN_USB_STATUS_OK;
+}
+
+bool vcan_usb_list_scan(vcan_usb_device_list_t *list, vcan_usb_error_t *error) {
+  if (list == nullptr) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_list_scan",
+             LIBUSB_ERROR_INVALID_PARAM, "device list is null");
+    return false;
+  }
+  std::memset(list, 0, sizeof(*list));
+  vcan_usb_error_clear(error);
+  libusb_context *context = nullptr;
+  int status = libusb_init(&context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    return false;
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    libusb_exit(context);
+    return false;
+  }
+
+  std::vector<EnumeratedInterface> found;
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid) {
+      continue;
+    }
+    for (const auto &usb_interface : FindInterfaces(devices[index])) {
+      EnumeratedInterface item;
+      item.path = MakePath(devices[index], usb_interface.number);
+      item.interface = usb_interface;
+      item.label = "VCAN USB";
+      item.busy = ProbeBusy(devices[index], usb_interface.number, &item.label,
+                            descriptor);
+      found.push_back(std::move(item));
+    }
+  }
+  libusb_free_device_list(devices, 1);
+  libusb_exit(context);
+
+  std::sort(found.begin(), found.end(),
+            [](const auto &left, const auto &right) {
+              return left.path < right.path;
+            });
+  list->count =
+      std::min(found.size(), static_cast<size_t>(VCAN_USB_MAX_DEVICES));
+  for (size_t index = 0; index < list->count; ++index) {
+    const auto &source = found[index];
+    auto &target = list->devices[index];
+    CopyText(target.path, sizeof(target.path), source.path);
+    CopyText(target.label, sizeof(target.label), source.label);
+    target.interface_number = source.interface.number;
+    target.endpoint_in = source.interface.endpoint_in;
+    target.endpoint_out = source.interface.endpoint_out;
+    target.busy = source.busy;
+  }
+  return true;
+}
+
+vcan_usb_device_t *vcan_usb_open(const char *path, vcan_usb_error_t *error) {
+  vcan_usb_error_clear(error);
+  DeviceKey key;
+  if (!ParsePath(path, &key)) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_open",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid libusb device path");
+    return nullptr;
+  }
+  auto *result = new (std::nothrow) vcan_usb_device_t();
+  if (result == nullptr) {
+    SetError(error, VCAN_USB_STATUS_SYSTEM_ERROR, "vcan_usb_open",
+             LIBUSB_ERROR_NO_MEM, "unable to allocate the USB device");
+    return nullptr;
+  }
+  int status = libusb_init(&result->context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    vcan_usb_close(result);
+    return nullptr;
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(result->context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    vcan_usb_close(result);
+    return nullptr;
+  }
+
+  InterfaceInfo usb_interface{};
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid || !Matches(devices[index], key) ||
+        !FindInterface(devices[index], key.interface_number, &usb_interface)) {
+      continue;
+    }
+    status = libusb_open(devices[index], &result->handle);
+    break;
+  }
+  libusb_free_device_list(devices, 1);
+  if (result->handle == nullptr || status != LIBUSB_SUCCESS) {
+    if (status == LIBUSB_SUCCESS)
+      status = LIBUSB_ERROR_NO_DEVICE;
+    SetLibusbError(error, "libusb_open", status);
+    vcan_usb_close(result);
+    return nullptr;
+  }
+
+  result->interface_number = usb_interface.number;
+  result->alternate_setting = usb_interface.alternate_setting;
+  result->endpoint_in = usb_interface.endpoint_in;
+  result->endpoint_out = usb_interface.endpoint_out;
+  const int kernel_active =
+      libusb_kernel_driver_active(result->handle, result->interface_number);
+  const int auto_detach =
+      libusb_set_auto_detach_kernel_driver(result->handle, 1);
+  if (kernel_active == 1 && auto_detach != LIBUSB_SUCCESS) {
+    status =
+        libusb_detach_kernel_driver(result->handle, result->interface_number);
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_detach_kernel_driver", status);
+      vcan_usb_close(result);
+      return nullptr;
+    }
+    result->manually_detached = true;
+  }
+  status = libusb_claim_interface(result->handle, result->interface_number);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_claim_interface", status);
+    vcan_usb_close(result);
+    return nullptr;
+  }
+  result->claimed = true;
+  if (result->alternate_setting != 0) {
+    status = libusb_set_interface_alt_setting(
+        result->handle, result->interface_number, result->alternate_setting);
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_set_interface_alt_setting", status);
+      vcan_usb_close(result);
+      return nullptr;
+    }
+  }
+  libusb_clear_halt(result->handle, result->endpoint_in);
+  libusb_clear_halt(result->handle, result->endpoint_out);
+  return result;
+}
+
+uint8_t vcan_usb_interface_number(const vcan_usb_device_t *device) {
+  return device != nullptr ? device->interface_number : 0;
+}
+
+bool vcan_usb_control_in(vcan_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vcan_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) == 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_control_in",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control IN arguments");
+    return false;
+  }
+  vcan_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index, data,
+                         length, timeout_ms, error);
+}
+
+bool vcan_usb_control_out(vcan_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vcan_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) != 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_control_out",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control OUT arguments");
+    return false;
+  }
+  vcan_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index,
+                         const_cast<uint8_t *>(data), length, timeout_ms,
+                         error);
+}
+
+bool vcan_usb_bulk_read(vcan_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vcan_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || capacity == 0 || capacity > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_bulk_read",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk read arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(IN)"))
+    return false;
+  vcan_usb_error_clear(error);
+  const unsigned int poll =
+      poll_timeout_ms == 0 ? kDefaultPollMs : poll_timeout_ms;
+  bool retried_stall = false;
+  while (!device->cancelled.load()) {
+    int count = 0;
+    const int status =
+        libusb_bulk_transfer(device->handle, device->endpoint_in, data,
+                             static_cast<int>(capacity), &count, poll);
+    if (count > 0) {
+      *transferred = static_cast<size_t>(count);
+      return true;
+    }
+    if (status == LIBUSB_SUCCESS)
+      return true;
+    if (status == LIBUSB_ERROR_TIMEOUT ||
+        (status == LIBUSB_ERROR_INTERRUPTED && !device->cancelled.load())) {
+      retried_stall = false;
+      continue;
+    }
+    if (status == LIBUSB_ERROR_PIPE && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_in) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    SetLibusbError(error, "libusb_bulk_transfer(IN)", status,
+                   device->cancelled.load());
+    return false;
+  }
+  SetLibusbError(error, "libusb_bulk_transfer(IN)", LIBUSB_ERROR_INTERRUPTED,
+                 true);
+  return false;
+}
+
+bool vcan_usb_bulk_write(vcan_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vcan_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || length == 0 || length > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_bulk_write",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk write arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(OUT)"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  vcan_usb_error_clear(error);
+  bool retried_stall = false;
+  while (true) {
+    int count = 0;
+    const int status = libusb_bulk_transfer(
+        device->handle, device->endpoint_out, const_cast<uint8_t *>(data),
+        static_cast<int>(length), &count,
+        timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+    if (status == LIBUSB_ERROR_PIPE && count == 0 && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_out) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_bulk_transfer(OUT)", status,
+                     device->cancelled.load());
+      return false;
+    }
+    *transferred = static_cast<size_t>(count);
+    if (static_cast<size_t>(count) != length) {
+      char detail[96]{};
+      std::snprintf(detail, sizeof(detail), "short bulk write: %d/%zu", count,
+                    length);
+      SetError(error, VCAN_USB_STATUS_SHORT_TRANSFER,
+               "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_IO, detail);
+      return false;
+    }
+    return true;
+  }
+}
+
+void vcan_usb_cancel(vcan_usb_device_t *device) {
+  if (device != nullptr)
+    device->cancelled.store(true);
+}
+
+void vcan_usb_close(vcan_usb_device_t *device) {
+  if (device == nullptr)
+    return;
+  vcan_usb_cancel(device);
+  if (device->handle != nullptr) {
+    if (device->claimed) {
+      libusb_release_interface(device->handle, device->interface_number);
+      device->claimed = false;
+    }
+    if (device->manually_detached) {
+      libusb_attach_kernel_driver(device->handle, device->interface_number);
+      device->manually_detached = false;
+    }
+    libusb_close(device->handle);
+    device->handle = nullptr;
+  }
+  if (device->context != nullptr) {
+    libusb_exit(device->context);
+    device->context = nullptr;
+  }
+  delete device;
+}

--- a/src/main/docan/vcan_usb/api/vcan_usb.h
+++ b/src/main/docan/vcan_usb/api/vcan_usb.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VCAN_USB_MAX_DEVICES 64
+#define VCAN_USB_PATH_CAPACITY 1024
+#define VCAN_USB_LABEL_CAPACITY 256
+#define VCAN_USB_OPERATION_CAPACITY 64
+#define VCAN_USB_MESSAGE_CAPACITY 512
+
+typedef enum {
+  VCAN_USB_STATUS_OK = 0,
+  VCAN_USB_STATUS_INVALID_ARGUMENT,
+  VCAN_USB_STATUS_SYSTEM_ERROR,
+  VCAN_USB_STATUS_NOT_OPEN,
+  VCAN_USB_STATUS_ENDPOINT_NOT_FOUND,
+  VCAN_USB_STATUS_SHORT_TRANSFER,
+  VCAN_USB_STATUS_TIMEOUT,
+  VCAN_USB_STATUS_CANCELLED
+} vcan_usb_status_t;
+
+typedef struct {
+  vcan_usb_status_t status;
+  int32_t native_code;
+  char operation[VCAN_USB_OPERATION_CAPACITY];
+  char message[VCAN_USB_MESSAGE_CAPACITY];
+} vcan_usb_error_t;
+
+typedef struct {
+  char path[VCAN_USB_PATH_CAPACITY];
+  char label[VCAN_USB_LABEL_CAPACITY];
+  uint8_t interface_number;
+  uint8_t endpoint_in;
+  uint8_t endpoint_out;
+  bool busy;
+} vcan_usb_interface_t;
+
+typedef struct {
+  size_t count;
+  vcan_usb_interface_t devices[VCAN_USB_MAX_DEVICES];
+} vcan_usb_device_list_t;
+
+typedef struct vcan_usb_device vcan_usb_device_t;
+
+void vcan_usb_error_clear(vcan_usb_error_t *error);
+
+bool vcan_usb_list_scan(vcan_usb_device_list_t *list, vcan_usb_error_t *error);
+
+vcan_usb_device_t *vcan_usb_open(const char *path, vcan_usb_error_t *error);
+
+uint8_t vcan_usb_interface_number(const vcan_usb_device_t *device);
+
+bool vcan_usb_control_in(vcan_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vcan_usb_error_t *error);
+
+bool vcan_usb_control_out(vcan_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vcan_usb_error_t *error);
+
+bool vcan_usb_bulk_read(vcan_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vcan_usb_error_t *error);
+
+bool vcan_usb_bulk_write(vcan_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vcan_usb_error_t *error);
+
+void vcan_usb_cancel(vcan_usb_device_t *device);
+
+void vcan_usb_close(vcan_usb_device_t *device);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/main/docan/vcan_usb/devicePath.ts
+++ b/src/main/docan/vcan_usb/devicePath.ts
@@ -1,0 +1,43 @@
+export interface VcanUsbPathCandidate {
+  path: string
+  interfaceNumber: number
+}
+
+const CURRENT_PATH_PREFIX = 'libusb://1d50:6080/'
+const LEGACY_DEVICE_ID = 'vid_1d50&pid_6080'
+
+/**
+ * Resolves handles saved by the former WinUSB backend without coupling the
+ * driver to a platform API. A legacy handle is migrated only when its channel
+ * identifies exactly one currently connected libusb interface.
+ */
+export function resolveVcanUsbPath(
+  path: string,
+  channel: number,
+  listDevices: () => readonly VcanUsbPathCandidate[]
+): string {
+  if (path.startsWith(CURRENT_PATH_PREFIX)) return path
+  if (!path.toLowerCase().includes(LEGACY_DEVICE_ID)) return path
+
+  let matches: readonly VcanUsbPathCandidate[]
+  try {
+    matches = listDevices().filter((device) => device.interfaceNumber === channel)
+  } catch (error) {
+    throw new Error(
+      `Unable to migrate the stored VCAN USB device path: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+
+  if (matches.length === 1) return matches[0].path
+  if (matches.length === 0) {
+    throw new Error(
+      `The stored VCAN USB device path uses the legacy WinUSB format, but channel ${channel} is not connected. Reconnect the device and reselect it in Hardware.`
+    )
+  }
+
+  throw new Error(
+    `The stored VCAN USB device path matches multiple channel ${channel} interfaces. Reselect the intended device in Hardware.`
+  )
+}

--- a/src/main/docan/vcan_usb/index.ts
+++ b/src/main/docan/vcan_usb/index.ts
@@ -1,0 +1,489 @@
+import { EventEmitter } from 'events'
+import { cloneDeep } from 'lodash'
+import {
+  CAN_ERROR_ID,
+  CAN_ID_TYPE,
+  CanBaseInfo,
+  CanDevice,
+  CanError,
+  CanMessage,
+  CanMsgType,
+  getTsUs
+} from '../../share/can'
+import { CanLOG } from '../../log'
+import { CanBase } from '../base'
+import { VcanUsbApi, VcanUsbCapabilities, VcanUsbDeviceInfo } from './protocol'
+import { NativeTransportError, VcanUsbTransport } from './transport'
+import { normalizeVcanData, VcanUsbEvent, VcanUsbFrame, VcanWireDecoder } from './wire'
+
+interface PendingTransmit {
+  resolve: (timestamp: number) => void
+  reject: (error: CanError) => void
+  id: number
+  msgType: CanMsgType
+  data: Buffer
+  extra?: { database?: string; name?: string }
+}
+
+interface PendingRead {
+  reject: (error: CanError) => void
+  msgType: CanMsgType
+  eventName: string
+  listener: (message: CanMessage | CanError) => void
+  timer: NodeJS.Timeout
+}
+
+const STATE_NAMES = [
+  'error-active',
+  'error-warning',
+  'error-passive',
+  'bus-off',
+  'stopped',
+  'sleeping'
+]
+
+const ERROR_NAMES = ['none', 'stuff', 'form', 'ack', 'bit1', 'bit0', 'crc']
+
+function splitHandle(handle: unknown): { path: string; channel: number } {
+  const value = String(handle)
+  const separator = value.lastIndexOf('|')
+  if (separator <= 0) throw new Error('invalid VCAN USB handle')
+  const channel = Number(value.slice(separator + 1))
+  if (!Number.isInteger(channel) || channel < 0 || channel > 255) {
+    throw new Error(`invalid VCAN USB channel in handle: ${value}`)
+  }
+  return { path: value.slice(0, separator), channel }
+}
+
+function formatVersion(version: number) {
+  return `${(version >>> 24) & 0xff}.${(version >>> 16) & 0xff}.${
+    (version >>> 8) & 0xff
+  }.${version & 0xff}`
+}
+
+function makeExtra(
+  capabilities: VcanUsbCapabilities,
+  deviceInfo?: VcanUsbDeviceInfo,
+  termination?: boolean
+) {
+  return {
+    usbCan: {
+      protocol: 'vcan_usb' as const,
+      cap: capabilities.nominal,
+      dataCap: capabilities.data,
+      fdSupported: capabilities.fdSupported,
+      Res: capabilities.terminationSupported || termination !== undefined,
+      termination,
+      swVersion: deviceInfo?.swVersion,
+      hwVersion: deviceInfo?.hwVersion
+    }
+  }
+}
+
+function getVcanUsbDevices(): CanDevice[] {
+  const interfaces = VcanUsbTransport.listDevices()
+  return interfaces.map((item, index) => {
+    let capabilities = VcanUsbApi.fallbackCapabilities()
+    let deviceInfo: VcanUsbDeviceInfo | undefined
+    let termination: boolean | undefined
+    let busy = item.busy
+
+    if (!busy) {
+      let transport: VcanUsbTransport | undefined
+      try {
+        transport = VcanUsbTransport.open(
+          item.path,
+          () => {},
+          () => {},
+          () => {}
+        )
+        const api = new VcanUsbApi(transport, item.interfaceNumber)
+        capabilities = api.readCapabilities()
+        try {
+          deviceInfo = api.readDeviceInfo()
+        } catch (error) {
+          sysLog.warn(
+            `vcan_usb device-info query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+        try {
+          termination = api.getTermination()
+        } catch (error) {
+          sysLog.warn(
+            `vcan_usb termination query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      } catch (error) {
+        busy = true
+        sysLog.warn(
+          `vcan_usb probe failed for channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      } finally {
+        transport?.close()
+      }
+    }
+
+    return {
+      label: `${item.label} CH${item.interfaceNumber}`,
+      id: `vcan_usb-${index}-ch${item.interfaceNumber}`,
+      handle: `${item.path}|${item.interfaceNumber}`,
+      serialNumber: item.path,
+      busy,
+      extra: makeExtra(capabilities, deviceInfo, termination)
+    }
+  })
+}
+
+export class VCAN_USB_CAN extends CanBase {
+  readonly event = new EventEmitter()
+  readonly info: CanBaseInfo
+  readonly log: CanLOG
+  closed = false
+
+  private readonly transport: VcanUsbTransport
+  private readonly api: VcanUsbApi
+  private readonly decoder: VcanWireDecoder
+  private readonly startTime = getTsUs()
+  private timestampOffset?: number
+  private nextToken = 1
+  private nextRead = 1
+  private lastState = -1
+  private fatalTransportError = false
+  private readonly pendingTransmits = new Map<number, PendingTransmit>()
+  private readonly pendingReads = new Map<number, PendingRead>()
+
+  constructor(info: CanBaseInfo) {
+    super()
+    this.info = cloneDeep(info)
+    this.log = new CanLOG('VCAN_USB', info.name, info.id, this.event)
+    const { path, channel } = splitHandle(info.handle)
+    this.transport = VcanUsbTransport.open(
+      path,
+      (data) => this.receive(data),
+      (error) => this.transportError(error),
+      (result) => this.transmitComplete(result)
+    )
+    this.api = new VcanUsbApi(this.transport, channel)
+    try {
+      const capabilities = this.api.readCapabilities()
+      this.validateTiming(info, capabilities)
+      try {
+        const deviceInfo = this.api.readDeviceInfo()
+        sysLog.info(
+          `vcan_usb ${info.name}: SW ${formatVersion(deviceInfo.swVersion)}, HW ${formatVersion(deviceInfo.hwVersion)}, channel ${channel}`
+        )
+      } catch (error) {
+        sysLog.warn(
+          `vcan_usb ${info.name}: device-info query unavailable: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+      this.decoder = this.api.configure(info, !!info.vcanUsbRes)
+      this.transport.startReceive()
+      this.attachCanMessage(this.busloadCb)
+    } catch (error) {
+      try {
+        this.api.stop()
+      } catch {
+        // Preserve the original configuration/open error.
+      }
+      this.transport.close()
+      this.log.close()
+      throw error
+    }
+  }
+
+  private validateTiming(info: CanBaseInfo, capabilities: VcanUsbCapabilities) {
+    const validate = (
+      name: string,
+      timing: CanBaseInfo['bitrate'],
+      cap: typeof capabilities.nominal
+    ) => {
+      const clock = Number(timing.clock) * 1_000_000
+      const calculated = Math.floor(
+        clock / (timing.preScaler * (1 + timing.timeSeg1 + timing.timeSeg2))
+      )
+      if (clock !== cap.fclk_can) {
+        throw new Error(`${name} clock must be ${cap.fclk_can / 1_000_000} MHz`)
+      }
+      if (Math.abs(calculated - timing.freq) / timing.freq > 0.01) {
+        throw new Error(`${name} timing calculates ${calculated} Hz, expected ${timing.freq} Hz`)
+      }
+      if (timing.timeSeg1 < cap.tseg1_min || timing.timeSeg1 > cap.tseg1_max) {
+        throw new Error(`${name} timeSeg1 is outside ${cap.tseg1_min}..${cap.tseg1_max}`)
+      }
+      if (timing.timeSeg2 < cap.tseg2_min || timing.timeSeg2 > cap.tseg2_max) {
+        throw new Error(`${name} timeSeg2 is outside ${cap.tseg2_min}..${cap.tseg2_max}`)
+      }
+      if (timing.sjw < 1 || timing.sjw > cap.sjw_max) {
+        throw new Error(`${name} sjw is outside 1..${cap.sjw_max}`)
+      }
+      if (timing.preScaler < cap.brp_min || timing.preScaler > cap.brp_max) {
+        throw new Error(`${name} prescaler is outside ${cap.brp_min}..${cap.brp_max}`)
+      }
+      if ((timing.preScaler - cap.brp_min) % Math.max(1, cap.brp_inc) !== 0) {
+        throw new Error(`${name} prescaler does not match the device increment ${cap.brp_inc}`)
+      }
+    }
+
+    validate('CAN', info.bitrate, capabilities.nominal)
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('CAN FD data timing is required')
+      validate('CAN FD', info.bitratefd, capabilities.data || capabilities.nominal)
+    }
+  }
+
+  private receive(transfer: Buffer) {
+    if (this.closed) return
+    try {
+      const decoded = this.decoder.push(transfer)
+      for (const event of decoded.events) this.handleWireEvent(event)
+      for (const frame of decoded.frames) this.handleFrame(frame)
+    } catch (error) {
+      this.decoder.reset()
+      this.log.error(
+        getTsUs() - this.startTime,
+        `VCAN USB receive framing error: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  private handleFrame(frame: VcanUsbFrame) {
+    let timestamp = getTsUs() - this.startTime
+    if (frame.timestampUs > 0) {
+      if (this.timestampOffset === undefined) this.timestampOffset = frame.timestampUs - timestamp
+      timestamp = frame.timestampUs - this.timestampOffset
+    }
+    const msgType: CanMsgType = {
+      idType: frame.extended ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+      canfd: frame.fd,
+      brs: frame.brs,
+      remote: frame.remote
+    }
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'IN',
+      id: frame.id,
+      data: frame.remote ? Buffer.alloc(0) : frame.data,
+      ts: timestamp,
+      msgType,
+      database: this.info.database
+    }
+    this.log.canBase(message)
+    this.event.emit(this.getReadBaseId(frame.id, msgType), message)
+  }
+
+  private handleWireEvent(event: VcanUsbEvent) {
+    if (event.kind === 'state') {
+      if (event.state === this.lastState) return
+      this.lastState = event.state
+      if (event.state !== 0) {
+        this.log.error(
+          event.timestampUs || getTsUs() - this.startTime,
+          `CAN state ${STATE_NAMES[event.state] || event.state}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+        )
+      }
+      return
+    }
+    if (event.errorCode !== 0) {
+      this.log.error(
+        getTsUs() - this.startTime,
+        `CAN bus error ${ERROR_NAMES[event.errorCode] || event.errorCode}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+      )
+    }
+  }
+
+  private transmitComplete(result: { token: number; ok: boolean; error?: string }) {
+    const pending = this.pendingTransmits.get(result.token)
+    if (!pending) return
+    this.pendingTransmits.delete(result.token)
+    if (!result.ok) {
+      pending.reject(
+        new CanError(CAN_ERROR_ID.CAN_INTERNAL_ERROR, pending.msgType, pending.data, result.error)
+      )
+      return
+    }
+    const timestamp = getTsUs() - this.startTime
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'OUT',
+      id: pending.id,
+      data: pending.data,
+      ts: timestamp,
+      msgType: pending.msgType,
+      database: pending.extra?.database,
+      name: pending.extra?.name
+    }
+    this.log.canBase(message)
+    pending.resolve(timestamp)
+  }
+
+  private transportError(error: NativeTransportError) {
+    if (this.closed) return
+    this.fatalTransportError = true
+    this.log.error(getTsUs() - this.startTime, error.message)
+    this.rejectAll(CAN_ERROR_ID.CAN_INTERNAL_ERROR, error)
+    setImmediate(() => this.close())
+  }
+
+  private rejectAll(errorId: CAN_ERROR_ID, cause?: unknown) {
+    for (const pending of this.pendingTransmits.values()) {
+      pending.reject(
+        new CanError(
+          errorId,
+          pending.msgType,
+          pending.data,
+          cause instanceof Error ? cause.message : cause === undefined ? undefined : String(cause)
+        )
+      )
+    }
+    this.pendingTransmits.clear()
+    for (const pending of this.pendingReads.values()) {
+      clearTimeout(pending.timer)
+      this.event.off(pending.eventName, pending.listener)
+      pending.reject(new CanError(errorId, pending.msgType))
+    }
+    this.pendingReads.clear()
+  }
+
+  setOption(cmd: string, value: unknown): unknown {
+    return this._setOption(cmd, value)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    this.rejectAll(CAN_ERROR_ID.CAN_BUS_CLOSED)
+    if (!this.fatalTransportError) {
+      try {
+        this.api.stop()
+      } catch (error) {
+        sysLog.warn(
+          `vcan_usb stop failed: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    this.transport.close()
+    this.detachCanMessage(this.busloadCb)
+    this.log.close()
+    this._close()
+  }
+
+  writeBase(
+    id: number,
+    msgType: CanMsgType,
+    data: Buffer,
+    extra?: { database?: string; name?: string }
+  ): Promise<number> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType, data))
+    }
+    const maximumId = msgType.idType === CAN_ID_TYPE.EXTENDED ? 0x1fffffff : 0x7ff
+    if (!Number.isInteger(id) || id < 0 || id > maximumId || (msgType.brs && !msgType.canfd)) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_PARAM_ERROR, msgType, data))
+    }
+
+    let normalized: Buffer
+    try {
+      normalized = normalizeVcanData(data, msgType.canfd)
+    } catch (error) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          msgType,
+          data,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    const frame: VcanUsbFrame = {
+      id,
+      data: normalized,
+      fd: msgType.canfd,
+      brs: msgType.brs,
+      extended: msgType.idType === CAN_ID_TYPE.EXTENDED,
+      remote: msgType.remote,
+      timestampUs: 0
+    }
+    const packet = this.api.encodeFrame(frame)
+
+    return new Promise<number>((resolve, reject) => {
+      const token = this.nextTransmitToken()
+      this.pendingTransmits.set(token, { resolve, reject, id, msgType, data: normalized, extra })
+      try {
+        if (!this.transport.write(packet, token)) {
+          this.pendingTransmits.delete(token)
+          reject(
+            new CanError(
+              CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+              msgType,
+              normalized,
+              'VCAN USB transmit queue is full'
+            )
+          )
+        }
+      } catch (error) {
+        this.pendingTransmits.delete(token)
+        reject(
+          new CanError(
+            CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+            msgType,
+            normalized,
+            error instanceof Error ? error.message : String(error)
+          )
+        )
+      }
+    })
+  }
+
+  private nextTransmitToken() {
+    while (this.pendingTransmits.has(this.nextToken)) {
+      this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    }
+    const token = this.nextToken
+    this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    return token
+  }
+
+  readBase(
+    id: number,
+    msgType: CanMsgType,
+    timeout: number
+  ): Promise<{ data: Buffer; ts: number }> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType))
+    }
+    const eventName = this.getReadBaseId(id, msgType)
+    const readId = this.nextRead++
+    return new Promise((resolve, reject) => {
+      const listener = (value: CanMessage | CanError) => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        clearTimeout(pending.timer)
+        this.pendingReads.delete(readId)
+        if (value instanceof CanError) reject(value)
+        else resolve({ data: value.data, ts: value.ts! })
+      }
+      const timer = setTimeout(() => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        this.pendingReads.delete(readId)
+        this.event.off(eventName, listener)
+        reject(new CanError(CAN_ERROR_ID.CAN_READ_TIMEOUT, msgType))
+      }, timeout)
+      this.pendingReads.set(readId, { reject, msgType, eventName, listener, timer })
+      this.event.once(eventName, listener)
+    })
+  }
+
+  getReadBaseId(id: number, msgType: CanMsgType): string {
+    return `${id}-${msgType.canfd ? msgType.brs : false}-${msgType.remote}-${msgType.canfd}-${msgType.idType}`
+  }
+
+  static override getValidDevices(): CanDevice[] {
+    return getVcanUsbDevices()
+  }
+
+  static override getLibVersion(): string {
+    return '1.0.0 (libusb)'
+  }
+}

--- a/src/main/docan/vcan_usb/index.ts
+++ b/src/main/docan/vcan_usb/index.ts
@@ -12,6 +12,7 @@ import {
 } from '../../share/can'
 import { CanLOG } from '../../log'
 import { CanBase } from '../base'
+import { resolveVcanUsbPath } from './devicePath'
 import { VcanUsbApi, VcanUsbCapabilities, VcanUsbDeviceInfo } from './protocol'
 import { NativeTransportError, VcanUsbTransport } from './transport'
 import { normalizeVcanData, VcanUsbEvent, VcanUsbFrame, VcanWireDecoder } from './wire'
@@ -156,7 +157,9 @@ export class VCAN_USB_CAN extends CanBase {
     super()
     this.info = cloneDeep(info)
     this.log = new CanLOG('VCAN_USB', info.name, info.id, this.event)
-    const { path, channel } = splitHandle(info.handle)
+    const { path: storedPath, channel } = splitHandle(info.handle)
+    const path = resolveVcanUsbPath(storedPath, channel, () => VcanUsbTransport.listDevices())
+    this.info.handle = `${path}|${channel}`
     this.transport = VcanUsbTransport.open(
       path,
       (data) => this.receive(data),

--- a/src/main/docan/vcan_usb/native/transport.cpp
+++ b/src/main/docan/vcan_usb/native/transport.cpp
@@ -1,0 +1,470 @@
+#include <napi.h>
+
+#include "../api/vcan_usb.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr size_t kTransferSize = 512;
+constexpr size_t kTxQueueLimit = 512;
+constexpr uint32_t kIoTimeoutMs = 2000;
+constexpr uint32_t kRxPollMs = 100;
+
+struct TxJob {
+  uint32_t token = 0;
+  std::vector<uint8_t> bytes;
+  uint32_t delayBeforeMs = 0;
+  uint32_t delayAfterMs = 0;
+};
+
+struct TxResult {
+  uint32_t token = 0;
+  bool ok = false;
+  std::string error;
+};
+
+struct ErrorResult {
+  int32_t code = 0;
+  std::string operation;
+  std::string detail;
+};
+
+std::mutex gDevicesMutex;
+std::map<uint32_t, std::shared_ptr<class UsbTransport>> gDevices;
+std::atomic<uint32_t> gNextHandle{1};
+
+std::string ApiErrorMessage(const vcan_usb_error_t &error) {
+  std::ostringstream output;
+  output << (error.operation[0] != '\0' ? error.operation : "VCAN USB");
+  if (error.message[0] != '\0')
+    output << " failed: " << error.message;
+  if (error.native_code != 0)
+    output << " (code " << error.native_code << ')';
+  return output.str();
+}
+
+int32_t ApiErrorCode(const vcan_usb_error_t &error) {
+  return error.native_code != 0 ? error.native_code
+                                : static_cast<int32_t>(error.status);
+}
+
+class UsbTransport {
+public:
+  UsbTransport(Napi::Env env, std::string path, Napi::Function rxCallback,
+               Napi::Function errorCallback, Napi::Function txCallback)
+      : path_(std::move(path)), rxTsfn_(Napi::ThreadSafeFunction::New(
+                                    env, rxCallback, "vcan-usb-rx", 4096, 1)),
+        errorTsfn_(Napi::ThreadSafeFunction::New(env, errorCallback,
+                                                 "vcan-usb-error", 8, 1)),
+        txTsfn_(Napi::ThreadSafeFunction::New(env, txCallback, "vcan-usb-tx",
+                                              1024, 1)) {}
+
+  ~UsbTransport() { Close(); }
+
+  void Open() {
+    vcan_usb_error_t error{};
+    device_ = vcan_usb_open(path_.c_str(), &error);
+    if (device_ == nullptr)
+      throw std::runtime_error(ApiErrorMessage(error));
+    txThread_ = std::thread(&UsbTransport::TxLoop, this);
+  }
+
+  uint8_t InterfaceNumber() const { return vcan_usb_interface_number(device_); }
+
+  void StartRx() {
+    EnsureOpen();
+    bool expected = false;
+    if (!rxStarted_.compare_exchange_strong(expected, true))
+      return;
+    rxThread_ = std::thread(&UsbTransport::RxLoop, this);
+  }
+
+  std::vector<uint8_t> ControlIn(uint8_t requestType, uint8_t request,
+                                 uint16_t value, uint16_t index,
+                                 uint16_t length) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    std::vector<uint8_t> result(length);
+    vcan_usb_error_t error{};
+    if (!vcan_usb_control_in(device_, requestType, request, value, index,
+                             result.data(), length, kIoTimeoutMs, &error)) {
+      throw std::runtime_error(ApiErrorMessage(error));
+    }
+    return result;
+  }
+
+  void ControlOut(uint8_t requestType, uint8_t request, uint16_t value,
+                  uint16_t index, const uint8_t *data, size_t length) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    if (length > UINT16_MAX)
+      throw std::runtime_error("VCAN USB control payload is too large");
+    vcan_usb_error_t error{};
+    if (!vcan_usb_control_out(device_, requestType, request, value, index, data,
+                              static_cast<uint16_t>(length), kIoTimeoutMs,
+                              &error)) {
+      throw std::runtime_error(ApiErrorMessage(error));
+    }
+  }
+
+  bool Enqueue(uint32_t token, const uint8_t *data, size_t length,
+               uint32_t delayBeforeMs, uint32_t delayAfterMs) {
+    if (data == nullptr || length == 0)
+      return false;
+    std::lock_guard<std::mutex> lock(txMutex_);
+    if (closing_ || txQueue_.size() >= kTxQueueLimit)
+      return false;
+    txQueue_.push_back(TxJob{token, std::vector<uint8_t>(data, data + length),
+                             delayBeforeMs, delayAfterMs});
+    txCondition_.notify_one();
+    return true;
+  }
+
+  void Close() {
+    bool expected = false;
+    if (!closing_.compare_exchange_strong(expected, true))
+      return;
+    txCondition_.notify_all();
+    vcan_usb_cancel(device_);
+    if (rxThread_.joinable())
+      rxThread_.join();
+    if (txThread_.joinable())
+      txThread_.join();
+    vcan_usb_close(device_);
+    device_ = nullptr;
+    rxTsfn_.Release();
+    errorTsfn_.Release();
+    txTsfn_.Release();
+  }
+
+private:
+  void EnsureOpen() const {
+    if (closing_ || device_ == nullptr) {
+      throw std::runtime_error("VCAN USB transport is closed");
+    }
+  }
+
+  bool WaitDelay(uint32_t delayMs) {
+    if (delayMs == 0)
+      return !closing_;
+    std::unique_lock<std::mutex> lock(txMutex_);
+    return !txCondition_.wait_for(lock, std::chrono::milliseconds(delayMs),
+                                  [&] { return closing_.load(); });
+  }
+
+  void RxLoop() {
+    while (!closing_) {
+      std::vector<uint8_t> bytes(kTransferSize);
+      size_t transferred = 0;
+      vcan_usb_error_t error{};
+      if (!vcan_usb_bulk_read(device_, bytes.data(), bytes.size(), &transferred,
+                              kRxPollMs, &error)) {
+        if (!closing_ && error.status != VCAN_USB_STATUS_CANCELLED)
+          ReportError(error);
+        break;
+      }
+      if (transferred == 0)
+        continue;
+      bytes.resize(transferred);
+      auto *payload = new std::vector<uint8_t>(std::move(bytes));
+      const napi_status status = rxTsfn_.NonBlockingCall(
+          payload, [](Napi::Env env, Napi::Function callback,
+                      std::vector<uint8_t> *value) {
+            callback.Call({Napi::Buffer<uint8_t>::Copy(env, value->data(),
+                                                       value->size())});
+            delete value;
+          });
+      if (status != napi_ok) {
+        delete payload;
+        if (!closing_ && status != napi_closing) {
+          vcan_usb_error_t queueError{};
+          queueError.status = VCAN_USB_STATUS_SYSTEM_ERROR;
+          queueError.native_code = 0;
+          std::snprintf(queueError.operation, sizeof(queueError.operation),
+                        "RX callback queue");
+          std::snprintf(queueError.message, sizeof(queueError.message),
+                        "callback queue is full");
+          ReportError(queueError);
+          break;
+        }
+      }
+    }
+  }
+
+  void TxLoop() {
+    while (true) {
+      TxJob job;
+      {
+        std::unique_lock<std::mutex> lock(txMutex_);
+        txCondition_.wait(lock, [&] { return closing_ || !txQueue_.empty(); });
+        if (closing_ && txQueue_.empty())
+          break;
+        job = std::move(txQueue_.front());
+        txQueue_.pop_front();
+      }
+
+      bool ok = WaitDelay(job.delayBeforeMs);
+      vcan_usb_error_t error{};
+      size_t transferred = 0;
+      if (ok) {
+        ok = vcan_usb_bulk_write(device_, job.bytes.data(), job.bytes.size(),
+                                 &transferred, kIoTimeoutMs, &error);
+      }
+      if (ok)
+        ok = WaitDelay(job.delayAfterMs);
+      std::string detail;
+      if (!ok) {
+        detail = error.status != VCAN_USB_STATUS_OK
+                     ? ApiErrorMessage(error)
+                     : "VCAN USB transport is closed";
+      }
+      PostTxResult(new TxResult{job.token, ok, std::move(detail)});
+    }
+
+    std::deque<TxJob> abandoned;
+    {
+      std::lock_guard<std::mutex> lock(txMutex_);
+      abandoned.swap(txQueue_);
+    }
+    for (const auto &job : abandoned) {
+      PostTxResult(
+          new TxResult{job.token, false, "VCAN USB transport is closed"});
+    }
+  }
+
+  void PostTxResult(TxResult *result) {
+    const napi_status status = txTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, TxResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("token", Napi::Number::New(env, value->token));
+          object.Set("ok", Napi::Boolean::New(env, value->ok));
+          if (!value->ok)
+            object.Set("error", Napi::String::New(env, value->error));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  void ReportError(const vcan_usb_error_t &error) {
+    auto *result = new ErrorResult{ApiErrorCode(error), error.operation,
+                                   ApiErrorMessage(error)};
+    const napi_status status = errorTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, ErrorResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("operation", Napi::String::New(env, value->operation));
+          object.Set("code", Napi::Number::New(env, value->code));
+          object.Set("message", Napi::String::New(env, value->detail));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  std::string path_;
+  vcan_usb_device_t *device_ = nullptr;
+  std::atomic<bool> closing_{false};
+  std::atomic<bool> rxStarted_{false};
+  std::thread rxThread_;
+  std::thread txThread_;
+  std::mutex controlMutex_;
+  std::mutex txMutex_;
+  std::condition_variable txCondition_;
+  std::deque<TxJob> txQueue_;
+  Napi::ThreadSafeFunction rxTsfn_;
+  Napi::ThreadSafeFunction errorTsfn_;
+  Napi::ThreadSafeFunction txTsfn_;
+};
+
+std::shared_ptr<UsbTransport> Lookup(uint32_t handle) {
+  std::lock_guard<std::mutex> lock(gDevicesMutex);
+  const auto found = gDevices.find(handle);
+  if (found == gDevices.end())
+    throw std::runtime_error("invalid VCAN USB transport handle");
+  return found->second;
+}
+
+uint32_t ReadHandle(const Napi::CallbackInfo &info) {
+  if (info.Length() == 0 || !info[0].IsNumber()) {
+    throw Napi::TypeError::New(info.Env(),
+                               "a numeric transport handle is required");
+  }
+  return info[0].As<Napi::Number>().Uint32Value();
+}
+
+Napi::Value ListDevices(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  vcan_usb_device_list_t list{};
+  vcan_usb_error_t error{};
+  if (!vcan_usb_list_scan(&list, &error)) {
+    throw Napi::Error::New(env, ApiErrorMessage(error));
+  }
+  Napi::Array output = Napi::Array::New(env, list.count);
+  for (size_t index = 0; index < list.count; ++index) {
+    const auto &item = list.devices[index];
+    Napi::Object object = Napi::Object::New(env);
+    object.Set("path", Napi::String::New(env, item.path));
+    object.Set("label", Napi::String::New(env, item.label));
+    object.Set("interfaceNumber",
+               Napi::Number::New(env, item.interface_number));
+    object.Set("endpointIn", Napi::Number::New(env, item.endpoint_in));
+    object.Set("endpointOut", Napi::Number::New(env, item.endpoint_out));
+    object.Set("busy", Napi::Boolean::New(env, item.busy));
+    output.Set(index, object);
+  }
+  return output;
+}
+
+Napi::Value Open(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 4 || !info[0].IsString() || !info[1].IsFunction() ||
+      !info[2].IsFunction() || !info[3].IsFunction()) {
+    throw Napi::TypeError::New(
+        env, "open expects path, rx callback, error callback, tx callback");
+  }
+  try {
+    auto device = std::make_shared<UsbTransport>(
+        env, info[0].As<Napi::String>().Utf8Value(),
+        info[1].As<Napi::Function>(), info[2].As<Napi::Function>(),
+        info[3].As<Napi::Function>());
+    device->Open();
+    const uint32_t handle = gNextHandle.fetch_add(1);
+    {
+      std::lock_guard<std::mutex> lock(gDevicesMutex);
+      gDevices.emplace(handle, device);
+    }
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("handle", Napi::Number::New(env, handle));
+    result.Set("interfaceNumber",
+               Napi::Number::New(env, device->InterfaceNumber()));
+    return result;
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value StartRx(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(ReadHandle(info))->StartRx();
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Control(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 6 || !info[0].IsNumber() || !info[1].IsNumber() ||
+      !info[2].IsNumber() || !info[3].IsNumber() || !info[4].IsNumber()) {
+    throw Napi::TypeError::New(
+        env,
+        "control expects handle, type, request, value, index, data/length");
+  }
+  try {
+    auto device = Lookup(ReadHandle(info));
+    const uint8_t requestType =
+        static_cast<uint8_t>(info[1].As<Napi::Number>().Uint32Value());
+    const uint8_t request =
+        static_cast<uint8_t>(info[2].As<Napi::Number>().Uint32Value());
+    const uint16_t value =
+        static_cast<uint16_t>(info[3].As<Napi::Number>().Uint32Value());
+    const uint16_t index =
+        static_cast<uint16_t>(info[4].As<Napi::Number>().Uint32Value());
+    if ((requestType & 0x80) != 0) {
+      if (!info[5].IsNumber())
+        throw std::runtime_error("control IN length must be numeric");
+      const uint32_t rawLength = info[5].As<Napi::Number>().Uint32Value();
+      if (rawLength > UINT16_MAX)
+        throw std::runtime_error("control IN length is too large");
+      const auto bytes = device->ControlIn(requestType, request, value, index,
+                                           static_cast<uint16_t>(rawLength));
+      return Napi::Buffer<uint8_t>::Copy(env, bytes.data(), bytes.size());
+    }
+    if (!info[5].IsBuffer())
+      throw std::runtime_error("control OUT payload must be a Buffer");
+    const auto input = info[5].As<Napi::Buffer<uint8_t>>();
+    device->ControlOut(requestType, request, value, index, input.Data(),
+                       input.Length());
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Write(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 5 || !info[0].IsNumber() || !info[1].IsBuffer() ||
+      !info[2].IsNumber() || !info[3].IsNumber() || !info[4].IsNumber()) {
+    throw Napi::TypeError::New(
+        env,
+        "write expects handle, Buffer, token, delayBeforeMs, delayAfterMs");
+  }
+  try {
+    const auto input = info[1].As<Napi::Buffer<uint8_t>>();
+    const bool queued =
+        Lookup(ReadHandle(info))
+            ->Enqueue(info[2].As<Napi::Number>().Uint32Value(), input.Data(),
+                      input.Length(), info[3].As<Napi::Number>().Uint32Value(),
+                      info[4].As<Napi::Number>().Uint32Value());
+    return Napi::Boolean::New(env, queued);
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Close(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  std::shared_ptr<UsbTransport> device;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    const auto found = gDevices.find(ReadHandle(info));
+    if (found == gDevices.end())
+      return env.Undefined();
+    device = found->second;
+    gDevices.erase(found);
+  }
+  device->Close();
+  return env.Undefined();
+}
+
+void Cleanup(void *) {
+  std::map<uint32_t, std::shared_ptr<UsbTransport>> devices;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    devices.swap(gDevices);
+  }
+  for (auto &entry : devices)
+    entry.second->Close();
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("listDevices", Napi::Function::New(env, ListDevices));
+  exports.Set("open", Napi::Function::New(env, Open));
+  exports.Set("startRx", Napi::Function::New(env, StartRx));
+  exports.Set("control", Napi::Function::New(env, Control));
+  exports.Set("write", Napi::Function::New(env, Write));
+  exports.Set("close", Napi::Function::New(env, Close));
+  napi_add_env_cleanup_hook(env, Cleanup, nullptr);
+  return exports;
+}
+
+} // namespace
+
+NODE_API_MODULE(vcan_usb, Init)

--- a/src/main/docan/vcan_usb/protocol.ts
+++ b/src/main/docan/vcan_usb/protocol.ts
@@ -1,0 +1,214 @@
+import { CanBaseInfo, CandleCapability } from '../../share/can'
+import { VcanUsbTransport } from './transport'
+import {
+  encodeVcanFrame,
+  makeVcanControlPayload,
+  stripVcanControlPayload,
+  VcanDecoder,
+  VcanUsbFrame,
+  VcanWireDecoder
+} from './wire'
+
+export const VCAN_USB_VID = 0x1d50
+export const VCAN_USB_PID = 0x6080
+
+const FEATURE_FD = 1 << 8
+const FEATURE_BT_CONST_EXT = 1 << 10
+const FEATURE_TERMINATION = 1 << 11
+const FEATURE_BERR_REPORTING = 1 << 12
+
+const MODE_LISTEN_ONLY = 1 << 0
+const MODE_FD = 1 << 8
+const MODE_BERR_REPORTING = 1 << 12
+
+const REQUEST = {
+  mode: 1,
+  btConst: 16,
+  btConstExt: 17,
+  bitTiming: 24,
+  dataBitTiming: 25,
+  deviceInfo: 33,
+  termination: 37
+} as const
+
+const FALLBACK_CAPABILITY: CandleCapability = {
+  feature: FEATURE_FD | FEATURE_BT_CONST_EXT,
+  fclk_can: 80_000_000,
+  tseg1_min: 2,
+  tseg1_max: 256,
+  tseg2_min: 1,
+  tseg2_max: 128,
+  sjw_max: 128,
+  brp_min: 1,
+  brp_max: 512,
+  brp_inc: 1
+}
+
+export interface VcanUsbDeviceInfo {
+  swVersion: number
+  hwVersion: number
+  uid: number[]
+  uuid: number[]
+}
+
+export interface VcanUsbCapabilities {
+  nominal: CandleCapability
+  data?: CandleCapability
+  fdSupported: boolean
+  terminationSupported: boolean
+}
+
+function readCapabilityFields(buffer: Buffer, offset: number, feature: number, clock: number) {
+  if (buffer.length < offset + 32) throw new Error('VCAN USB capability response is too short')
+  return {
+    feature,
+    fclk_can: clock || 80_000_000,
+    tseg1_min: buffer.readUInt32LE(offset),
+    tseg1_max: buffer.readUInt32LE(offset + 4),
+    tseg2_min: buffer.readUInt32LE(offset + 8),
+    tseg2_max: buffer.readUInt32LE(offset + 12),
+    sjw_max: buffer.readUInt32LE(offset + 16),
+    brp_min: buffer.readUInt32LE(offset + 20),
+    brp_max: buffer.readUInt32LE(offset + 24),
+    brp_inc: buffer.readUInt32LE(offset + 28)
+  }
+}
+
+export class VcanUsbApi {
+  readonly channel: number
+  readonly transport: VcanUsbTransport
+  private capabilities?: VcanUsbCapabilities
+  fdMode = false
+
+  constructor(transport: VcanUsbTransport, channel: number) {
+    this.transport = transport
+    this.channel = channel
+    if (transport.interfaceNumber !== channel) {
+      throw new Error(
+        `VCAN USB interface mismatch: selected channel ${channel}, opened ${transport.interfaceNumber}`
+      )
+    }
+  }
+
+  private setControl(request: number, payload: Buffer) {
+    this.transport.controlOut(
+      request,
+      0,
+      this.channel,
+      makeVcanControlPayload(this.channel, request, payload)
+    )
+  }
+
+  private getControl(request: number, payloadLength: number): Buffer {
+    const response = this.transport.controlIn(request | 0x80, 0, this.channel, payloadLength + 8)
+    return stripVcanControlPayload(this.channel, request, response)
+  }
+
+  readCapabilities(): VcanUsbCapabilities {
+    if (this.capabilities) return this.capabilities
+    const response = this.getControl(REQUEST.btConst, 40)
+    const feature = response.readUInt32LE(0)
+    const clock = response.readUInt32LE(4)
+    const nominal = readCapabilityFields(response, 8, feature, clock)
+    let data: CandleCapability | undefined
+    if (feature & FEATURE_FD && feature & FEATURE_BT_CONST_EXT) {
+      const extended = this.getControl(REQUEST.btConstExt, 72)
+      data = readCapabilityFields(extended, 40, extended.readUInt32LE(0), extended.readUInt32LE(4))
+    }
+    this.capabilities = {
+      nominal,
+      data,
+      fdSupported: !!(feature & FEATURE_FD),
+      terminationSupported: !!(feature & FEATURE_TERMINATION)
+    }
+    return this.capabilities
+  }
+
+  readDeviceInfo(): VcanUsbDeviceInfo {
+    const response = this.getControl(REQUEST.deviceInfo, 40)
+    return {
+      swVersion: response.readUInt32LE(0),
+      hwVersion: response.readUInt32LE(4),
+      uid: Array.from({ length: 4 }, (_, index) => response.readUInt32LE(8 + index * 4)),
+      uuid: Array.from({ length: 4 }, (_, index) => response.readUInt32LE(24 + index * 4))
+    }
+  }
+
+  getTermination(): boolean {
+    return this.getControl(REQUEST.termination, 4).readUInt32LE(0) !== 0
+  }
+
+  setTermination(enabled: boolean) {
+    const payload = Buffer.alloc(4)
+    payload.writeUInt32LE(enabled ? 1 : 0)
+    this.setControl(REQUEST.termination, payload)
+  }
+
+  private setBitTiming(info: CanBaseInfo, dataPhase: boolean) {
+    const timing = dataPhase ? info.bitratefd : info.bitrate
+    if (!timing) throw new Error('VCAN USB CAN FD data timing is not configured')
+    if (Math.min(timing.preScaler, timing.timeSeg1, timing.timeSeg2, timing.sjw) < 1) {
+      throw new Error('VCAN USB timing values must be at least 1')
+    }
+    const payload = Buffer.alloc(20)
+    payload.writeUInt32LE(0, 0)
+    payload.writeUInt32LE(timing.timeSeg1 - 1, 4)
+    payload.writeUInt32LE(timing.timeSeg2 - 1, 8)
+    payload.writeUInt32LE(timing.sjw - 1, 12)
+    payload.writeUInt32LE(timing.preScaler - 1, 16)
+    this.setControl(dataPhase ? REQUEST.dataBitTiming : REQUEST.bitTiming, payload)
+  }
+
+  private setMode(mode: number, flags: number) {
+    const payload = Buffer.alloc(8)
+    payload.writeUInt32LE(mode, 0)
+    payload.writeUInt32LE(flags, 4)
+    this.setControl(REQUEST.mode, payload)
+  }
+
+  configure(info: CanBaseInfo, termination: boolean): VcanWireDecoder {
+    const capabilities = this.readCapabilities()
+    const configuredClock = Number(info.bitrate.clock) * 1_000_000
+    if (!Number.isFinite(configuredClock) || configuredClock !== capabilities.nominal.fclk_can) {
+      throw new Error(
+        `VCAN USB clock mismatch: configured ${configuredClock || 0} Hz, device reports ${capabilities.nominal.fclk_can} Hz`
+      )
+    }
+    if (info.canfd && !capabilities.fdSupported) {
+      throw new Error('CAN FD is enabled, but the selected VCAN USB device does not support it')
+    }
+
+    this.setMode(0, 0)
+    this.setBitTiming(info, false)
+    if (info.canfd) this.setBitTiming(info, true)
+    try {
+      this.setTermination(termination)
+    } catch (error) {
+      if (termination || capabilities.terminationSupported) throw error
+    }
+
+    let flags = info.silent ? MODE_LISTEN_ONLY : 0
+    if (info.canfd) flags |= MODE_FD
+    if (capabilities.nominal.feature & FEATURE_BERR_REPORTING) flags |= MODE_BERR_REPORTING
+    this.fdMode = info.canfd
+    this.setMode(1, flags)
+    return new VcanDecoder(this.channel)
+  }
+
+  stop() {
+    this.setMode(0, 0)
+  }
+
+  encodeFrame(frame: VcanUsbFrame): Buffer {
+    return encodeVcanFrame(this.channel, frame)
+  }
+
+  static fallbackCapabilities(): VcanUsbCapabilities {
+    return {
+      nominal: { ...FALLBACK_CAPABILITY },
+      data: { ...FALLBACK_CAPABILITY },
+      fdSupported: true,
+      terminationSupported: false
+    }
+  }
+}

--- a/src/main/docan/vcan_usb/transport.ts
+++ b/src/main/docan/vcan_usb/transport.ts
@@ -1,0 +1,113 @@
+import NativeVcanUsb from './../build/Release/vcan_usb.node'
+
+export interface NativeUsbInterface {
+  path: string
+  label: string
+  interfaceNumber: number
+  endpointIn: number
+  endpointOut: number
+  busy: boolean
+}
+
+interface NativeOpenResult {
+  handle: number
+  interfaceNumber: number
+}
+
+export interface NativeTransportError {
+  operation: string
+  code: number
+  message: string
+}
+
+interface NativeTxResult {
+  token: number
+  ok: boolean
+  error?: string
+}
+
+interface NativeApi {
+  listDevices(): NativeUsbInterface[]
+  open(
+    path: string,
+    onReceive: (data: Buffer) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): NativeOpenResult
+  startRx(handle: number): void
+  control(
+    handle: number,
+    requestType: number,
+    request: number,
+    value: number,
+    index: number,
+    dataOrLength: Buffer | number
+  ): Buffer | undefined
+  write(
+    handle: number,
+    data: Buffer,
+    token: number,
+    delayBeforeMs?: number,
+    delayAfterMs?: number
+  ): boolean
+  close(handle: number): void
+}
+
+const native = NativeVcanUsb as NativeApi
+
+export class VcanUsbTransport {
+  readonly handle: number
+  readonly interfaceNumber: number
+  private closed = false
+
+  private constructor(result: NativeOpenResult) {
+    this.handle = result.handle
+    this.interfaceNumber = result.interfaceNumber
+  }
+
+  static listDevices(): NativeUsbInterface[] {
+    return native.listDevices()
+  }
+
+  static open(
+    path: string,
+    onReceive: (data: Buffer) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): VcanUsbTransport {
+    const result = native.open(path, onReceive, onError, onTransmit)
+    return new VcanUsbTransport(result)
+  }
+
+  startReceive() {
+    this.assertOpen()
+    native.startRx(this.handle)
+  }
+
+  controlIn(request: number, value: number, index: number, length: number): Buffer {
+    this.assertOpen()
+    const result = native.control(this.handle, 0xc1, request, value, index, length)
+    if (!Buffer.isBuffer(result)) throw new Error('VCAN USB control read returned no data')
+    return result
+  }
+
+  controlOut(request: number, value: number, index: number, data: Buffer) {
+    this.assertOpen()
+    native.control(this.handle, 0x41, request, value, index, data)
+  }
+
+  write(data: Buffer, token: number, delayBeforeMs = 0, delayAfterMs = 0): boolean {
+    this.assertOpen()
+    return native.write(this.handle, data, token, delayBeforeMs, delayAfterMs)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    native.close(this.handle)
+  }
+
+  private assertOpen() {
+    if (this.closed) throw new Error('VCAN USB transport is closed')
+  }
+}

--- a/src/main/docan/vcan_usb/wire.ts
+++ b/src/main/docan/vcan_usb/wire.ts
@@ -1,0 +1,228 @@
+export interface VcanUsbFrame {
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+  timestampUs: number
+}
+
+export interface VcanUsbStateEvent {
+  kind: 'state'
+  state: number
+  rxErrorCount: number
+  txErrorCount: number
+  timestampUs: number
+}
+
+export interface VcanUsbBusErrorEvent {
+  kind: 'bus-error'
+  errorCode: number
+  rxErrorCount: number
+  txErrorCount: number
+}
+
+export type VcanUsbEvent = VcanUsbStateEvent | VcanUsbBusErrorEvent
+
+export interface VcanDecodeResult {
+  frames: VcanUsbFrame[]
+  events: VcanUsbEvent[]
+  tail: Buffer
+}
+
+export interface VcanWireDecoder {
+  push(transfer: Buffer): VcanDecodeResult
+  reset(): void
+}
+
+const FLAG_FD = 1 << 1
+const FLAG_BRS = 1 << 2
+const FLAG_EFF = 1 << 4
+const FLAG_RTR = 1 << 5
+
+const CAN_ID_MASK = 0x1fffffff
+
+const VCAN_ECHO_TX = 0xa1c95e3d
+const VCAN_ECHO_RX = 0xa2c95e3d
+const VCAN_ECHO_STATE = 0xa4c95e3d
+const VCAN_ECHO_CONTROL = 0xa5c95e3d
+const VCAN_HEADER_SIZE = 8
+const VCAN_FRAME_DATA_OFFSET = 24
+const VCAN_OPCODE_SIZE_MASK = 0x0fff
+const VCAN_OPCODE_CHANNEL_SHIFT = 12
+const VCAN_STATE_REQUEST = 3
+const VCAN_BERR_REQUEST = 2
+
+const FD_DLC_LENGTHS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]
+
+export function lengthToVcanDlc(length: number, fd: boolean): number {
+  const maximum = fd ? 64 : 8
+  if (!Number.isInteger(length) || length < 0 || length > maximum) {
+    throw new RangeError(`CAN payload length must be 0..${maximum}`)
+  }
+  if (!fd) return length
+  const dlc = FD_DLC_LENGTHS.findIndex((candidate) => candidate >= length)
+  if (dlc < 0) throw new RangeError('CAN FD payload exceeds 64 bytes')
+  return dlc
+}
+
+export function vcanDlcToLength(dlc: number, fd: boolean): number {
+  const normalized = dlc & 0x0f
+  return fd ? FD_DLC_LENGTHS[normalized] : Math.min(normalized, 8)
+}
+
+export function normalizeVcanData(data: Buffer, fd: boolean): Buffer {
+  const wireLength = vcanDlcToLength(lengthToVcanDlc(data.length, fd), fd)
+  if (wireLength === data.length) return Buffer.from(data)
+  return Buffer.concat([data, Buffer.alloc(wireLength - data.length)])
+}
+
+function readTimestamp(buffer: Buffer, offset: number): number {
+  const timestamp = buffer.readBigUInt64LE(offset)
+  if (timestamp > BigInt(Number.MAX_SAFE_INTEGER)) return 0
+  return Number(timestamp)
+}
+
+function vcanOpcode(channel: number, size: number): number {
+  return ((channel & 0x0f) << VCAN_OPCODE_CHANNEL_SHIFT) | (size & VCAN_OPCODE_SIZE_MASK)
+}
+
+export function makeVcanControlPayload(
+  channel: number,
+  request: number,
+  payload: Buffer = Buffer.alloc(0)
+): Buffer {
+  const result = Buffer.alloc(VCAN_HEADER_SIZE + payload.length)
+  result.writeUInt32LE(VCAN_ECHO_CONTROL, 0)
+  result.writeUInt16LE(vcanOpcode(channel, result.length), 4)
+  result.writeUInt16LE(request, 6)
+  payload.copy(result, VCAN_HEADER_SIZE)
+  return result
+}
+
+export function stripVcanControlPayload(
+  channel: number,
+  request: number,
+  response: Buffer
+): Buffer {
+  if (response.length < VCAN_HEADER_SIZE) throw new Error('VCAN control response is too short')
+  const opcode = response.readUInt16LE(4)
+  if (
+    response.readUInt32LE(0) !== VCAN_ECHO_CONTROL ||
+    (opcode & VCAN_OPCODE_SIZE_MASK) !== response.length ||
+    ((opcode >> VCAN_OPCODE_CHANNEL_SHIFT) & 0x0f) !== channel ||
+    (response.readUInt16LE(6) & 0x7f) !== request
+  ) {
+    throw new Error('VCAN control response header is invalid')
+  }
+  return response.subarray(VCAN_HEADER_SIZE)
+}
+
+export function encodeVcanFrame(channel: number, frame: VcanUsbFrame): Buffer {
+  const data = normalizeVcanData(frame.data, frame.fd)
+  const width = frame.fd ? 64 : 8
+  const size = VCAN_FRAME_DATA_OFFSET + width
+  const packet = Buffer.alloc(size)
+  let flags = frame.fd ? FLAG_FD : 0
+  if (frame.brs) flags |= FLAG_BRS
+  if (frame.extended) flags |= FLAG_EFF
+  if (frame.remote) flags |= FLAG_RTR
+  packet.writeUInt32LE(VCAN_ECHO_TX, 0)
+  packet.writeUInt16LE(vcanOpcode(channel, size), 4)
+  packet.writeUInt16LE(flags, 6)
+  packet.writeUInt32LE(frame.id & CAN_ID_MASK, 8)
+  packet.writeUInt8(lengthToVcanDlc(data.length, frame.fd), 12)
+  data.copy(packet, VCAN_FRAME_DATA_OFFSET)
+  return packet
+}
+
+export class VcanDecoder implements VcanWireDecoder {
+  private tail = Buffer.alloc(0)
+
+  constructor(private readonly expectedChannel?: number) {}
+
+  reset() {
+    this.tail = Buffer.alloc(0)
+  }
+
+  push(transfer: Buffer): VcanDecodeResult {
+    const buffer = this.tail.length ? Buffer.concat([this.tail, transfer]) : transfer
+    this.tail = Buffer.alloc(0)
+    const frames: VcanUsbFrame[] = []
+    const events: VcanUsbEvent[] = []
+    let offset = 0
+
+    while (offset + VCAN_HEADER_SIZE <= buffer.length) {
+      const echoId = buffer.readUInt32LE(offset)
+      if (echoId === 0) break
+      const opcode = buffer.readUInt16LE(offset + 4)
+      const flags = buffer.readUInt16LE(offset + 6)
+      const frameSize = opcode & VCAN_OPCODE_SIZE_MASK
+      if (frameSize < VCAN_HEADER_SIZE || frameSize > 512) {
+        this.reset()
+        throw new Error(`invalid VCAN bulk frame size: ${frameSize}`)
+      }
+      const frameChannel = (opcode >> VCAN_OPCODE_CHANNEL_SHIFT) & 0x0f
+      if (this.expectedChannel !== undefined && frameChannel !== this.expectedChannel) {
+        this.reset()
+        throw new Error(
+          `VCAN bulk frame channel ${frameChannel} does not match interface ${this.expectedChannel}`
+        )
+      }
+      if (offset + frameSize > buffer.length) {
+        this.tail = Buffer.from(buffer.subarray(offset))
+        break
+      }
+
+      if (echoId === VCAN_ECHO_RX && frameSize >= VCAN_FRAME_DATA_OFFSET) {
+        const fd = !!(flags & FLAG_FD)
+        const length = vcanDlcToLength(buffer.readUInt8(offset + 12), fd)
+        if (VCAN_FRAME_DATA_OFFSET + length > frameSize) {
+          this.reset()
+          throw new Error('VCAN frame payload exceeds its declared frame size')
+        }
+        frames.push({
+          id: buffer.readUInt32LE(offset + 8) & CAN_ID_MASK,
+          data: Buffer.from(
+            buffer.subarray(
+              offset + VCAN_FRAME_DATA_OFFSET,
+              offset + VCAN_FRAME_DATA_OFFSET + length
+            )
+          ),
+          fd,
+          brs: !!(flags & FLAG_BRS),
+          extended: !!(flags & FLAG_EFF),
+          remote: !!(flags & FLAG_RTR),
+          timestampUs: readTimestamp(buffer, offset + 16)
+        })
+      } else if (echoId === VCAN_ECHO_STATE) {
+        if (flags === VCAN_STATE_REQUEST && frameSize >= 28) {
+          events.push({
+            kind: 'state',
+            timestampUs: readTimestamp(buffer, offset + 8),
+            state: buffer.readUInt32LE(offset + 16),
+            rxErrorCount: buffer.readUInt32LE(offset + 20),
+            txErrorCount: buffer.readUInt32LE(offset + 24)
+          })
+        } else if (flags === VCAN_BERR_REQUEST && frameSize >= 16) {
+          events.push({
+            kind: 'bus-error',
+            errorCode: buffer.readUInt8(offset + 9),
+            rxErrorCount: buffer.readUInt8(offset + 10),
+            txErrorCount: buffer.readUInt8(offset + 11)
+          })
+        }
+      }
+      offset += frameSize
+    }
+
+    if (!this.tail.length && offset < buffer.length) {
+      const remainder = buffer.subarray(offset)
+      if (remainder.length < VCAN_HEADER_SIZE && remainder.some((value) => value !== 0)) {
+        this.tail = Buffer.from(remainder)
+      }
+    }
+    return { frames, events, tail: Buffer.from(this.tail) }
+  }
+}

--- a/src/main/docan/vkgs_usb/api/vkgs_usb.cpp
+++ b/src/main/docan/vkgs_usb/api/vkgs_usb.cpp
@@ -1,0 +1,699 @@
+#include "vkgs_usb.h"
+
+#include <libusb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint16_t kDeviceVid = 0x1d50;
+constexpr uint16_t kDevicePid = 0x606f;
+constexpr uint32_t kDefaultTimeoutMs = 2000;
+constexpr uint32_t kDefaultPollMs = 100;
+constexpr size_t kMaxPortDepth = 16;
+constexpr const char *kPathPrefix = "libusb://1d50:606f/";
+
+struct DeviceKey {
+  uint8_t bus = 0;
+  uint8_t address = 0;
+  uint8_t interface_number = 0;
+  std::vector<uint8_t> ports;
+};
+
+struct InterfaceInfo {
+  uint8_t number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+};
+
+struct EnumeratedInterface {
+  std::string path;
+  std::string label;
+  InterfaceInfo interface;
+  bool busy = false;
+};
+
+void CopyText(char *destination, size_t capacity, const std::string &source) {
+  if (destination == nullptr || capacity == 0)
+    return;
+  const size_t length = std::min(capacity - 1, source.size());
+  if (length > 0)
+    std::memcpy(destination, source.data(), length);
+  destination[length] = '\0';
+}
+
+vkgs_usb_status_t StatusFromLibusb(int code, bool cancelled) {
+  if (cancelled) {
+    return VKGS_USB_STATUS_CANCELLED;
+  }
+  if (code == LIBUSB_ERROR_INVALID_PARAM) {
+    return VKGS_USB_STATUS_INVALID_ARGUMENT;
+  }
+  if (code == LIBUSB_ERROR_TIMEOUT)
+    return VKGS_USB_STATUS_TIMEOUT;
+  if (code == LIBUSB_ERROR_NOT_FOUND) {
+    return VKGS_USB_STATUS_ENDPOINT_NOT_FOUND;
+  }
+  return VKGS_USB_STATUS_SYSTEM_ERROR;
+}
+
+std::string LibusbMessage(int code) {
+  const char *name = libusb_error_name(code);
+  const char *detail = libusb_strerror(static_cast<libusb_error>(code));
+  std::string message = name != nullptr ? name : "LIBUSB_ERROR_UNKNOWN";
+  if (detail != nullptr && detail[0] != '\0' && message != detail) {
+    message += ": ";
+    message += detail;
+  }
+  return message;
+}
+
+void SetError(vkgs_usb_error_t *error, vkgs_usb_status_t status,
+              const char *operation, int32_t native_code,
+              const std::string &detail) {
+  if (error == nullptr)
+    return;
+  vkgs_usb_error_clear(error);
+  error->status = status;
+  error->native_code = native_code;
+  CopyText(error->operation, sizeof(error->operation),
+           operation != nullptr ? operation : "libusb");
+  CopyText(error->message, sizeof(error->message),
+           detail.empty() ? "operation failed" : detail);
+}
+
+void SetLibusbError(vkgs_usb_error_t *error, const char *operation, int code,
+                    bool cancelled = false) {
+  SetError(error, StatusFromLibusb(code, cancelled), operation, code,
+           cancelled ? "USB transfer was cancelled" : LibusbMessage(code));
+}
+
+bool ParseByte(const std::string &text, uint8_t *output) {
+  if (text.empty() || output == nullptr)
+    return false;
+  errno = 0;
+  char *end = nullptr;
+  const unsigned long value = std::strtoul(text.c_str(), &end, 10);
+  if (errno != 0 || end == text.c_str() || *end != '\0' || value > UINT8_MAX) {
+    return false;
+  }
+  *output = static_cast<uint8_t>(value);
+  return true;
+}
+
+std::vector<uint8_t> GetPorts(libusb_device *device) {
+  uint8_t ports[kMaxPortDepth]{};
+  const int count =
+      libusb_get_port_numbers(device, ports, static_cast<int>(kMaxPortDepth));
+  if (count <= 0)
+    return {};
+  return std::vector<uint8_t>(ports, ports + count);
+}
+
+std::string MakePath(libusb_device *device, uint8_t interface_number) {
+  std::ostringstream output;
+  output << kPathPrefix << static_cast<unsigned>(libusb_get_bus_number(device))
+         << '/';
+  const auto ports = GetPorts(device);
+  if (ports.empty()) {
+    output << 'a' << static_cast<unsigned>(libusb_get_device_address(device));
+  } else {
+    output << 'p';
+    for (size_t index = 0; index < ports.size(); ++index) {
+      if (index != 0)
+        output << '.';
+      output << static_cast<unsigned>(ports[index]);
+    }
+  }
+  output << '/' << static_cast<unsigned>(interface_number);
+  return output.str();
+}
+
+bool ParsePath(const char *path, DeviceKey *key) {
+  if (path == nullptr || key == nullptr)
+    return false;
+  const std::string value(path);
+  if (value.compare(0, std::strlen(kPathPrefix), kPathPrefix) != 0)
+    return false;
+  const std::string body = value.substr(std::strlen(kPathPrefix));
+  const size_t first = body.find('/');
+  const size_t second = first == std::string::npos ? std::string::npos
+                                                   : body.find('/', first + 1);
+  if (first == std::string::npos || second == std::string::npos ||
+      body.find('/', second + 1) != std::string::npos) {
+    return false;
+  }
+  DeviceKey parsed;
+  if (!ParseByte(body.substr(0, first), &parsed.bus) ||
+      !ParseByte(body.substr(second + 1), &parsed.interface_number)) {
+    return false;
+  }
+  const std::string location = body.substr(first + 1, second - first - 1);
+  if (location.size() < 2)
+    return false;
+  if (location[0] == 'a') {
+    if (!ParseByte(location.substr(1), &parsed.address))
+      return false;
+  } else if (location[0] == 'p') {
+    size_t start = 1;
+    while (start < location.size()) {
+      const size_t end = location.find('.', start);
+      uint8_t port = 0;
+      if (!ParseByte(location.substr(start, end - start), &port) || port == 0) {
+        return false;
+      }
+      parsed.ports.push_back(port);
+      if (parsed.ports.size() > kMaxPortDepth)
+        return false;
+      if (end == std::string::npos)
+        break;
+      if (end + 1 >= location.size())
+        return false;
+      start = end + 1;
+    }
+    if (parsed.ports.empty())
+      return false;
+  } else {
+    return false;
+  }
+  *key = std::move(parsed);
+  return true;
+}
+
+bool Matches(libusb_device *device, const DeviceKey &key) {
+  if (libusb_get_bus_number(device) != key.bus)
+    return false;
+  if (!key.ports.empty())
+    return GetPorts(device) == key.ports;
+  return libusb_get_device_address(device) == key.address;
+}
+
+bool FindInterface(libusb_device *device, uint8_t interface_number,
+                   InterfaceInfo *result) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return false;
+
+  bool found = false;
+  InterfaceInfo fallback{};
+  bool has_fallback = false;
+  for (uint8_t interface_index = 0;
+       interface_index < config->bNumInterfaces && !found; ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    for (int alternate_index = 0;
+         alternate_index < usb_interface.num_altsetting; ++alternate_index) {
+      const libusb_interface_descriptor &descriptor =
+          usb_interface.altsetting[alternate_index];
+      if (descriptor.bInterfaceNumber != interface_number)
+        continue;
+      InterfaceInfo candidate{};
+      candidate.number = descriptor.bInterfaceNumber;
+      candidate.alternate_setting = descriptor.bAlternateSetting;
+      for (uint8_t endpoint_index = 0;
+           endpoint_index < descriptor.bNumEndpoints; ++endpoint_index) {
+        const libusb_endpoint_descriptor &endpoint =
+            descriptor.endpoint[endpoint_index];
+        if ((endpoint.bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+            LIBUSB_TRANSFER_TYPE_BULK) {
+          continue;
+        }
+        if ((endpoint.bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) ==
+            LIBUSB_ENDPOINT_IN) {
+          candidate.endpoint_in = endpoint.bEndpointAddress;
+        } else {
+          candidate.endpoint_out = endpoint.bEndpointAddress;
+        }
+      }
+      if (candidate.endpoint_in == 0 || candidate.endpoint_out == 0)
+        continue;
+      if (!has_fallback) {
+        fallback = candidate;
+        has_fallback = true;
+      }
+      if (candidate.alternate_setting == 0) {
+        *result = candidate;
+        found = true;
+        break;
+      }
+    }
+  }
+  if (!found && has_fallback) {
+    *result = fallback;
+    found = true;
+  }
+  libusb_free_config_descriptor(config);
+  return found;
+}
+
+std::vector<InterfaceInfo> FindInterfaces(libusb_device *device) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return {};
+  std::vector<InterfaceInfo> output;
+  for (uint8_t interface_index = 0; interface_index < config->bNumInterfaces;
+       ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    if (usb_interface.num_altsetting <= 0)
+      continue;
+    const uint8_t number = usb_interface.altsetting[0].bInterfaceNumber;
+    InterfaceInfo info{};
+    if (FindInterface(device, number, &info))
+      output.push_back(info);
+  }
+  libusb_free_config_descriptor(config);
+  return output;
+}
+
+std::string ReadLabel(libusb_device_handle *handle,
+                      const libusb_device_descriptor &descriptor) {
+  if (handle == nullptr || descriptor.iProduct == 0)
+    return "VKGS USB";
+  unsigned char value[VKGS_USB_LABEL_CAPACITY]{};
+  const int length = libusb_get_string_descriptor_ascii(
+      handle, descriptor.iProduct, value, static_cast<int>(sizeof(value) - 1));
+  return length > 0 ? std::string(reinterpret_cast<char *>(value), length)
+                    : "VKGS USB";
+}
+
+bool ProbeBusy(libusb_device *device, uint8_t interface_number,
+               std::string *label, const libusb_device_descriptor &descriptor) {
+  libusb_device_handle *handle = nullptr;
+  const int open_status = libusb_open(device, &handle);
+  if (open_status != LIBUSB_SUCCESS || handle == nullptr)
+    return true;
+  *label = ReadLabel(handle, descriptor);
+  bool busy = false;
+  const int kernel_active =
+      libusb_kernel_driver_active(handle, interface_number);
+  if (kernel_active != 1) {
+    const int claim_status = libusb_claim_interface(handle, interface_number);
+    busy = claim_status != LIBUSB_SUCCESS;
+    if (!busy)
+      libusb_release_interface(handle, interface_number);
+  }
+  libusb_close(handle);
+  return busy;
+}
+
+bool ValidateOpen(vkgs_usb_device_t *device, vkgs_usb_error_t *error,
+                  const char *operation);
+
+} // namespace
+
+struct vkgs_usb_device {
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  uint8_t interface_number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+  bool claimed = false;
+  bool manually_detached = false;
+  std::atomic<bool> cancelled{false};
+};
+
+namespace {
+
+bool ValidateOpen(vkgs_usb_device_t *device, vkgs_usb_error_t *error,
+                  const char *operation) {
+  if (device != nullptr && device->handle != nullptr && device->claimed) {
+    return true;
+  }
+  SetError(error, VKGS_USB_STATUS_NOT_OPEN, operation, LIBUSB_ERROR_NO_DEVICE,
+           "VKGS USB device is not open");
+  return false;
+}
+
+bool ControlTransfer(vkgs_usb_device_t *device, uint8_t request_type,
+                     uint8_t request, uint16_t value, uint16_t index,
+                     uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                     vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "libusb_control_transfer"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_control_transfer", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  const int transferred = libusb_control_transfer(
+      device->handle, request_type, request, value, index, data, length,
+      timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+  if (transferred < 0) {
+    SetLibusbError(error, "libusb_control_transfer", transferred,
+                   device->cancelled.load());
+    return false;
+  }
+  if (transferred != length) {
+    char detail[96]{};
+    std::snprintf(detail, sizeof(detail), "short control transfer: %d/%u",
+                  transferred, length);
+    SetError(error, VKGS_USB_STATUS_SHORT_TRANSFER, "libusb_control_transfer",
+             LIBUSB_ERROR_IO, detail);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+void vkgs_usb_error_clear(vkgs_usb_error_t *error) {
+  if (error == nullptr)
+    return;
+  std::memset(error, 0, sizeof(*error));
+  error->status = VKGS_USB_STATUS_OK;
+}
+
+bool vkgs_usb_list_scan(vkgs_usb_device_list_t *list, vkgs_usb_error_t *error) {
+  if (list == nullptr) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_list_scan",
+             LIBUSB_ERROR_INVALID_PARAM, "device list is null");
+    return false;
+  }
+  std::memset(list, 0, sizeof(*list));
+  vkgs_usb_error_clear(error);
+  libusb_context *context = nullptr;
+  int status = libusb_init(&context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    return false;
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    libusb_exit(context);
+    return false;
+  }
+
+  std::vector<EnumeratedInterface> found;
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid) {
+      continue;
+    }
+    for (const auto &usb_interface : FindInterfaces(devices[index])) {
+      EnumeratedInterface item;
+      item.path = MakePath(devices[index], usb_interface.number);
+      item.interface = usb_interface;
+      item.label = "VKGS USB";
+      item.busy = ProbeBusy(devices[index], usb_interface.number, &item.label,
+                            descriptor);
+      found.push_back(std::move(item));
+    }
+  }
+  libusb_free_device_list(devices, 1);
+  libusb_exit(context);
+
+  std::sort(found.begin(), found.end(),
+            [](const auto &left, const auto &right) {
+              return left.path < right.path;
+            });
+  list->count =
+      std::min(found.size(), static_cast<size_t>(VKGS_USB_MAX_DEVICES));
+  for (size_t index = 0; index < list->count; ++index) {
+    const auto &source = found[index];
+    auto &target = list->devices[index];
+    CopyText(target.path, sizeof(target.path), source.path);
+    CopyText(target.label, sizeof(target.label), source.label);
+    target.interface_number = source.interface.number;
+    target.endpoint_in = source.interface.endpoint_in;
+    target.endpoint_out = source.interface.endpoint_out;
+    target.busy = source.busy;
+  }
+  return true;
+}
+
+vkgs_usb_device_t *vkgs_usb_open(const char *path, vkgs_usb_error_t *error) {
+  vkgs_usb_error_clear(error);
+  DeviceKey key;
+  if (!ParsePath(path, &key)) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_open",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid libusb device path");
+    return nullptr;
+  }
+  auto *result = new (std::nothrow) vkgs_usb_device_t();
+  if (result == nullptr) {
+    SetError(error, VKGS_USB_STATUS_SYSTEM_ERROR, "vkgs_usb_open",
+             LIBUSB_ERROR_NO_MEM, "unable to allocate the USB device");
+    return nullptr;
+  }
+  int status = libusb_init(&result->context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(result->context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+
+  InterfaceInfo usb_interface{};
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid || !Matches(devices[index], key) ||
+        !FindInterface(devices[index], key.interface_number, &usb_interface)) {
+      continue;
+    }
+    status = libusb_open(devices[index], &result->handle);
+    break;
+  }
+  libusb_free_device_list(devices, 1);
+  if (result->handle == nullptr || status != LIBUSB_SUCCESS) {
+    if (status == LIBUSB_SUCCESS)
+      status = LIBUSB_ERROR_NO_DEVICE;
+    SetLibusbError(error, "libusb_open", status);
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+
+  result->interface_number = usb_interface.number;
+  result->alternate_setting = usb_interface.alternate_setting;
+  result->endpoint_in = usb_interface.endpoint_in;
+  result->endpoint_out = usb_interface.endpoint_out;
+  const int kernel_active =
+      libusb_kernel_driver_active(result->handle, result->interface_number);
+  const int auto_detach =
+      libusb_set_auto_detach_kernel_driver(result->handle, 1);
+  if (kernel_active == 1 && auto_detach != LIBUSB_SUCCESS) {
+    status =
+        libusb_detach_kernel_driver(result->handle, result->interface_number);
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_detach_kernel_driver", status);
+      vkgs_usb_close(result);
+      return nullptr;
+    }
+    result->manually_detached = true;
+  }
+  status = libusb_claim_interface(result->handle, result->interface_number);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_claim_interface", status);
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+  result->claimed = true;
+  if (result->alternate_setting != 0) {
+    status = libusb_set_interface_alt_setting(
+        result->handle, result->interface_number, result->alternate_setting);
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_set_interface_alt_setting", status);
+      vkgs_usb_close(result);
+      return nullptr;
+    }
+  }
+  libusb_clear_halt(result->handle, result->endpoint_in);
+  libusb_clear_halt(result->handle, result->endpoint_out);
+  return result;
+}
+
+uint8_t vkgs_usb_interface_number(const vkgs_usb_device_t *device) {
+  return device != nullptr ? device->interface_number : 0;
+}
+
+bool vkgs_usb_control_in(vkgs_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vkgs_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) == 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_control_in",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control IN arguments");
+    return false;
+  }
+  vkgs_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index, data,
+                         length, timeout_ms, error);
+}
+
+bool vkgs_usb_control_out(vkgs_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vkgs_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) != 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_control_out",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control OUT arguments");
+    return false;
+  }
+  vkgs_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index,
+                         const_cast<uint8_t *>(data), length, timeout_ms,
+                         error);
+}
+
+bool vkgs_usb_bulk_read(vkgs_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vkgs_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || capacity == 0 || capacity > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_bulk_read",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk read arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(IN)"))
+    return false;
+  vkgs_usb_error_clear(error);
+  const unsigned int poll =
+      poll_timeout_ms == 0 ? kDefaultPollMs : poll_timeout_ms;
+  bool retried_stall = false;
+  while (!device->cancelled.load()) {
+    int count = 0;
+    const int status =
+        libusb_bulk_transfer(device->handle, device->endpoint_in, data,
+                             static_cast<int>(capacity), &count, poll);
+    if (count > 0) {
+      *transferred = static_cast<size_t>(count);
+      return true;
+    }
+    if (status == LIBUSB_SUCCESS)
+      return true;
+    if (status == LIBUSB_ERROR_TIMEOUT ||
+        (status == LIBUSB_ERROR_INTERRUPTED && !device->cancelled.load())) {
+      retried_stall = false;
+      continue;
+    }
+    if (status == LIBUSB_ERROR_PIPE && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_in) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    SetLibusbError(error, "libusb_bulk_transfer(IN)", status,
+                   device->cancelled.load());
+    return false;
+  }
+  SetLibusbError(error, "libusb_bulk_transfer(IN)", LIBUSB_ERROR_INTERRUPTED,
+                 true);
+  return false;
+}
+
+bool vkgs_usb_bulk_write(vkgs_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vkgs_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || length == 0 || length > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_bulk_write",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk write arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(OUT)"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  vkgs_usb_error_clear(error);
+  bool retried_stall = false;
+  while (true) {
+    int count = 0;
+    const int status = libusb_bulk_transfer(
+        device->handle, device->endpoint_out, const_cast<uint8_t *>(data),
+        static_cast<int>(length), &count,
+        timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+    if (status == LIBUSB_ERROR_PIPE && count == 0 && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_out) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_bulk_transfer(OUT)", status,
+                     device->cancelled.load());
+      return false;
+    }
+    *transferred = static_cast<size_t>(count);
+    if (static_cast<size_t>(count) != length) {
+      char detail[96]{};
+      std::snprintf(detail, sizeof(detail), "short bulk write: %d/%zu", count,
+                    length);
+      SetError(error, VKGS_USB_STATUS_SHORT_TRANSFER,
+               "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_IO, detail);
+      return false;
+    }
+    return true;
+  }
+}
+
+void vkgs_usb_cancel(vkgs_usb_device_t *device) {
+  if (device != nullptr)
+    device->cancelled.store(true);
+}
+
+void vkgs_usb_close(vkgs_usb_device_t *device) {
+  if (device == nullptr)
+    return;
+  vkgs_usb_cancel(device);
+  if (device->handle != nullptr) {
+    if (device->claimed) {
+      libusb_release_interface(device->handle, device->interface_number);
+      device->claimed = false;
+    }
+    if (device->manually_detached) {
+      libusb_attach_kernel_driver(device->handle, device->interface_number);
+      device->manually_detached = false;
+    }
+    libusb_close(device->handle);
+    device->handle = nullptr;
+  }
+  if (device->context != nullptr) {
+    libusb_exit(device->context);
+    device->context = nullptr;
+  }
+  delete device;
+}

--- a/src/main/docan/vkgs_usb/api/vkgs_usb.h
+++ b/src/main/docan/vkgs_usb/api/vkgs_usb.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VKGS_USB_MAX_DEVICES 64
+#define VKGS_USB_PATH_CAPACITY 1024
+#define VKGS_USB_LABEL_CAPACITY 256
+#define VKGS_USB_OPERATION_CAPACITY 64
+#define VKGS_USB_MESSAGE_CAPACITY 512
+
+typedef enum {
+  VKGS_USB_STATUS_OK = 0,
+  VKGS_USB_STATUS_INVALID_ARGUMENT,
+  VKGS_USB_STATUS_SYSTEM_ERROR,
+  VKGS_USB_STATUS_NOT_OPEN,
+  VKGS_USB_STATUS_ENDPOINT_NOT_FOUND,
+  VKGS_USB_STATUS_SHORT_TRANSFER,
+  VKGS_USB_STATUS_TIMEOUT,
+  VKGS_USB_STATUS_CANCELLED
+} vkgs_usb_status_t;
+
+typedef struct {
+  vkgs_usb_status_t status;
+  int32_t native_code;
+  char operation[VKGS_USB_OPERATION_CAPACITY];
+  char message[VKGS_USB_MESSAGE_CAPACITY];
+} vkgs_usb_error_t;
+
+typedef struct {
+  char path[VKGS_USB_PATH_CAPACITY];
+  char label[VKGS_USB_LABEL_CAPACITY];
+  uint8_t interface_number;
+  uint8_t endpoint_in;
+  uint8_t endpoint_out;
+  bool busy;
+} vkgs_usb_interface_t;
+
+typedef struct {
+  size_t count;
+  vkgs_usb_interface_t devices[VKGS_USB_MAX_DEVICES];
+} vkgs_usb_device_list_t;
+
+typedef struct vkgs_usb_device vkgs_usb_device_t;
+
+void vkgs_usb_error_clear(vkgs_usb_error_t *error);
+
+bool vkgs_usb_list_scan(vkgs_usb_device_list_t *list, vkgs_usb_error_t *error);
+
+vkgs_usb_device_t *vkgs_usb_open(const char *path, vkgs_usb_error_t *error);
+
+uint8_t vkgs_usb_interface_number(const vkgs_usb_device_t *device);
+
+bool vkgs_usb_control_in(vkgs_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vkgs_usb_error_t *error);
+
+bool vkgs_usb_control_out(vkgs_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vkgs_usb_error_t *error);
+
+bool vkgs_usb_bulk_read(vkgs_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vkgs_usb_error_t *error);
+
+bool vkgs_usb_bulk_write(vkgs_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vkgs_usb_error_t *error);
+
+void vkgs_usb_cancel(vkgs_usb_device_t *device);
+
+void vkgs_usb_close(vkgs_usb_device_t *device);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/main/docan/vkgs_usb/devicePath.ts
+++ b/src/main/docan/vkgs_usb/devicePath.ts
@@ -1,0 +1,43 @@
+export interface VkgsUsbPathCandidate {
+  path: string
+  interfaceNumber: number
+}
+
+const CURRENT_PATH_PREFIX = 'libusb://1d50:606f/'
+const LEGACY_DEVICE_ID = 'vid_1d50&pid_606f'
+
+/**
+ * Resolves handles saved by the former WinUSB backend without coupling the
+ * driver to a platform API. A legacy handle is migrated only when its channel
+ * identifies exactly one currently connected libusb interface.
+ */
+export function resolveVkgsUsbPath(
+  path: string,
+  channel: number,
+  listDevices: () => readonly VkgsUsbPathCandidate[]
+): string {
+  if (path.startsWith(CURRENT_PATH_PREFIX)) return path
+  if (!path.toLowerCase().includes(LEGACY_DEVICE_ID)) return path
+
+  let matches: readonly VkgsUsbPathCandidate[]
+  try {
+    matches = listDevices().filter((device) => device.interfaceNumber === channel)
+  } catch (error) {
+    throw new Error(
+      `Unable to migrate the stored VKGS USB device path: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+
+  if (matches.length === 1) return matches[0].path
+  if (matches.length === 0) {
+    throw new Error(
+      `The stored VKGS USB device path uses the legacy WinUSB format, but channel ${channel} is not connected. Reconnect the device and reselect it in Hardware.`
+    )
+  }
+
+  throw new Error(
+    `The stored VKGS USB device path matches multiple channel ${channel} interfaces. Reselect the intended device in Hardware.`
+  )
+}

--- a/src/main/docan/vkgs_usb/index.ts
+++ b/src/main/docan/vkgs_usb/index.ts
@@ -1,0 +1,489 @@
+import { EventEmitter } from 'events'
+import { cloneDeep } from 'lodash'
+import {
+  CAN_ERROR_ID,
+  CAN_ID_TYPE,
+  CanBaseInfo,
+  CanDevice,
+  CanError,
+  CanMessage,
+  CanMsgType,
+  getTsUs
+} from '../../share/can'
+import { CanLOG } from '../../log'
+import { CanBase } from '../base'
+import { VkgsUsbApi, VkgsUsbCapabilities, VkgsUsbDeviceInfo } from './protocol'
+import { NativeTransportError, VkgsUsbTransport } from './transport'
+import { normalizeVkgsData, VkgsUsbEvent, VkgsUsbFrame, VkgsWireDecoder } from './wire'
+
+interface PendingTransmit {
+  resolve: (timestamp: number) => void
+  reject: (error: CanError) => void
+  id: number
+  msgType: CanMsgType
+  data: Buffer
+  extra?: { database?: string; name?: string }
+}
+
+interface PendingRead {
+  reject: (error: CanError) => void
+  msgType: CanMsgType
+  eventName: string
+  listener: (message: CanMessage | CanError) => void
+  timer: NodeJS.Timeout
+}
+
+const STATE_NAMES = [
+  'error-active',
+  'error-warning',
+  'error-passive',
+  'bus-off',
+  'stopped',
+  'sleeping'
+]
+
+const ERROR_NAMES = ['none', 'stuff', 'form', 'ack', 'bit1', 'bit0', 'crc']
+
+function splitHandle(handle: unknown): { path: string; channel: number } {
+  const value = String(handle)
+  const separator = value.lastIndexOf('|')
+  if (separator <= 0) throw new Error('invalid VKGS USB handle')
+  const channel = Number(value.slice(separator + 1))
+  if (!Number.isInteger(channel) || channel < 0 || channel > 255) {
+    throw new Error(`invalid VKGS USB channel in handle: ${value}`)
+  }
+  return { path: value.slice(0, separator), channel }
+}
+
+function formatVersion(version: number) {
+  return `${(version >>> 24) & 0xff}.${(version >>> 16) & 0xff}.${
+    (version >>> 8) & 0xff
+  }.${version & 0xff}`
+}
+
+function makeExtra(
+  capabilities: VkgsUsbCapabilities,
+  deviceInfo?: VkgsUsbDeviceInfo,
+  termination?: boolean
+) {
+  return {
+    usbCan: {
+      protocol: 'vkgs_usb' as const,
+      cap: capabilities.nominal,
+      dataCap: capabilities.data,
+      fdSupported: capabilities.fdSupported,
+      Res: capabilities.terminationSupported || termination !== undefined,
+      termination,
+      swVersion: deviceInfo?.swVersion,
+      hwVersion: deviceInfo?.hwVersion
+    }
+  }
+}
+
+function getVkgsUsbDevices(): CanDevice[] {
+  const interfaces = VkgsUsbTransport.listDevices()
+  return interfaces.map((item, index) => {
+    let capabilities = VkgsUsbApi.fallbackCapabilities()
+    let deviceInfo: VkgsUsbDeviceInfo | undefined
+    let termination: boolean | undefined
+    let busy = item.busy
+
+    if (!busy) {
+      let transport: VkgsUsbTransport | undefined
+      try {
+        transport = VkgsUsbTransport.open(
+          item.path,
+          () => {},
+          () => {},
+          () => {}
+        )
+        const api = new VkgsUsbApi(transport, item.interfaceNumber)
+        capabilities = api.readCapabilities()
+        try {
+          deviceInfo = api.readDeviceInfo()
+        } catch (error) {
+          sysLog.warn(
+            `vkgs_usb device-info query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+        try {
+          termination = api.getTermination()
+        } catch (error) {
+          sysLog.warn(
+            `vkgs_usb termination query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      } catch (error) {
+        busy = true
+        sysLog.warn(
+          `vkgs_usb probe failed for channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      } finally {
+        transport?.close()
+      }
+    }
+
+    return {
+      label: `${item.label} CH${item.interfaceNumber}`,
+      id: `vkgs_usb-${index}-ch${item.interfaceNumber}`,
+      handle: `${item.path}|${item.interfaceNumber}`,
+      serialNumber: item.path,
+      busy,
+      extra: makeExtra(capabilities, deviceInfo, termination)
+    }
+  })
+}
+
+export class VKGS_USB_CAN extends CanBase {
+  readonly event = new EventEmitter()
+  readonly info: CanBaseInfo
+  readonly log: CanLOG
+  closed = false
+
+  private readonly transport: VkgsUsbTransport
+  private readonly api: VkgsUsbApi
+  private readonly decoder: VkgsWireDecoder
+  private readonly startTime = getTsUs()
+  private timestampOffset?: number
+  private nextToken = 1
+  private nextRead = 1
+  private lastState = -1
+  private fatalTransportError = false
+  private readonly pendingTransmits = new Map<number, PendingTransmit>()
+  private readonly pendingReads = new Map<number, PendingRead>()
+
+  constructor(info: CanBaseInfo) {
+    super()
+    this.info = cloneDeep(info)
+    this.log = new CanLOG('VKGS_USB', info.name, info.id, this.event)
+    const { path, channel } = splitHandle(info.handle)
+    this.transport = VkgsUsbTransport.open(
+      path,
+      (data) => this.receive(data),
+      (error) => this.transportError(error),
+      (result) => this.transmitComplete(result)
+    )
+    this.api = new VkgsUsbApi(this.transport, channel)
+    try {
+      const capabilities = this.api.readCapabilities()
+      this.validateTiming(info, capabilities)
+      try {
+        const deviceInfo = this.api.readDeviceInfo()
+        sysLog.info(
+          `vkgs_usb ${info.name}: SW ${formatVersion(deviceInfo.swVersion)}, HW ${formatVersion(deviceInfo.hwVersion)}, channel ${channel}`
+        )
+      } catch (error) {
+        sysLog.warn(
+          `vkgs_usb ${info.name}: device-info query unavailable: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+      this.decoder = this.api.configure(info, !!info.vkgsUsbRes)
+      this.transport.startReceive()
+      this.attachCanMessage(this.busloadCb)
+    } catch (error) {
+      try {
+        this.api.stop()
+      } catch {
+        // Preserve the original configuration/open error.
+      }
+      this.transport.close()
+      this.log.close()
+      throw error
+    }
+  }
+
+  private validateTiming(info: CanBaseInfo, capabilities: VkgsUsbCapabilities) {
+    const validate = (
+      name: string,
+      timing: CanBaseInfo['bitrate'],
+      cap: typeof capabilities.nominal
+    ) => {
+      const clock = Number(timing.clock) * 1_000_000
+      const calculated = Math.floor(
+        clock / (timing.preScaler * (1 + timing.timeSeg1 + timing.timeSeg2))
+      )
+      if (clock !== cap.fclk_can) {
+        throw new Error(`${name} clock must be ${cap.fclk_can / 1_000_000} MHz`)
+      }
+      if (Math.abs(calculated - timing.freq) / timing.freq > 0.01) {
+        throw new Error(`${name} timing calculates ${calculated} Hz, expected ${timing.freq} Hz`)
+      }
+      if (timing.timeSeg1 < cap.tseg1_min || timing.timeSeg1 > cap.tseg1_max) {
+        throw new Error(`${name} timeSeg1 is outside ${cap.tseg1_min}..${cap.tseg1_max}`)
+      }
+      if (timing.timeSeg2 < cap.tseg2_min || timing.timeSeg2 > cap.tseg2_max) {
+        throw new Error(`${name} timeSeg2 is outside ${cap.tseg2_min}..${cap.tseg2_max}`)
+      }
+      if (timing.sjw < 1 || timing.sjw > cap.sjw_max) {
+        throw new Error(`${name} sjw is outside 1..${cap.sjw_max}`)
+      }
+      if (timing.preScaler < cap.brp_min || timing.preScaler > cap.brp_max) {
+        throw new Error(`${name} prescaler is outside ${cap.brp_min}..${cap.brp_max}`)
+      }
+      if ((timing.preScaler - cap.brp_min) % Math.max(1, cap.brp_inc) !== 0) {
+        throw new Error(`${name} prescaler does not match the device increment ${cap.brp_inc}`)
+      }
+    }
+
+    validate('CAN', info.bitrate, capabilities.nominal)
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('CAN FD data timing is required')
+      validate('CAN FD', info.bitratefd, capabilities.data || capabilities.nominal)
+    }
+  }
+
+  private receive(transfer: Buffer) {
+    if (this.closed) return
+    try {
+      const decoded = this.decoder.push(transfer)
+      for (const event of decoded.events) this.handleWireEvent(event)
+      for (const frame of decoded.frames) this.handleFrame(frame)
+    } catch (error) {
+      this.decoder.reset()
+      this.log.error(
+        getTsUs() - this.startTime,
+        `VKGS USB receive framing error: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  private handleFrame(frame: VkgsUsbFrame) {
+    let timestamp = getTsUs() - this.startTime
+    if (frame.timestampUs > 0) {
+      if (this.timestampOffset === undefined) this.timestampOffset = frame.timestampUs - timestamp
+      timestamp = frame.timestampUs - this.timestampOffset
+    }
+    const msgType: CanMsgType = {
+      idType: frame.extended ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+      canfd: frame.fd,
+      brs: frame.brs,
+      remote: frame.remote
+    }
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'IN',
+      id: frame.id,
+      data: frame.remote ? Buffer.alloc(0) : frame.data,
+      ts: timestamp,
+      msgType,
+      database: this.info.database
+    }
+    this.log.canBase(message)
+    this.event.emit(this.getReadBaseId(frame.id, msgType), message)
+  }
+
+  private handleWireEvent(event: VkgsUsbEvent) {
+    if (event.kind === 'state') {
+      if (event.state === this.lastState) return
+      this.lastState = event.state
+      if (event.state !== 0) {
+        this.log.error(
+          event.timestampUs || getTsUs() - this.startTime,
+          `CAN state ${STATE_NAMES[event.state] || event.state}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+        )
+      }
+      return
+    }
+    if (event.errorCode !== 0) {
+      this.log.error(
+        getTsUs() - this.startTime,
+        `CAN bus error ${ERROR_NAMES[event.errorCode] || event.errorCode}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+      )
+    }
+  }
+
+  private transmitComplete(result: { token: number; ok: boolean; error?: string }) {
+    const pending = this.pendingTransmits.get(result.token)
+    if (!pending) return
+    this.pendingTransmits.delete(result.token)
+    if (!result.ok) {
+      pending.reject(
+        new CanError(CAN_ERROR_ID.CAN_INTERNAL_ERROR, pending.msgType, pending.data, result.error)
+      )
+      return
+    }
+    const timestamp = getTsUs() - this.startTime
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'OUT',
+      id: pending.id,
+      data: pending.data,
+      ts: timestamp,
+      msgType: pending.msgType,
+      database: pending.extra?.database,
+      name: pending.extra?.name
+    }
+    this.log.canBase(message)
+    pending.resolve(timestamp)
+  }
+
+  private transportError(error: NativeTransportError) {
+    if (this.closed) return
+    this.fatalTransportError = true
+    this.log.error(getTsUs() - this.startTime, error.message)
+    this.rejectAll(CAN_ERROR_ID.CAN_INTERNAL_ERROR, error)
+    setImmediate(() => this.close())
+  }
+
+  private rejectAll(errorId: CAN_ERROR_ID, cause?: unknown) {
+    for (const pending of this.pendingTransmits.values()) {
+      pending.reject(
+        new CanError(
+          errorId,
+          pending.msgType,
+          pending.data,
+          cause instanceof Error ? cause.message : cause === undefined ? undefined : String(cause)
+        )
+      )
+    }
+    this.pendingTransmits.clear()
+    for (const pending of this.pendingReads.values()) {
+      clearTimeout(pending.timer)
+      this.event.off(pending.eventName, pending.listener)
+      pending.reject(new CanError(errorId, pending.msgType))
+    }
+    this.pendingReads.clear()
+  }
+
+  setOption(cmd: string, value: unknown): unknown {
+    return this._setOption(cmd, value)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    this.rejectAll(CAN_ERROR_ID.CAN_BUS_CLOSED)
+    if (!this.fatalTransportError) {
+      try {
+        this.api.stop()
+      } catch (error) {
+        sysLog.warn(
+          `vkgs_usb stop failed: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    this.transport.close()
+    this.detachCanMessage(this.busloadCb)
+    this.log.close()
+    this._close()
+  }
+
+  writeBase(
+    id: number,
+    msgType: CanMsgType,
+    data: Buffer,
+    extra?: { database?: string; name?: string }
+  ): Promise<number> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType, data))
+    }
+    const maximumId = msgType.idType === CAN_ID_TYPE.EXTENDED ? 0x1fffffff : 0x7ff
+    if (!Number.isInteger(id) || id < 0 || id > maximumId || (msgType.brs && !msgType.canfd)) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_PARAM_ERROR, msgType, data))
+    }
+
+    let normalized: Buffer
+    try {
+      normalized = normalizeVkgsData(data, msgType.canfd)
+    } catch (error) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          msgType,
+          data,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    const frame: VkgsUsbFrame = {
+      id,
+      data: normalized,
+      fd: msgType.canfd,
+      brs: msgType.brs,
+      extended: msgType.idType === CAN_ID_TYPE.EXTENDED,
+      remote: msgType.remote,
+      timestampUs: 0
+    }
+    const packet = this.api.encodeFrame(frame)
+
+    return new Promise<number>((resolve, reject) => {
+      const token = this.nextTransmitToken()
+      this.pendingTransmits.set(token, { resolve, reject, id, msgType, data: normalized, extra })
+      try {
+        if (!this.transport.write(packet, token, 5, 10)) {
+          this.pendingTransmits.delete(token)
+          reject(
+            new CanError(
+              CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+              msgType,
+              normalized,
+              'VKGS USB transmit queue is full'
+            )
+          )
+        }
+      } catch (error) {
+        this.pendingTransmits.delete(token)
+        reject(
+          new CanError(
+            CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+            msgType,
+            normalized,
+            error instanceof Error ? error.message : String(error)
+          )
+        )
+      }
+    })
+  }
+
+  private nextTransmitToken() {
+    while (this.pendingTransmits.has(this.nextToken)) {
+      this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    }
+    const token = this.nextToken
+    this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    return token
+  }
+
+  readBase(
+    id: number,
+    msgType: CanMsgType,
+    timeout: number
+  ): Promise<{ data: Buffer; ts: number }> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType))
+    }
+    const eventName = this.getReadBaseId(id, msgType)
+    const readId = this.nextRead++
+    return new Promise((resolve, reject) => {
+      const listener = (value: CanMessage | CanError) => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        clearTimeout(pending.timer)
+        this.pendingReads.delete(readId)
+        if (value instanceof CanError) reject(value)
+        else resolve({ data: value.data, ts: value.ts! })
+      }
+      const timer = setTimeout(() => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        this.pendingReads.delete(readId)
+        this.event.off(eventName, listener)
+        reject(new CanError(CAN_ERROR_ID.CAN_READ_TIMEOUT, msgType))
+      }, timeout)
+      this.pendingReads.set(readId, { reject, msgType, eventName, listener, timer })
+      this.event.once(eventName, listener)
+    })
+  }
+
+  getReadBaseId(id: number, msgType: CanMsgType): string {
+    return `${id}-${msgType.canfd ? msgType.brs : false}-${msgType.remote}-${msgType.canfd}-${msgType.idType}`
+  }
+
+  static override getValidDevices(): CanDevice[] {
+    return getVkgsUsbDevices()
+  }
+
+  static override getLibVersion(): string {
+    return '1.0.0 (libusb)'
+  }
+}

--- a/src/main/docan/vkgs_usb/index.ts
+++ b/src/main/docan/vkgs_usb/index.ts
@@ -12,6 +12,7 @@ import {
 } from '../../share/can'
 import { CanLOG } from '../../log'
 import { CanBase } from '../base'
+import { resolveVkgsUsbPath } from './devicePath'
 import { VkgsUsbApi, VkgsUsbCapabilities, VkgsUsbDeviceInfo } from './protocol'
 import { NativeTransportError, VkgsUsbTransport } from './transport'
 import { normalizeVkgsData, VkgsUsbEvent, VkgsUsbFrame, VkgsWireDecoder } from './wire'
@@ -156,7 +157,9 @@ export class VKGS_USB_CAN extends CanBase {
     super()
     this.info = cloneDeep(info)
     this.log = new CanLOG('VKGS_USB', info.name, info.id, this.event)
-    const { path, channel } = splitHandle(info.handle)
+    const { path: storedPath, channel } = splitHandle(info.handle)
+    const path = resolveVkgsUsbPath(storedPath, channel, () => VkgsUsbTransport.listDevices())
+    this.info.handle = `${path}|${channel}`
     this.transport = VkgsUsbTransport.open(
       path,
       (data) => this.receive(data),

--- a/src/main/docan/vkgs_usb/native/transport.cpp
+++ b/src/main/docan/vkgs_usb/native/transport.cpp
@@ -1,0 +1,470 @@
+#include <napi.h>
+
+#include "../api/vkgs_usb.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr size_t kTransferSize = 512;
+constexpr size_t kTxQueueLimit = 512;
+constexpr uint32_t kIoTimeoutMs = 2000;
+constexpr uint32_t kRxPollMs = 100;
+
+struct TxJob {
+  uint32_t token = 0;
+  std::vector<uint8_t> bytes;
+  uint32_t delayBeforeMs = 0;
+  uint32_t delayAfterMs = 0;
+};
+
+struct TxResult {
+  uint32_t token = 0;
+  bool ok = false;
+  std::string error;
+};
+
+struct ErrorResult {
+  int32_t code = 0;
+  std::string operation;
+  std::string detail;
+};
+
+std::mutex gDevicesMutex;
+std::map<uint32_t, std::shared_ptr<class UsbTransport>> gDevices;
+std::atomic<uint32_t> gNextHandle{1};
+
+std::string ApiErrorMessage(const vkgs_usb_error_t &error) {
+  std::ostringstream output;
+  output << (error.operation[0] != '\0' ? error.operation : "VKGS USB");
+  if (error.message[0] != '\0')
+    output << " failed: " << error.message;
+  if (error.native_code != 0)
+    output << " (code " << error.native_code << ')';
+  return output.str();
+}
+
+int32_t ApiErrorCode(const vkgs_usb_error_t &error) {
+  return error.native_code != 0 ? error.native_code
+                                : static_cast<int32_t>(error.status);
+}
+
+class UsbTransport {
+public:
+  UsbTransport(Napi::Env env, std::string path, Napi::Function rxCallback,
+               Napi::Function errorCallback, Napi::Function txCallback)
+      : path_(std::move(path)), rxTsfn_(Napi::ThreadSafeFunction::New(
+                                    env, rxCallback, "vkgs-usb-rx", 4096, 1)),
+        errorTsfn_(Napi::ThreadSafeFunction::New(env, errorCallback,
+                                                 "vkgs-usb-error", 8, 1)),
+        txTsfn_(Napi::ThreadSafeFunction::New(env, txCallback, "vkgs-usb-tx",
+                                              1024, 1)) {}
+
+  ~UsbTransport() { Close(); }
+
+  void Open() {
+    vkgs_usb_error_t error{};
+    device_ = vkgs_usb_open(path_.c_str(), &error);
+    if (device_ == nullptr)
+      throw std::runtime_error(ApiErrorMessage(error));
+    txThread_ = std::thread(&UsbTransport::TxLoop, this);
+  }
+
+  uint8_t InterfaceNumber() const { return vkgs_usb_interface_number(device_); }
+
+  void StartRx() {
+    EnsureOpen();
+    bool expected = false;
+    if (!rxStarted_.compare_exchange_strong(expected, true))
+      return;
+    rxThread_ = std::thread(&UsbTransport::RxLoop, this);
+  }
+
+  std::vector<uint8_t> ControlIn(uint8_t requestType, uint8_t request,
+                                 uint16_t value, uint16_t index,
+                                 uint16_t length) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    std::vector<uint8_t> result(length);
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_control_in(device_, requestType, request, value, index,
+                             result.data(), length, kIoTimeoutMs, &error)) {
+      throw std::runtime_error(ApiErrorMessage(error));
+    }
+    return result;
+  }
+
+  void ControlOut(uint8_t requestType, uint8_t request, uint16_t value,
+                  uint16_t index, const uint8_t *data, size_t length) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    if (length > UINT16_MAX)
+      throw std::runtime_error("VKGS USB control payload is too large");
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_control_out(device_, requestType, request, value, index, data,
+                              static_cast<uint16_t>(length), kIoTimeoutMs,
+                              &error)) {
+      throw std::runtime_error(ApiErrorMessage(error));
+    }
+  }
+
+  bool Enqueue(uint32_t token, const uint8_t *data, size_t length,
+               uint32_t delayBeforeMs, uint32_t delayAfterMs) {
+    if (data == nullptr || length == 0)
+      return false;
+    std::lock_guard<std::mutex> lock(txMutex_);
+    if (closing_ || txQueue_.size() >= kTxQueueLimit)
+      return false;
+    txQueue_.push_back(TxJob{token, std::vector<uint8_t>(data, data + length),
+                             delayBeforeMs, delayAfterMs});
+    txCondition_.notify_one();
+    return true;
+  }
+
+  void Close() {
+    bool expected = false;
+    if (!closing_.compare_exchange_strong(expected, true))
+      return;
+    txCondition_.notify_all();
+    vkgs_usb_cancel(device_);
+    if (rxThread_.joinable())
+      rxThread_.join();
+    if (txThread_.joinable())
+      txThread_.join();
+    vkgs_usb_close(device_);
+    device_ = nullptr;
+    rxTsfn_.Release();
+    errorTsfn_.Release();
+    txTsfn_.Release();
+  }
+
+private:
+  void EnsureOpen() const {
+    if (closing_ || device_ == nullptr) {
+      throw std::runtime_error("VKGS USB transport is closed");
+    }
+  }
+
+  bool WaitDelay(uint32_t delayMs) {
+    if (delayMs == 0)
+      return !closing_;
+    std::unique_lock<std::mutex> lock(txMutex_);
+    return !txCondition_.wait_for(lock, std::chrono::milliseconds(delayMs),
+                                  [&] { return closing_.load(); });
+  }
+
+  void RxLoop() {
+    while (!closing_) {
+      std::vector<uint8_t> bytes(kTransferSize);
+      size_t transferred = 0;
+      vkgs_usb_error_t error{};
+      if (!vkgs_usb_bulk_read(device_, bytes.data(), bytes.size(), &transferred,
+                              kRxPollMs, &error)) {
+        if (!closing_ && error.status != VKGS_USB_STATUS_CANCELLED)
+          ReportError(error);
+        break;
+      }
+      if (transferred == 0)
+        continue;
+      bytes.resize(transferred);
+      auto *payload = new std::vector<uint8_t>(std::move(bytes));
+      const napi_status status = rxTsfn_.NonBlockingCall(
+          payload, [](Napi::Env env, Napi::Function callback,
+                      std::vector<uint8_t> *value) {
+            callback.Call({Napi::Buffer<uint8_t>::Copy(env, value->data(),
+                                                       value->size())});
+            delete value;
+          });
+      if (status != napi_ok) {
+        delete payload;
+        if (!closing_ && status != napi_closing) {
+          vkgs_usb_error_t queueError{};
+          queueError.status = VKGS_USB_STATUS_SYSTEM_ERROR;
+          queueError.native_code = 0;
+          std::snprintf(queueError.operation, sizeof(queueError.operation),
+                        "RX callback queue");
+          std::snprintf(queueError.message, sizeof(queueError.message),
+                        "callback queue is full");
+          ReportError(queueError);
+          break;
+        }
+      }
+    }
+  }
+
+  void TxLoop() {
+    while (true) {
+      TxJob job;
+      {
+        std::unique_lock<std::mutex> lock(txMutex_);
+        txCondition_.wait(lock, [&] { return closing_ || !txQueue_.empty(); });
+        if (closing_ && txQueue_.empty())
+          break;
+        job = std::move(txQueue_.front());
+        txQueue_.pop_front();
+      }
+
+      bool ok = WaitDelay(job.delayBeforeMs);
+      vkgs_usb_error_t error{};
+      size_t transferred = 0;
+      if (ok) {
+        ok = vkgs_usb_bulk_write(device_, job.bytes.data(), job.bytes.size(),
+                                 &transferred, kIoTimeoutMs, &error);
+      }
+      if (ok)
+        ok = WaitDelay(job.delayAfterMs);
+      std::string detail;
+      if (!ok) {
+        detail = error.status != VKGS_USB_STATUS_OK
+                     ? ApiErrorMessage(error)
+                     : "VKGS USB transport is closed";
+      }
+      PostTxResult(new TxResult{job.token, ok, std::move(detail)});
+    }
+
+    std::deque<TxJob> abandoned;
+    {
+      std::lock_guard<std::mutex> lock(txMutex_);
+      abandoned.swap(txQueue_);
+    }
+    for (const auto &job : abandoned) {
+      PostTxResult(
+          new TxResult{job.token, false, "VKGS USB transport is closed"});
+    }
+  }
+
+  void PostTxResult(TxResult *result) {
+    const napi_status status = txTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, TxResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("token", Napi::Number::New(env, value->token));
+          object.Set("ok", Napi::Boolean::New(env, value->ok));
+          if (!value->ok)
+            object.Set("error", Napi::String::New(env, value->error));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  void ReportError(const vkgs_usb_error_t &error) {
+    auto *result = new ErrorResult{ApiErrorCode(error), error.operation,
+                                   ApiErrorMessage(error)};
+    const napi_status status = errorTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, ErrorResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("operation", Napi::String::New(env, value->operation));
+          object.Set("code", Napi::Number::New(env, value->code));
+          object.Set("message", Napi::String::New(env, value->detail));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  std::string path_;
+  vkgs_usb_device_t *device_ = nullptr;
+  std::atomic<bool> closing_{false};
+  std::atomic<bool> rxStarted_{false};
+  std::thread rxThread_;
+  std::thread txThread_;
+  std::mutex controlMutex_;
+  std::mutex txMutex_;
+  std::condition_variable txCondition_;
+  std::deque<TxJob> txQueue_;
+  Napi::ThreadSafeFunction rxTsfn_;
+  Napi::ThreadSafeFunction errorTsfn_;
+  Napi::ThreadSafeFunction txTsfn_;
+};
+
+std::shared_ptr<UsbTransport> Lookup(uint32_t handle) {
+  std::lock_guard<std::mutex> lock(gDevicesMutex);
+  const auto found = gDevices.find(handle);
+  if (found == gDevices.end())
+    throw std::runtime_error("invalid VKGS USB transport handle");
+  return found->second;
+}
+
+uint32_t ReadHandle(const Napi::CallbackInfo &info) {
+  if (info.Length() == 0 || !info[0].IsNumber()) {
+    throw Napi::TypeError::New(info.Env(),
+                               "a numeric transport handle is required");
+  }
+  return info[0].As<Napi::Number>().Uint32Value();
+}
+
+Napi::Value ListDevices(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  vkgs_usb_device_list_t list{};
+  vkgs_usb_error_t error{};
+  if (!vkgs_usb_list_scan(&list, &error)) {
+    throw Napi::Error::New(env, ApiErrorMessage(error));
+  }
+  Napi::Array output = Napi::Array::New(env, list.count);
+  for (size_t index = 0; index < list.count; ++index) {
+    const auto &item = list.devices[index];
+    Napi::Object object = Napi::Object::New(env);
+    object.Set("path", Napi::String::New(env, item.path));
+    object.Set("label", Napi::String::New(env, item.label));
+    object.Set("interfaceNumber",
+               Napi::Number::New(env, item.interface_number));
+    object.Set("endpointIn", Napi::Number::New(env, item.endpoint_in));
+    object.Set("endpointOut", Napi::Number::New(env, item.endpoint_out));
+    object.Set("busy", Napi::Boolean::New(env, item.busy));
+    output.Set(index, object);
+  }
+  return output;
+}
+
+Napi::Value Open(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 4 || !info[0].IsString() || !info[1].IsFunction() ||
+      !info[2].IsFunction() || !info[3].IsFunction()) {
+    throw Napi::TypeError::New(
+        env, "open expects path, rx callback, error callback, tx callback");
+  }
+  try {
+    auto device = std::make_shared<UsbTransport>(
+        env, info[0].As<Napi::String>().Utf8Value(),
+        info[1].As<Napi::Function>(), info[2].As<Napi::Function>(),
+        info[3].As<Napi::Function>());
+    device->Open();
+    const uint32_t handle = gNextHandle.fetch_add(1);
+    {
+      std::lock_guard<std::mutex> lock(gDevicesMutex);
+      gDevices.emplace(handle, device);
+    }
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("handle", Napi::Number::New(env, handle));
+    result.Set("interfaceNumber",
+               Napi::Number::New(env, device->InterfaceNumber()));
+    return result;
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value StartRx(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(ReadHandle(info))->StartRx();
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Control(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 6 || !info[0].IsNumber() || !info[1].IsNumber() ||
+      !info[2].IsNumber() || !info[3].IsNumber() || !info[4].IsNumber()) {
+    throw Napi::TypeError::New(
+        env,
+        "control expects handle, type, request, value, index, data/length");
+  }
+  try {
+    auto device = Lookup(ReadHandle(info));
+    const uint8_t requestType =
+        static_cast<uint8_t>(info[1].As<Napi::Number>().Uint32Value());
+    const uint8_t request =
+        static_cast<uint8_t>(info[2].As<Napi::Number>().Uint32Value());
+    const uint16_t value =
+        static_cast<uint16_t>(info[3].As<Napi::Number>().Uint32Value());
+    const uint16_t index =
+        static_cast<uint16_t>(info[4].As<Napi::Number>().Uint32Value());
+    if ((requestType & 0x80) != 0) {
+      if (!info[5].IsNumber())
+        throw std::runtime_error("control IN length must be numeric");
+      const uint32_t rawLength = info[5].As<Napi::Number>().Uint32Value();
+      if (rawLength > UINT16_MAX)
+        throw std::runtime_error("control IN length is too large");
+      const auto bytes = device->ControlIn(requestType, request, value, index,
+                                           static_cast<uint16_t>(rawLength));
+      return Napi::Buffer<uint8_t>::Copy(env, bytes.data(), bytes.size());
+    }
+    if (!info[5].IsBuffer())
+      throw std::runtime_error("control OUT payload must be a Buffer");
+    const auto input = info[5].As<Napi::Buffer<uint8_t>>();
+    device->ControlOut(requestType, request, value, index, input.Data(),
+                       input.Length());
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Write(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 5 || !info[0].IsNumber() || !info[1].IsBuffer() ||
+      !info[2].IsNumber() || !info[3].IsNumber() || !info[4].IsNumber()) {
+    throw Napi::TypeError::New(
+        env,
+        "write expects handle, Buffer, token, delayBeforeMs, delayAfterMs");
+  }
+  try {
+    const auto input = info[1].As<Napi::Buffer<uint8_t>>();
+    const bool queued =
+        Lookup(ReadHandle(info))
+            ->Enqueue(info[2].As<Napi::Number>().Uint32Value(), input.Data(),
+                      input.Length(), info[3].As<Napi::Number>().Uint32Value(),
+                      info[4].As<Napi::Number>().Uint32Value());
+    return Napi::Boolean::New(env, queued);
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Close(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  std::shared_ptr<UsbTransport> device;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    const auto found = gDevices.find(ReadHandle(info));
+    if (found == gDevices.end())
+      return env.Undefined();
+    device = found->second;
+    gDevices.erase(found);
+  }
+  device->Close();
+  return env.Undefined();
+}
+
+void Cleanup(void *) {
+  std::map<uint32_t, std::shared_ptr<UsbTransport>> devices;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    devices.swap(gDevices);
+  }
+  for (auto &entry : devices)
+    entry.second->Close();
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("listDevices", Napi::Function::New(env, ListDevices));
+  exports.Set("open", Napi::Function::New(env, Open));
+  exports.Set("startRx", Napi::Function::New(env, StartRx));
+  exports.Set("control", Napi::Function::New(env, Control));
+  exports.Set("write", Napi::Function::New(env, Write));
+  exports.Set("close", Napi::Function::New(env, Close));
+  napi_add_env_cleanup_hook(env, Cleanup, nullptr);
+  return exports;
+}
+
+} // namespace
+
+NODE_API_MODULE(vkgs_usb, Init)

--- a/src/main/docan/vkgs_usb/protocol.ts
+++ b/src/main/docan/vkgs_usb/protocol.ts
@@ -1,0 +1,234 @@
+import { CanBaseInfo, CandleCapability } from '../../share/can'
+import { VkgsUsbTransport } from './transport'
+import { encodeVkgsFrame, VkgsDecoder, VkgsUsbFrame, VkgsWireDecoder } from './wire'
+
+export const VKGS_USB_VID = 0x1d50
+export const VKGS_USB_PID = 0x606f
+
+const FEATURE_HW_TIMESTAMP = 1 << 4
+const FEATURE_FD = 1 << 8
+const FEATURE_BT_CONST_EXT = 1 << 10
+const FEATURE_TERMINATION = 1 << 11
+const FEATURE_BERR_REPORTING = 1 << 12
+
+const MODE_LISTEN_ONLY = 1 << 0
+const MODE_HW_TIMESTAMP = 1 << 4
+const MODE_FD = 1 << 8
+const MODE_BERR_REPORTING = 1 << 12
+
+const REQUEST = {
+  hostFormat: 0,
+  bitTiming: 1,
+  mode: 2,
+  btConst: 4,
+  dataBitTiming: 10,
+  btConstExt: 11,
+  fallbackSetTermination: 12,
+  fallbackGetTermination: 13,
+  deviceInfo: 33,
+  termination: 37
+} as const
+
+const FALLBACK_CAPABILITY: CandleCapability = {
+  feature: FEATURE_FD | FEATURE_BT_CONST_EXT,
+  fclk_can: 80_000_000,
+  tseg1_min: 2,
+  tseg1_max: 256,
+  tseg2_min: 1,
+  tseg2_max: 128,
+  sjw_max: 128,
+  brp_min: 1,
+  brp_max: 512,
+  brp_inc: 1
+}
+
+export interface VkgsUsbDeviceInfo {
+  swVersion: number
+  hwVersion: number
+  uid: number[]
+  uuid: number[]
+}
+
+export interface VkgsUsbCapabilities {
+  nominal: CandleCapability
+  data?: CandleCapability
+  fdSupported: boolean
+  terminationSupported: boolean
+}
+
+function sleep(milliseconds: number) {
+  if (milliseconds <= 0) return
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+}
+
+function readCapabilityFields(buffer: Buffer, offset: number, feature: number, clock: number) {
+  if (buffer.length < offset + 32) throw new Error('VKGS USB capability response is too short')
+  return {
+    feature,
+    fclk_can: clock || 80_000_000,
+    tseg1_min: buffer.readUInt32LE(offset),
+    tseg1_max: buffer.readUInt32LE(offset + 4),
+    tseg2_min: buffer.readUInt32LE(offset + 8),
+    tseg2_max: buffer.readUInt32LE(offset + 12),
+    sjw_max: buffer.readUInt32LE(offset + 16),
+    brp_min: buffer.readUInt32LE(offset + 20),
+    brp_max: buffer.readUInt32LE(offset + 24),
+    brp_inc: buffer.readUInt32LE(offset + 28)
+  }
+}
+
+export class VkgsUsbApi {
+  readonly channel: number
+  readonly transport: VkgsUsbTransport
+  private capabilities?: VkgsUsbCapabilities
+  timestampsEnabled = false
+  fdMode = false
+
+  constructor(transport: VkgsUsbTransport, channel: number) {
+    this.transport = transport
+    this.channel = channel
+    if (transport.interfaceNumber !== channel) {
+      throw new Error(
+        `VKGS USB interface mismatch: selected channel ${channel}, opened ${transport.interfaceNumber}`
+      )
+    }
+  }
+
+  private setControl(request: number, payload: Buffer) {
+    this.transport.controlOut(request, this.channel, this.channel, payload)
+    sleep(5)
+  }
+
+  private getControl(request: number, payloadLength: number): Buffer {
+    return this.transport.controlIn(request, 0, this.channel, payloadLength)
+  }
+
+  readCapabilities(): VkgsUsbCapabilities {
+    if (this.capabilities) return this.capabilities
+    const response = this.getControl(REQUEST.btConst, 40)
+    const feature = response.readUInt32LE(0)
+    const clock = response.readUInt32LE(4)
+    const nominal = readCapabilityFields(response, 8, feature, clock)
+    let data: CandleCapability | undefined
+    if (feature & FEATURE_FD && feature & FEATURE_BT_CONST_EXT) {
+      const extended = this.getControl(REQUEST.btConstExt, 72)
+      data = readCapabilityFields(extended, 40, extended.readUInt32LE(0), extended.readUInt32LE(4))
+    }
+    this.capabilities = {
+      nominal,
+      data,
+      fdSupported: !!(feature & FEATURE_FD),
+      terminationSupported: !!(feature & FEATURE_TERMINATION)
+    }
+    return this.capabilities
+  }
+
+  readDeviceInfo(): VkgsUsbDeviceInfo {
+    const response = this.getControl(REQUEST.deviceInfo, 40)
+    return {
+      swVersion: response.readUInt32LE(0),
+      hwVersion: response.readUInt32LE(4),
+      uid: Array.from({ length: 4 }, (_, index) => response.readUInt32LE(8 + index * 4)),
+      uuid: Array.from({ length: 4 }, (_, index) => response.readUInt32LE(24 + index * 4))
+    }
+  }
+
+  getTermination(): boolean {
+    try {
+      return this.getControl(REQUEST.termination, 4).readUInt32LE(0) !== 0
+    } catch {
+      return this.getControl(REQUEST.fallbackGetTermination, 4).readUInt32LE(0) !== 0
+    }
+  }
+
+  setTermination(enabled: boolean) {
+    const payload = Buffer.alloc(4)
+    payload.writeUInt32LE(enabled ? 1 : 0)
+    try {
+      this.setControl(REQUEST.termination, payload)
+    } catch {
+      this.setControl(REQUEST.fallbackSetTermination, payload)
+    }
+  }
+
+  private setBitTiming(info: CanBaseInfo, dataPhase: boolean) {
+    const timing = dataPhase ? info.bitratefd : info.bitrate
+    if (!timing) throw new Error('VKGS USB CAN FD data timing is not configured')
+    if (Math.min(timing.preScaler, timing.timeSeg1, timing.timeSeg2, timing.sjw) < 1) {
+      throw new Error('VKGS USB timing values must be at least 1')
+    }
+    const payload = Buffer.alloc(20)
+    payload.writeUInt32LE(0, 0)
+    payload.writeUInt32LE(timing.timeSeg1 - 1, 4)
+    payload.writeUInt32LE(timing.timeSeg2 - 1, 8)
+    payload.writeUInt32LE(timing.sjw - 1, 12)
+    payload.writeUInt32LE(timing.preScaler - 1, 16)
+    this.setControl(dataPhase ? REQUEST.dataBitTiming : REQUEST.bitTiming, payload)
+  }
+
+  private setMode(mode: number, flags: number) {
+    const payload = Buffer.alloc(8)
+    payload.writeUInt32LE(mode, 0)
+    payload.writeUInt32LE(flags, 4)
+    this.setControl(REQUEST.mode, payload)
+    sleep(150)
+  }
+
+  private setHostFormat() {
+    const hostFormat = Buffer.alloc(4)
+    hostFormat.writeUInt32LE(0x0000beef)
+    this.setControl(REQUEST.hostFormat, hostFormat)
+  }
+
+  configure(info: CanBaseInfo, termination: boolean): VkgsWireDecoder {
+    const capabilities = this.readCapabilities()
+    const configuredClock = Number(info.bitrate.clock) * 1_000_000
+    if (!Number.isFinite(configuredClock) || configuredClock !== capabilities.nominal.fclk_can) {
+      throw new Error(
+        `VKGS USB clock mismatch: configured ${configuredClock || 0} Hz, device reports ${capabilities.nominal.fclk_can} Hz`
+      )
+    }
+    if (info.canfd && !capabilities.fdSupported) {
+      throw new Error('CAN FD is enabled, but the selected VKGS USB device does not support it')
+    }
+
+    this.setMode(0, 0)
+    this.setHostFormat()
+    this.setBitTiming(info, false)
+    if (info.canfd) this.setBitTiming(info, true)
+    try {
+      this.setTermination(termination)
+    } catch (error) {
+      if (termination || capabilities.terminationSupported) throw error
+    }
+
+    let flags = info.silent ? MODE_LISTEN_ONLY : 0
+    if (info.canfd) flags |= MODE_FD
+    if (capabilities.nominal.feature & FEATURE_BERR_REPORTING) flags |= MODE_BERR_REPORTING
+    if (capabilities.nominal.feature & FEATURE_HW_TIMESTAMP) {
+      flags |= MODE_HW_TIMESTAMP
+      this.timestampsEnabled = true
+    }
+    this.fdMode = info.canfd
+    this.setMode(1, flags)
+    return new VkgsDecoder(this.timestampsEnabled, this.channel)
+  }
+
+  stop() {
+    this.setMode(0, 0)
+    this.setHostFormat()
+  }
+
+  encodeFrame(frame: VkgsUsbFrame): Buffer {
+    return encodeVkgsFrame(this.channel, frame, this.fdMode)
+  }
+
+  static fallbackCapabilities(): VkgsUsbCapabilities {
+    return {
+      nominal: { ...FALLBACK_CAPABILITY },
+      data: { ...FALLBACK_CAPABILITY },
+      fdSupported: true,
+      terminationSupported: false
+    }
+  }
+}

--- a/src/main/docan/vkgs_usb/transport.ts
+++ b/src/main/docan/vkgs_usb/transport.ts
@@ -1,0 +1,113 @@
+import NativeVkgsUsb from './../build/Release/vkgs_usb.node'
+
+export interface NativeUsbInterface {
+  path: string
+  label: string
+  interfaceNumber: number
+  endpointIn: number
+  endpointOut: number
+  busy: boolean
+}
+
+interface NativeOpenResult {
+  handle: number
+  interfaceNumber: number
+}
+
+export interface NativeTransportError {
+  operation: string
+  code: number
+  message: string
+}
+
+interface NativeTxResult {
+  token: number
+  ok: boolean
+  error?: string
+}
+
+interface NativeApi {
+  listDevices(): NativeUsbInterface[]
+  open(
+    path: string,
+    onReceive: (data: Buffer) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): NativeOpenResult
+  startRx(handle: number): void
+  control(
+    handle: number,
+    requestType: number,
+    request: number,
+    value: number,
+    index: number,
+    dataOrLength: Buffer | number
+  ): Buffer | undefined
+  write(
+    handle: number,
+    data: Buffer,
+    token: number,
+    delayBeforeMs?: number,
+    delayAfterMs?: number
+  ): boolean
+  close(handle: number): void
+}
+
+const native = NativeVkgsUsb as NativeApi
+
+export class VkgsUsbTransport {
+  readonly handle: number
+  readonly interfaceNumber: number
+  private closed = false
+
+  private constructor(result: NativeOpenResult) {
+    this.handle = result.handle
+    this.interfaceNumber = result.interfaceNumber
+  }
+
+  static listDevices(): NativeUsbInterface[] {
+    return native.listDevices()
+  }
+
+  static open(
+    path: string,
+    onReceive: (data: Buffer) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): VkgsUsbTransport {
+    const result = native.open(path, onReceive, onError, onTransmit)
+    return new VkgsUsbTransport(result)
+  }
+
+  startReceive() {
+    this.assertOpen()
+    native.startRx(this.handle)
+  }
+
+  controlIn(request: number, value: number, index: number, length: number): Buffer {
+    this.assertOpen()
+    const result = native.control(this.handle, 0xc1, request, value, index, length)
+    if (!Buffer.isBuffer(result)) throw new Error('VKGS USB control read returned no data')
+    return result
+  }
+
+  controlOut(request: number, value: number, index: number, data: Buffer) {
+    this.assertOpen()
+    native.control(this.handle, 0x41, request, value, index, data)
+  }
+
+  write(data: Buffer, token: number, delayBeforeMs = 0, delayAfterMs = 0): boolean {
+    this.assertOpen()
+    return native.write(this.handle, data, token, delayBeforeMs, delayAfterMs)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    native.close(this.handle)
+  }
+
+  private assertOpen() {
+    if (this.closed) throw new Error('VKGS USB transport is closed')
+  }
+}

--- a/src/main/docan/vkgs_usb/wire.ts
+++ b/src/main/docan/vkgs_usb/wire.ts
@@ -1,0 +1,199 @@
+export interface VkgsUsbFrame {
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+  timestampUs: number
+}
+
+export interface VkgsUsbStateEvent {
+  kind: 'state'
+  state: number
+  rxErrorCount: number
+  txErrorCount: number
+  timestampUs: number
+}
+
+export interface VkgsUsbBusErrorEvent {
+  kind: 'bus-error'
+  errorCode: number
+  rxErrorCount: number
+  txErrorCount: number
+}
+
+export type VkgsUsbEvent = VkgsUsbStateEvent | VkgsUsbBusErrorEvent
+
+export interface VkgsDecodeResult {
+  frames: VkgsUsbFrame[]
+  events: VkgsUsbEvent[]
+  tail: Buffer
+}
+
+export interface VkgsWireDecoder {
+  push(transfer: Buffer): VkgsDecodeResult
+  reset(): void
+}
+
+const FLAG_FD = 1 << 1
+const FLAG_BRS = 1 << 2
+
+const CAN_EFF_FLAG = 0x80000000
+const CAN_RTR_FLAG = 0x40000000
+const CAN_ID_MASK = 0x1fffffff
+
+const VKGS_ECHO_RX = 0xffffffff
+const VKGS_ECHO_LOAD = 0xa3c95e3d
+const VKGS_ECHO_STATE = 0xa4c95e3d
+const VKGS_ECHO_BERR = 0xa6c95e3d
+const VKGS_HEADER_SIZE = 12
+const VKGS_STATE_SIZE = 28
+const VKGS_BERR_SIZE = 16
+const VKGS_LOAD_SIZE = 28
+
+const FD_DLC_LENGTHS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]
+
+export function lengthToVkgsDlc(length: number, fd: boolean): number {
+  const maximum = fd ? 64 : 8
+  if (!Number.isInteger(length) || length < 0 || length > maximum) {
+    throw new RangeError(`CAN payload length must be 0..${maximum}`)
+  }
+  if (!fd) return length
+  const dlc = FD_DLC_LENGTHS.findIndex((candidate) => candidate >= length)
+  if (dlc < 0) throw new RangeError('CAN FD payload exceeds 64 bytes')
+  return dlc
+}
+
+export function vkgsDlcToLength(dlc: number, fd: boolean): number {
+  const normalized = dlc & 0x0f
+  return fd ? FD_DLC_LENGTHS[normalized] : Math.min(normalized, 8)
+}
+
+export function normalizeVkgsData(data: Buffer, fd: boolean): Buffer {
+  const wireLength = vkgsDlcToLength(lengthToVkgsDlc(data.length, fd), fd)
+  if (wireLength === data.length) return Buffer.from(data)
+  return Buffer.concat([data, Buffer.alloc(wireLength - data.length)])
+}
+
+function readTimestamp(buffer: Buffer, offset: number): number {
+  const timestamp = buffer.readBigUInt64LE(offset)
+  if (timestamp > BigInt(Number.MAX_SAFE_INTEGER)) return 0
+  return Number(timestamp)
+}
+
+export function encodeVkgsFrame(channel: number, frame: VkgsUsbFrame, fdMode: boolean): Buffer {
+  const data = normalizeVkgsData(frame.data, frame.fd)
+  const width = fdMode || frame.fd ? 64 : 8
+  const packet = Buffer.alloc(VKGS_HEADER_SIZE + width)
+  let canId = frame.id & CAN_ID_MASK
+  if (frame.extended) canId = (canId | CAN_EFF_FLAG) >>> 0
+  if (frame.remote) canId = (canId | CAN_RTR_FLAG) >>> 0
+  let flags = frame.fd ? FLAG_FD : 0
+  if (frame.brs) flags |= FLAG_BRS
+  packet.writeUInt32LE(0, 0)
+  packet.writeUInt32LE(canId, 4)
+  packet.writeUInt8(lengthToVkgsDlc(data.length, frame.fd), 8)
+  packet.writeUInt8(channel, 9)
+  packet.writeUInt8(flags, 10)
+  data.copy(packet, VKGS_HEADER_SIZE)
+  return packet
+}
+
+export class VkgsDecoder implements VkgsWireDecoder {
+  private tail = Buffer.alloc(0)
+
+  constructor(
+    private readonly timestampsEnabled: boolean,
+    private readonly expectedChannel?: number
+  ) {}
+
+  reset() {
+    this.tail = Buffer.alloc(0)
+  }
+
+  push(transfer: Buffer): VkgsDecodeResult {
+    const buffer = this.tail.length ? Buffer.concat([this.tail, transfer]) : transfer
+    this.tail = Buffer.alloc(0)
+    const frames: VkgsUsbFrame[] = []
+    const events: VkgsUsbEvent[] = []
+    let offset = 0
+
+    while (offset < buffer.length) {
+      const remaining = buffer.length - offset
+      if (remaining < 4) {
+        if (buffer.subarray(offset).some((value) => value !== 0)) {
+          this.tail = Buffer.from(buffer.subarray(offset))
+        }
+        break
+      }
+      const echoId = buffer.readUInt32LE(offset)
+      if (echoId === 0) break
+      if (remaining < VKGS_HEADER_SIZE) {
+        this.tail = Buffer.from(buffer.subarray(offset))
+        break
+      }
+
+      let size: number
+      if (echoId === VKGS_ECHO_STATE) size = VKGS_STATE_SIZE
+      else if (echoId === VKGS_ECHO_BERR) size = VKGS_BERR_SIZE
+      else if (echoId === VKGS_ECHO_LOAD) size = VKGS_LOAD_SIZE
+      else if (echoId === VKGS_ECHO_RX) {
+        const flags = buffer.readUInt8(offset + 10)
+        size = VKGS_HEADER_SIZE + (flags & FLAG_FD ? 64 : 8) + (this.timestampsEnabled ? 8 : 0)
+      } else {
+        this.reset()
+        throw new Error(`unknown VKGS bulk frame marker: 0x${echoId.toString(16)}`)
+      }
+
+      const frameChannel = buffer.readUInt8(offset + (echoId === VKGS_ECHO_RX ? 9 : 4))
+      if (this.expectedChannel !== undefined && frameChannel !== this.expectedChannel) {
+        this.reset()
+        throw new Error(
+          `VKGS bulk frame channel ${frameChannel} does not match interface ${this.expectedChannel}`
+        )
+      }
+
+      if (offset + size > buffer.length) {
+        this.tail = Buffer.from(buffer.subarray(offset))
+        break
+      }
+
+      if (echoId === VKGS_ECHO_RX) {
+        const rawId = buffer.readUInt32LE(offset + 4)
+        const flags = buffer.readUInt8(offset + 10)
+        const fd = !!(flags & FLAG_FD)
+        const length = vkgsDlcToLength(buffer.readUInt8(offset + 8), fd)
+        frames.push({
+          id: rawId & CAN_ID_MASK,
+          data: Buffer.from(
+            buffer.subarray(offset + VKGS_HEADER_SIZE, offset + VKGS_HEADER_SIZE + length)
+          ),
+          fd,
+          brs: !!(flags & FLAG_BRS),
+          extended: !!(rawId & CAN_EFF_FLAG),
+          remote: !!(rawId & CAN_RTR_FLAG),
+          timestampUs: this.timestampsEnabled ? readTimestamp(buffer, offset + size - 8) : 0
+        })
+      } else if (echoId === VKGS_ECHO_STATE) {
+        events.push({
+          kind: 'state',
+          timestampUs: readTimestamp(buffer, offset + 8),
+          state: buffer.readUInt32LE(offset + 16),
+          rxErrorCount: buffer.readUInt32LE(offset + 20),
+          txErrorCount: buffer.readUInt32LE(offset + 24)
+        })
+      } else if (echoId === VKGS_ECHO_BERR) {
+        events.push({
+          kind: 'bus-error',
+          errorCode: buffer.readUInt8(offset + 9),
+          rxErrorCount: buffer.readUInt8(offset + 10),
+          txErrorCount: buffer.readUInt8(offset + 11)
+        })
+      }
+      offset += size
+    }
+
+    return { frames, events, tail: Buffer.from(this.tail) }
+  }
+}

--- a/src/main/share/can.ts
+++ b/src/main/share/can.ts
@@ -23,6 +23,8 @@ export type CanVendor =
   | 'slcan'
   | 'ecubus'
   | 'candle'
+  | 'vcan_usb'
+  | 'vkgs_usb'
 export interface CanBaseInfo {
   id: string
   handle: any
@@ -36,6 +38,8 @@ export interface CanBaseInfo {
   toomossRes?: boolean
   zlgRes?: boolean
   candleRes?: boolean
+  vcanUsbRes?: boolean
+  vkgsUsbRes?: boolean
   slcanDelay?: number
 }
 
@@ -495,6 +499,16 @@ export interface CanDevice {
       dataCap?: CandleCapability
       fdSupported?: boolean
       Res?: boolean
+    }
+    usbCan?: {
+      protocol?: 'vcan_usb' | 'vkgs_usb'
+      cap?: CandleCapability
+      dataCap?: CandleCapability
+      fdSupported?: boolean
+      Res?: boolean
+      termination?: boolean
+      swVersion?: number
+      hwVersion?: number
     }
   }
 }

--- a/src/renderer/src/views/uds/hardware/canNode.vue
+++ b/src/renderer/src/views/uds/hardware/canNode.vue
@@ -80,6 +80,28 @@
       </el-select>
     </el-form-item>
     <el-form-item
+      v-else-if="props.vendor == 'vcan_usb' && getSelectedUsbCanDevice()?.extra?.usbCan?.Res"
+      :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
+      prop="vcanUsbRes"
+      :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
+    >
+      <el-select v-model="data.vcanUsbRes" :loading="deviceLoading" style="width: 300px">
+        <el-option :label="i18next.t('uds.hardware.canNode.options.enable')" :value="true" />
+        <el-option :label="i18next.t('uds.hardware.canNode.options.disable')" :value="false" />
+      </el-select>
+    </el-form-item>
+    <el-form-item
+      v-else-if="props.vendor == 'vkgs_usb' && getSelectedUsbCanDevice()?.extra?.usbCan?.Res"
+      :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
+      prop="vkgsUsbRes"
+      :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
+    >
+      <el-select v-model="data.vkgsUsbRes" :loading="deviceLoading" style="width: 300px">
+        <el-option :label="i18next.t('uds.hardware.canNode.options.enable')" :value="true" />
+        <el-option :label="i18next.t('uds.hardware.canNode.options.disable')" :value="false" />
+      </el-select>
+    </el-form-item>
+    <el-form-item
       v-else-if="props.vendor == 'zlg'"
       :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
       prop="zlgRes"
@@ -91,7 +113,9 @@
       </el-select>
     </el-form-item>
     <el-form-item
-      v-else-if="props.vendor == 'kvaser'"
+      v-else-if="
+        props.vendor == 'kvaser' || props.vendor == 'vcan_usb' || props.vendor == 'vkgs_usb'
+      "
       :label="i18next.t('uds.hardware.canNode.labels.silentMode')"
       prop="silent"
       :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
@@ -710,6 +734,19 @@ const configInfo: Record<CanVendor, any> = {
       }
     }
   }
+} as Record<CanVendor, any>
+
+for (const vendor of ['vcan_usb', 'vkgs_usb'] as const) {
+  const config = cloneDeep(configInfo.candle)
+  config.can.clock = [{ clock: '80', name: '80' }]
+  config.canFd.clock = [{ clock: '80', name: '80' }]
+  configInfo[vendor] = config
+}
+
+function getSelectedUsbCanDevice(): CanDevice | undefined {
+  if (props.vendor !== 'vcan_usb' && props.vendor !== 'vkgs_usb') return undefined
+  if (data.value.handle === '' || data.value.handle == null) return undefined
+  return deviceList.value.find((device) => device.handle === data.value.handle)
 }
 
 /** Look up the currently selected candle device from the device list */
@@ -779,6 +816,10 @@ const showCandleTimingTable = computed(() => {
 })
 
 const showCanFdCheckbox = computed(() => {
+  if (props.vendor === 'vcan_usb' || props.vendor === 'vkgs_usb') {
+    const device = getSelectedUsbCanDevice()
+    return !device || !!device.extra?.usbCan?.fdSupported
+  }
   if (props.vendor !== 'candle') return true
   const dev = getSelectedCandleDevice()
   return !!dev?.extra?.candle?.fdSupported
@@ -958,7 +999,9 @@ function getBaudrateSP(speed: CanBitrate, index: number) {
     props.vendor == 'kvaser' ||
     props.vendor == 'toomoss' ||
     props.vendor == 'vector' ||
-    props.vendor == 'candle'
+    props.vendor == 'candle' ||
+    props.vendor == 'vcan_usb' ||
+    props.vendor == 'vkgs_usb'
   ) {
     let f_clock = Number(speed.clock || 80) * 1000000
     if (index == 1) {
@@ -1142,7 +1185,9 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
     props.vendor == 'peak' ||
     props.vendor == 'kvaser' ||
     props.vendor == 'toomoss' ||
-    props.vendor == 'candle'
+    props.vendor == 'candle' ||
+    props.vendor == 'vcan_usb' ||
+    props.vendor == 'vkgs_usb'
   ) {
     if (data.value.bitrate.clock == undefined) {
       callback(new Error(i18next.t('uds.hardware.canNode.validation.selectClock')))
@@ -1272,7 +1317,9 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
       props.vendor == 'kvaser' ||
       props.vendor == 'toomoss' ||
       props.vendor == 'peak' ||
-      props.vendor == 'candle'
+      props.vendor == 'candle' ||
+      props.vendor == 'vcan_usb' ||
+      props.vendor == 'vkgs_usb'
     ) {
       const calcFreq =
         (Number(data.value.bitrate.clock || 40) * 1000000) /

--- a/src/renderer/src/views/uds/hardware/index.vue
+++ b/src/renderer/src/views/uds/hardware/index.vue
@@ -566,6 +566,18 @@ async function buildTree() {
     t.push(candle)
     addSubTree('candle', candle, deviceIndexMap)
   }
+  for (const vendor of ['vcan_usb', 'vkgs_usb'] as const) {
+    if (!vendors.includes(vendor)) continue
+    const usbCan: tree = {
+      label: i18next.t(`uds.hardware.vendors.${vendor}`),
+      vendor,
+      append: false,
+      id: vendor.toUpperCase(),
+      children: []
+    }
+    t.push(usbCan)
+    addSubTree(vendor, usbCan, deviceIndexMap)
+  }
 
   tData.value = t
 }

--- a/test/docan/vcan_usb/devicePath.test.ts
+++ b/test/docan/vcan_usb/devicePath.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest'
+import { resolveVcanUsbPath } from '../../../src/main/docan/vcan_usb/devicePath'
+
+describe('VCAN USB device path compatibility', () => {
+  test('keeps a current libusb path without enumerating devices', () => {
+    const listDevices = vi.fn(() => [])
+    const path = 'libusb://1d50:6080/2/p2.1.3/0'
+
+    expect(resolveVcanUsbPath(path, 0, listDevices)).toBe(path)
+    expect(listDevices).not.toHaveBeenCalled()
+  })
+
+  test('migrates a legacy WinUSB path when the channel match is unique', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_6080&MI_01#device`
+    const currentPath = 'libusb://1d50:6080/2/p2.1.3/1'
+
+    expect(
+      resolveVcanUsbPath(legacyPath, 1, () => [
+        { path: 'libusb://1d50:6080/2/p2.1.3/0', interfaceNumber: 0 },
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('does not guess when more than one physical device has the channel', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_6080&MI_00#device`
+
+    expect(() =>
+      resolveVcanUsbPath(legacyPath, 0, () => [
+        { path: 'libusb://1d50:6080/1/p1/0', interfaceNumber: 0 },
+        { path: 'libusb://1d50:6080/2/p2/0', interfaceNumber: 0 }
+      ])
+    ).toThrow(/multiple channel 0 interfaces/)
+  })
+})

--- a/test/docan/vcan_usb/protocol.test.ts
+++ b/test/docan/vcan_usb/protocol.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest'
+import { VcanUsbApi } from '../../../src/main/docan/vcan_usb/protocol'
+import { VcanUsbTransport } from '../../../src/main/docan/vcan_usb/transport'
+import { makeVcanControlPayload } from '../../../src/main/docan/vcan_usb/wire'
+
+const FEATURE_FD = 1 << 8
+const FEATURE_BT_CONST_EXT = 1 << 10
+const FEATURE_TERMINATION = 1 << 11
+
+function capabilityPayload(feature: number, clock: number, offset = 0, size = 40) {
+  const payload = Buffer.alloc(size)
+  payload.writeUInt32LE(feature, 0)
+  payload.writeUInt32LE(clock, 4)
+  const values = [2, 256, 1, 128, 128, 1, 512, 1]
+  values.forEach((value, index) => payload.writeUInt32LE(value, offset + 8 + index * 4))
+  return payload
+}
+
+class FakeVcanTransport {
+  readonly interfaceNumber = 1
+  readonly reads: number[] = []
+  malformed = false
+
+  controlIn(request: number, _value: number, _index: number, _length: number) {
+    this.reads.push(request)
+    const baseRequest = request & 0x7f
+    let payload: Buffer
+    if (baseRequest === 16) {
+      payload = capabilityPayload(
+        FEATURE_FD | FEATURE_BT_CONST_EXT | FEATURE_TERMINATION,
+        80_000_000
+      )
+    } else if (baseRequest === 17) {
+      payload = capabilityPayload(FEATURE_FD | FEATURE_BT_CONST_EXT, 80_000_000, 32, 72)
+    } else {
+      throw new Error(`unexpected request ${baseRequest}`)
+    }
+    const response = makeVcanControlPayload(this.interfaceNumber, baseRequest, payload)
+    if (this.malformed) response.writeUInt32LE(0, 0)
+    return response
+  }
+}
+
+describe('VCAN USB protocol API', () => {
+  test('reads extended capabilities and caches the result', () => {
+    const transport = new FakeVcanTransport()
+    const api = new VcanUsbApi(transport as unknown as VcanUsbTransport, 1)
+
+    const first = api.readCapabilities()
+    const second = api.readCapabilities()
+
+    expect(first).toBe(second)
+    expect(first).toMatchObject({
+      fdSupported: true,
+      terminationSupported: true,
+      nominal: { fclk_can: 80_000_000, brp_max: 512 },
+      data: { fclk_can: 80_000_000, tseg1_max: 256 }
+    })
+    expect(transport.reads).toEqual([16 | 0x80, 17 | 0x80])
+  })
+
+  test('rejects a response whose VCAN control header is invalid', () => {
+    const transport = new FakeVcanTransport()
+    transport.malformed = true
+    const api = new VcanUsbApi(transport as unknown as VcanUsbTransport, 1)
+    expect(() => api.readCapabilities()).toThrow(/header is invalid/)
+  })
+
+  test('rejects an interface/channel mismatch before USB configuration', () => {
+    const transport = new FakeVcanTransport()
+    expect(() => new VcanUsbApi(transport as unknown as VcanUsbTransport, 0)).toThrow(
+      /interface mismatch/
+    )
+  })
+})

--- a/test/docan/vcan_usb/wire.test.ts
+++ b/test/docan/vcan_usb/wire.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest'
+import {
+  encodeVcanFrame,
+  lengthToVcanDlc,
+  makeVcanControlPayload,
+  stripVcanControlPayload,
+  VcanDecoder,
+  vcanDlcToLength,
+  VcanUsbFrame
+} from '../../../src/main/docan/vcan_usb/wire'
+
+const frame: VcanUsbFrame = {
+  id: 0x18daf110,
+  data: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+  fd: true,
+  brs: true,
+  extended: true,
+  remote: false,
+  timestampUs: 0
+}
+
+describe('VCAN USB wire codec', () => {
+  test('maps CAN FD lengths to canonical DLC values', () => {
+    expect(lengthToVcanDlc(9, true)).toBe(9)
+    expect(vcanDlcToLength(9, true)).toBe(12)
+    expect(lengthToVcanDlc(64, true)).toBe(15)
+    expect(() => lengthToVcanDlc(65, true)).toThrow(/0\.\.64/)
+    expect(() => lengthToVcanDlc(9, false)).toThrow(/0\.\.8/)
+  })
+
+  test('builds and validates control headers', () => {
+    const request = 37
+    const packet = makeVcanControlPayload(1, request, Buffer.from([1, 0, 0, 0]))
+    expect(packet.length).toBe(12)
+    expect(packet.readUInt16LE(4)).toBe(0x100c)
+    expect(stripVcanControlPayload(1, request, packet)).toEqual(Buffer.from([1, 0, 0, 0]))
+
+    const corrupt = Buffer.from(packet)
+    corrupt.writeUInt16LE(0x000c, 4)
+    expect(() => stripVcanControlPayload(1, request, corrupt)).toThrow(/invalid/)
+  })
+
+  test('decodes an FD frame split across USB transfers', () => {
+    const packet = encodeVcanFrame(1, frame)
+    packet.writeUInt32LE(0xa2c95e3d, 0)
+    packet.writeBigUInt64LE(123456789n, 16)
+    const decoder = new VcanDecoder(1)
+
+    expect(decoder.push(packet.subarray(0, 17)).frames).toHaveLength(0)
+    const result = decoder.push(packet.subarray(17))
+
+    expect(result.frames).toHaveLength(1)
+    expect(result.frames[0]).toMatchObject({
+      id: frame.id,
+      fd: true,
+      brs: true,
+      extended: true,
+      timestampUs: 123456789
+    })
+    expect(result.frames[0].data).toEqual(Buffer.concat([frame.data, Buffer.alloc(3)]))
+    expect(result.tail).toHaveLength(0)
+  })
+
+  test('decodes aggregated frames using the opcode length', () => {
+    const first = encodeVcanFrame(0, {
+      ...frame,
+      fd: false,
+      brs: false,
+      data: Buffer.from([1])
+    })
+    first.writeUInt32LE(0xa2c95e3d, 0)
+    const second = Buffer.from(first)
+    second.writeUInt32LE(0x321, 8)
+
+    const result = new VcanDecoder(0).push(Buffer.concat([first, second]))
+    expect(result.frames.map((item) => item.id)).toEqual([frame.id, 0x321])
+  })
+
+  test('rejects an invalid frame length and resets buffered state', () => {
+    const invalid = Buffer.alloc(8)
+    invalid.writeUInt32LE(0xa2c95e3d, 0)
+    invalid.writeUInt16LE(4, 4)
+    const decoder = new VcanDecoder(0)
+    expect(() => decoder.push(invalid)).toThrow(/frame size/)
+
+    const valid = encodeVcanFrame(0, {
+      ...frame,
+      fd: false,
+      brs: false,
+      data: Buffer.alloc(0)
+    })
+    valid.writeUInt32LE(0xa2c95e3d, 0)
+    expect(decoder.push(valid).frames).toHaveLength(1)
+  })
+
+  test('rejects frames received on the wrong interface', () => {
+    const packet = encodeVcanFrame(1, {
+      ...frame,
+      fd: false,
+      brs: false,
+      data: Buffer.alloc(0)
+    })
+    packet.writeUInt32LE(0xa2c95e3d, 0)
+    expect(() => new VcanDecoder(0).push(packet)).toThrow(/channel 1.*interface 0/)
+  })
+})

--- a/test/docan/vkgs_usb/devicePath.test.ts
+++ b/test/docan/vkgs_usb/devicePath.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest'
+import { resolveVkgsUsbPath } from '../../../src/main/docan/vkgs_usb/devicePath'
+
+describe('VKGS USB device path compatibility', () => {
+  test('keeps a current libusb path without enumerating devices', () => {
+    const listDevices = vi.fn(() => [])
+    const path = 'libusb://1d50:606f/2/p2.1.3/0'
+
+    expect(resolveVkgsUsbPath(path, 0, listDevices)).toBe(path)
+    expect(listDevices).not.toHaveBeenCalled()
+  })
+
+  test('migrates a legacy WinUSB path when the channel match is unique', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_606F&MI_01#device`
+    const currentPath = 'libusb://1d50:606f/2/p2.1.3/1'
+
+    expect(
+      resolveVkgsUsbPath(legacyPath, 1, () => [
+        { path: 'libusb://1d50:606f/2/p2.1.3/0', interfaceNumber: 0 },
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('does not guess when more than one physical device has the channel', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_606F&MI_00#device`
+
+    expect(() =>
+      resolveVkgsUsbPath(legacyPath, 0, () => [
+        { path: 'libusb://1d50:606f/1/p1/0', interfaceNumber: 0 },
+        { path: 'libusb://1d50:606f/2/p2/0', interfaceNumber: 0 }
+      ])
+    ).toThrow(/multiple channel 0 interfaces/)
+  })
+})

--- a/test/docan/vkgs_usb/protocol.test.ts
+++ b/test/docan/vkgs_usb/protocol.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest'
+import { VkgsUsbApi } from '../../../src/main/docan/vkgs_usb/protocol'
+import { VkgsUsbTransport } from '../../../src/main/docan/vkgs_usb/transport'
+
+const FEATURE_FD = 1 << 8
+const FEATURE_BT_CONST_EXT = 1 << 10
+const FEATURE_TERMINATION = 1 << 11
+
+function capabilityPayload(feature: number, clock: number, offset = 0, size = 40) {
+  const payload = Buffer.alloc(size)
+  payload.writeUInt32LE(feature, 0)
+  payload.writeUInt32LE(clock, 4)
+  const values = [2, 256, 1, 128, 128, 1, 512, 1]
+  values.forEach((value, index) => payload.writeUInt32LE(value, offset + 8 + index * 4))
+  return payload
+}
+
+class FakeVkgsTransport {
+  readonly interfaceNumber = 0
+  readonly reads: number[] = []
+  readonly writes: number[] = []
+  failModernTermination = false
+
+  controlIn(request: number, _value: number, _index: number, _length: number) {
+    this.reads.push(request)
+    if (request === 4) {
+      return capabilityPayload(FEATURE_FD | FEATURE_BT_CONST_EXT | FEATURE_TERMINATION, 80_000_000)
+    }
+    if (request === 11) {
+      return capabilityPayload(FEATURE_FD | FEATURE_BT_CONST_EXT, 80_000_000, 32, 72)
+    }
+    if (request === 37 && this.failModernTermination) throw new Error('unsupported request')
+    if (request === 37 || request === 13) {
+      const response = Buffer.alloc(4)
+      response.writeUInt32LE(1)
+      return response
+    }
+    throw new Error(`unexpected request ${request}`)
+  }
+
+  controlOut(request: number) {
+    this.writes.push(request)
+    if (request === 37 && this.failModernTermination) throw new Error('unsupported request')
+  }
+}
+
+describe('VKGS USB protocol API', () => {
+  test('reads extended gs_usb capabilities and caches the result', () => {
+    const transport = new FakeVkgsTransport()
+    const api = new VkgsUsbApi(transport as unknown as VkgsUsbTransport, 0)
+
+    const first = api.readCapabilities()
+    const second = api.readCapabilities()
+
+    expect(first).toBe(second)
+    expect(first).toMatchObject({
+      fdSupported: true,
+      terminationSupported: true,
+      nominal: { fclk_can: 80_000_000, brp_max: 512 },
+      data: { fclk_can: 80_000_000, tseg2_max: 128 }
+    })
+    expect(transport.reads).toEqual([4, 11])
+  })
+
+  test('keeps compatibility with legacy termination requests', () => {
+    const transport = new FakeVkgsTransport()
+    transport.failModernTermination = true
+    const api = new VkgsUsbApi(transport as unknown as VkgsUsbTransport, 0)
+
+    expect(api.getTermination()).toBe(true)
+    api.setTermination(true)
+
+    expect(transport.reads).toEqual([37, 13])
+    expect(transport.writes).toEqual([37, 12])
+  })
+
+  test('rejects an interface/channel mismatch before USB configuration', () => {
+    const transport = new FakeVkgsTransport()
+    expect(() => new VkgsUsbApi(transport as unknown as VkgsUsbTransport, 1)).toThrow(
+      /interface mismatch/
+    )
+  })
+})

--- a/test/docan/vkgs_usb/wire.test.ts
+++ b/test/docan/vkgs_usb/wire.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+import {
+  encodeVkgsFrame,
+  lengthToVkgsDlc,
+  VkgsDecoder,
+  vkgsDlcToLength,
+  VkgsUsbFrame
+} from '../../../src/main/docan/vkgs_usb/wire'
+
+const frame: VkgsUsbFrame = {
+  id: 0x18daf110,
+  data: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+  fd: true,
+  brs: true,
+  extended: true,
+  remote: false,
+  timestampUs: 0
+}
+
+describe('VKGS USB wire codec', () => {
+  test('maps CAN FD lengths to canonical DLC values', () => {
+    expect(lengthToVkgsDlc(9, true)).toBe(9)
+    expect(vkgsDlcToLength(9, true)).toBe(12)
+    expect(lengthToVkgsDlc(64, true)).toBe(15)
+    expect(() => lengthToVkgsDlc(65, true)).toThrow(/0\.\.64/)
+    expect(() => lengthToVkgsDlc(9, false)).toThrow(/0\.\.8/)
+  })
+
+  test('encodes FD mode with a fixed 64-byte data area', () => {
+    const packet = encodeVkgsFrame(1, frame, true)
+    expect(packet.length).toBe(76)
+    expect(packet.readUInt8(8)).toBe(9)
+    expect(packet.readUInt8(9)).toBe(1)
+    expect(packet.subarray(12, 21)).toEqual(frame.data)
+    expect(packet.subarray(21)).toEqual(Buffer.alloc(55))
+  })
+
+  test('decodes split frames with hardware timestamps', () => {
+    const packet = encodeVkgsFrame(0, frame, true)
+    packet.writeUInt32LE(0xffffffff, 0)
+    const timestamp = Buffer.alloc(8)
+    timestamp.writeBigUInt64LE(987654321n)
+    const transfer = Buffer.concat([packet, timestamp])
+    const decoder = new VkgsDecoder(true, 0)
+
+    expect(decoder.push(transfer.subarray(0, 25)).frames).toHaveLength(0)
+    const result = decoder.push(transfer.subarray(25))
+    expect(result.frames).toHaveLength(1)
+    expect(result.frames[0].timestampUs).toBe(987654321)
+    expect(result.frames[0].data).toEqual(Buffer.concat([frame.data, Buffer.alloc(3)]))
+  })
+
+  test('decodes state events without interpreting them as CAN data', () => {
+    const state = Buffer.alloc(28)
+    state.writeUInt32LE(0xa4c95e3d, 0)
+    state.writeUInt8(0, 4)
+    state.writeBigUInt64LE(5000n, 8)
+    state.writeUInt32LE(2, 16)
+    state.writeUInt32LE(7, 20)
+    state.writeUInt32LE(9, 24)
+
+    expect(new VkgsDecoder(false, 0).push(state).events).toEqual([
+      {
+        kind: 'state',
+        timestampUs: 5000,
+        state: 2,
+        rxErrorCount: 7,
+        txErrorCount: 9
+      }
+    ])
+  })
+
+  test('rejects frames received on the wrong interface', () => {
+    const packet = encodeVkgsFrame(
+      1,
+      { ...frame, fd: false, brs: false, data: Buffer.alloc(0) },
+      false
+    )
+    packet.writeUInt32LE(0xffffffff, 0)
+    expect(() => new VkgsDecoder(false, 0).push(packet)).toThrow(/channel 1.*interface 0/)
+  })
+})


### PR DESCRIPTION
## Summary

- add `vcan_usb` and `vkgs_usb` as independent CAN adapters, each with its own API, native transport, protocol handling, wire codec, and tests
- use a single libusb-based implementation per adapter on Windows, Linux, and macOS; there are no platform-specific `*_win.cpp` implementations or non-Windows stubs
- expose device capabilities, CAN/CAN-FD timing, listen-only mode, termination control, device information, state/error events, and hardware timestamps where supported
- register both adapters in the desktop UI and CLI vendor catalog

The USB layer uses stable bus/port/interface identifiers, validates exact control and bulk transfer sizes, bounds the transmit queue, recovers stalled endpoints, and performs deterministic cancellation and interface cleanup. The two adapter trees intentionally remain self-contained so protocol changes cannot leak across drivers.

## Validation

- `npm run docan`
- `npm run test -- --run test/docan/vcan_usb test/docan/vkgs_usb` — 17 tests passed
- `npm run typecheck`
- `npm run build`
- VKGS USB hardware check on two interfaces: endpoint discovery and capability reads passed (`feature=0xdbb`, 80 MHz); 40 open/start-RX/cancel/close cycles passed
- verified the Windows `.node` modules contain libusb and do not require a separate `libusb-1.0.dll`

On Windows the USB interfaces still need a WinUSB-compatible device binding. On Linux, normal USB device permissions are required; an attached kernel driver is handled through libusb when the interface is opened.

## Related device resources

For users who need device-side documentation or update packages:

- [VCAN documentation](http://docs.vseasky.com/projects/vcan/index.html)
- Application updates: [GitHub](https://github.com/vseasky/NexuTrace) / [Gitee](https://gitee.com/vseasky/NexuTrace)
- Driver updates: [GitHub](https://github.com/vseasky/VCANDrive) / [Gitee](https://gitee.com/vseasky/VCANDrive)
