### PR TITLE
feat(docan): add cross-platform VCAN USB and VKGS USB drivers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,7 @@
         "ts-loader": "^9.5.4",
         "typedoc": "^0.27.6",
         "typescript": "^5.3.3",
+        "usb": "2.18.0",
         "viewerjs": "^1.11.6",
         "vite": "^5.4.21",
         "vite-plugin-conditional-compiler": "^0.3.1",
@@ -5518,6 +5519,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
@@ -19108,6 +19116,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.18.0.tgz",
+      "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
       }
     },
     "node_modules/utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -17,15 +17,21 @@
         "vector",
         "slcan",
         "ecubus",
-        "candle"
+        "candle",
+        "vcan_usb",
+        "vkgs_usb"
       ],
       "linux": [
         "simulate",
-        "slcan"
+        "slcan",
+        "vcan_usb",
+        "vkgs_usb"
       ],
       "darwin": [
         "simulate",
-        "slcan"
+        "slcan",
+        "vcan_usb",
+        "vkgs_usb"
       ]
     }
   },
@@ -60,7 +66,7 @@
     "build:linux": "npm run build && electron-builder --linux",
     "native": "npm run docan && npm run dolin && npm run someip",
     "api": "typedoc --tsconfig tsconfig.worker.json --lang en-US",
-    "docan": "cd src/main/docan && npx node-gyp rebuild",
+    "docan": "npx node-gyp rebuild --directory src/main/docan && npx node-gyp rebuild --directory src/main/docan/vcan_usb -- -Duse_udev=0 && npx node-gyp rebuild --directory src/main/docan/vkgs_usb -- -Duse_udev=0",
     "dolin": "cd src/main/dolin && npx node-gyp rebuild",
     "someip": "cd src/main/vsomeip && npx node-gyp rebuild",
     "docs:dev": "vitepress dev",
@@ -178,6 +184,7 @@
     "ts-loader": "^9.5.4",
     "typedoc": "^0.27.6",
     "typescript": "^5.3.3",
+    "usb": "2.18.0",
     "viewerjs": "^1.11.6",
     "vite": "^5.4.21",
     "vite-plugin-conditional-compiler": "^0.3.1",

--- a/resources/locales/en/translation.json
+++ b/resources/locales/en/translation.json
@@ -1140,7 +1140,9 @@
         "toomoss": "TOOMOSS",
         "vector": "VECTOR",
         "slcan": "SLCAN",
-        "candle": "CANDLE"
+        "candle": "CANDLE",
+        "vcan_usb": "VCAN USB",
+        "vkgs_usb": "VKGS USB"
       },
       "canNode": {
         "sections": {

--- a/src/cli/rpc/canService.ts
+++ b/src/cli/rpc/canService.ts
@@ -83,7 +83,9 @@ const VENDORS: CanVendor[] = [
   'vector',
   'slcan',
   'ecubus',
-  'candle'
+  'candle',
+  'vcan_usb',
+  'vkgs_usb'
 ]
 
 function loadNativeCan(): typeof import('src/main/docan/can') {

--- a/src/main/docan/can.ts
+++ b/src/main/docan/can.ts
@@ -11,6 +11,8 @@ import { CanBaseInfo } from '../share/can'
 import { CanBase } from './base'
 import { SLCAN_CAN } from './slcan'
 import { Candle_CAN } from './candle'
+import { VCAN_USB_CAN } from './vcan_usb'
+import { VKGS_USB_CAN } from './vkgs_usb'
 
 const libPath = path.dirname(dllLib)
 PEAK_TP.loadDllPath(libPath)
@@ -38,6 +40,10 @@ export function openCanDevice(canDevice: CanBaseInfo) {
     canBase = new SLCAN_CAN(canDevice)
   } else if (canDevice.vendor == 'candle') {
     canBase = new Candle_CAN(canDevice)
+  } else if (canDevice.vendor == 'vcan_usb') {
+    canBase = new VCAN_USB_CAN(canDevice)
+  } else if (canDevice.vendor == 'vkgs_usb') {
+    canBase = new VKGS_USB_CAN(canDevice)
   }
 
   return canBase
@@ -61,6 +67,10 @@ export function getCanVersion(vendor: string) {
     return SLCAN_CAN.getLibVersion()
   } else if (vendor === 'CANDLE') {
     return Candle_CAN.getLibVersion()
+  } else if (vendor === 'VCAN_USB') {
+    return VCAN_USB_CAN.getLibVersion()
+  } else if (vendor === 'VKGS_USB') {
+    return VKGS_USB_CAN.getLibVersion()
   } else {
     return 'Not supported'
   }
@@ -84,6 +94,10 @@ export function getCanDevices(vendor: string) {
     return SLCAN_CAN.getValidDevices()
   } else if (vendor === 'CANDLE') {
     return Candle_CAN.getValidDevices()
+  } else if (vendor === 'VCAN_USB') {
+    return VCAN_USB_CAN.getValidDevices()
+  } else if (vendor === 'VKGS_USB') {
+    return VKGS_USB_CAN.getValidDevices()
   } else {
     return []
   }

--- a/src/main/docan/vcan_usb/api/vcan_usb.cpp
+++ b/src/main/docan/vcan_usb/api/vcan_usb.cpp
@@ -1,0 +1,1561 @@
+#include "vcan_usb.h"
+
+#include <libusb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint16_t kDeviceVid = 0x1d50;
+constexpr uint16_t kDevicePid = 0x6080;
+constexpr uint32_t kDefaultTimeoutMs = 2000;
+constexpr uint32_t kDefaultPollMs = 100;
+constexpr uint32_t kModeSettleMs = 150;
+constexpr size_t kMaxPortDepth = 16;
+constexpr const char *kPathPrefix = "libusb://1d50:6080/";
+
+/* Effective HPM MCAN limits after the firmware translates the USB fields to
+ * the SDK's low-level timing structure.  Keep these local to this driver: the
+ * similarly shaped Candle protocol does not use the same wire semantics. */
+constexpr uint32_t kNominalTseg1Min = 1;
+constexpr uint32_t kNominalTseg1Max = 128;
+constexpr uint32_t kNominalTseg2Min = 2;
+constexpr uint32_t kNominalTseg2Max = 32;
+constexpr uint32_t kNominalSjwMax = 64;
+constexpr uint32_t kNominalBrpMax = 256;
+constexpr uint32_t kDataTseg1Min = 1;
+constexpr uint32_t kDataTseg1Max = 30;
+constexpr uint32_t kDataTseg2Min = 1;
+constexpr uint32_t kDataTseg2Max = 15;
+constexpr uint32_t kDataSjwMax = 15;
+constexpr uint32_t kDataBrpMax = 32;
+
+/* VCAN firmware consumes zero-based register fields, unlike Candle's
+ * host-semantic gs_usb timing values.  Validation guarantees value > 0. */
+constexpr uint32_t EncodeTimingRegister(uint32_t value) { return value - 1U; }
+static_assert(EncodeTimingRegister(1U) == 0U);
+static_assert(EncodeTimingRegister(128U) == 127U);
+
+struct DeviceKey {
+  uint8_t bus = 0;
+  uint8_t address = 0;
+  uint8_t interface_number = 0;
+  std::vector<uint8_t> ports;
+};
+
+struct InterfaceInfo {
+  uint8_t number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+};
+
+struct EnumeratedInterface {
+  std::string path;
+  std::string label;
+  InterfaceInfo interface;
+  bool busy = false;
+};
+struct SharedUsbDevice {
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  std::mutex interface_mutex;
+  std::mutex control_mutex;
+  std::set<uint8_t> claimed_interfaces;
+  std::set<uint8_t> active_interfaces;
+  std::set<uint8_t> manually_detached_interfaces;
+
+  ~SharedUsbDevice() {
+    if (handle != nullptr) {
+      for (const uint8_t interface_number : claimed_interfaces)
+        libusb_release_interface(handle, interface_number);
+      for (const uint8_t interface_number : manually_detached_interfaces)
+        libusb_attach_kernel_driver(handle, interface_number);
+      libusb_close(handle);
+    }
+    if (context != nullptr)
+      libusb_exit(context);
+  }
+};
+
+std::mutex gOpenDevicesMutex;
+std::map<std::string, std::weak_ptr<SharedUsbDevice>> gOpenDevices;
+
+void CopyText(char *destination, size_t capacity, const std::string &source) {
+  if (destination == nullptr || capacity == 0)
+    return;
+  const size_t length = std::min(capacity - 1, source.size());
+  if (length > 0)
+    std::memcpy(destination, source.data(), length);
+  destination[length] = '\0';
+}
+
+vcan_usb_status_t StatusFromLibusb(int code, bool cancelled) {
+  if (cancelled) {
+    return VCAN_USB_STATUS_CANCELLED;
+  }
+  if (code == LIBUSB_ERROR_INVALID_PARAM) {
+    return VCAN_USB_STATUS_INVALID_ARGUMENT;
+  }
+  if (code == LIBUSB_ERROR_TIMEOUT)
+    return VCAN_USB_STATUS_TIMEOUT;
+  if (code == LIBUSB_ERROR_NOT_FOUND) {
+    return VCAN_USB_STATUS_ENDPOINT_NOT_FOUND;
+  }
+  return VCAN_USB_STATUS_SYSTEM_ERROR;
+}
+
+std::string LibusbMessage(int code) {
+  const char *name = libusb_error_name(code);
+  const char *detail = libusb_strerror(static_cast<libusb_error>(code));
+  std::string message = name != nullptr ? name : "LIBUSB_ERROR_UNKNOWN";
+  if (detail != nullptr && detail[0] != '\0' && message != detail) {
+    message += ": ";
+    message += detail;
+  }
+  return message;
+}
+
+void SetError(vcan_usb_error_t *error, vcan_usb_status_t status,
+              const char *operation, int32_t native_code,
+              const std::string &detail) {
+  if (error == nullptr)
+    return;
+  vcan_usb_error_clear(error);
+  error->status = status;
+  error->native_code = native_code;
+  CopyText(error->operation, sizeof(error->operation),
+           operation != nullptr ? operation : "libusb");
+  CopyText(error->message, sizeof(error->message),
+           detail.empty() ? "operation failed" : detail);
+}
+
+void SetLibusbError(vcan_usb_error_t *error, const char *operation, int code,
+                    bool cancelled = false) {
+  SetError(error, StatusFromLibusb(code, cancelled), operation, code,
+           cancelled ? "USB transfer was cancelled" : LibusbMessage(code));
+}
+
+bool ParseByte(const std::string &text, uint8_t *output) {
+  if (text.empty() || output == nullptr)
+    return false;
+  errno = 0;
+  char *end = nullptr;
+  const unsigned long value = std::strtoul(text.c_str(), &end, 10);
+  if (errno != 0 || end == text.c_str() || *end != '\0' || value > UINT8_MAX) {
+    return false;
+  }
+  *output = static_cast<uint8_t>(value);
+  return true;
+}
+
+std::vector<uint8_t> GetPorts(libusb_device *device) {
+  uint8_t ports[kMaxPortDepth]{};
+  const int count =
+      libusb_get_port_numbers(device, ports, static_cast<int>(kMaxPortDepth));
+  if (count <= 0)
+    return {};
+  return std::vector<uint8_t>(ports, ports + count);
+}
+
+std::string MakePath(libusb_device *device, uint8_t interface_number) {
+  std::ostringstream output;
+  output << kPathPrefix << static_cast<unsigned>(libusb_get_bus_number(device))
+         << '/';
+  const auto ports = GetPorts(device);
+  if (ports.empty()) {
+    output << 'a' << static_cast<unsigned>(libusb_get_device_address(device));
+  } else {
+    output << 'p';
+    for (size_t index = 0; index < ports.size(); ++index) {
+      if (index != 0)
+        output << '.';
+      output << static_cast<unsigned>(ports[index]);
+    }
+  }
+  output << '/' << static_cast<unsigned>(interface_number);
+  return output.str();
+}
+
+bool ParsePath(const char *path, DeviceKey *key) {
+  if (path == nullptr || key == nullptr)
+    return false;
+  const std::string value(path);
+  if (value.compare(0, std::strlen(kPathPrefix), kPathPrefix) != 0)
+    return false;
+  const std::string body = value.substr(std::strlen(kPathPrefix));
+  const size_t first = body.find('/');
+  const size_t second = first == std::string::npos ? std::string::npos
+                                                   : body.find('/', first + 1);
+  if (first == std::string::npos || second == std::string::npos ||
+      body.find('/', second + 1) != std::string::npos) {
+    return false;
+  }
+  DeviceKey parsed;
+  if (!ParseByte(body.substr(0, first), &parsed.bus) ||
+      !ParseByte(body.substr(second + 1), &parsed.interface_number)) {
+    return false;
+  }
+  const std::string location = body.substr(first + 1, second - first - 1);
+  if (location.size() < 2)
+    return false;
+  if (location[0] == 'a') {
+    if (!ParseByte(location.substr(1), &parsed.address))
+      return false;
+  } else if (location[0] == 'p') {
+    size_t start = 1;
+    while (start < location.size()) {
+      const size_t end = location.find('.', start);
+      uint8_t port = 0;
+      if (!ParseByte(location.substr(start, end - start), &port) || port == 0) {
+        return false;
+      }
+      parsed.ports.push_back(port);
+      if (parsed.ports.size() > kMaxPortDepth)
+        return false;
+      if (end == std::string::npos)
+        break;
+      if (end + 1 >= location.size())
+        return false;
+      start = end + 1;
+    }
+    if (parsed.ports.empty())
+      return false;
+  } else {
+    return false;
+  }
+  *key = std::move(parsed);
+  return true;
+}
+
+bool Matches(libusb_device *device, const DeviceKey &key) {
+  if (libusb_get_bus_number(device) != key.bus)
+    return false;
+  if (!key.ports.empty())
+    return GetPorts(device) == key.ports;
+  return libusb_get_device_address(device) == key.address;
+}
+
+bool FindInterface(libusb_device *device, uint8_t interface_number,
+                   InterfaceInfo *result) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return false;
+
+  bool found = false;
+  InterfaceInfo fallback{};
+  bool has_fallback = false;
+  for (uint8_t interface_index = 0;
+       interface_index < config->bNumInterfaces && !found; ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    for (int alternate_index = 0;
+         alternate_index < usb_interface.num_altsetting; ++alternate_index) {
+      const libusb_interface_descriptor &descriptor =
+          usb_interface.altsetting[alternate_index];
+      if (descriptor.bInterfaceNumber != interface_number)
+        continue;
+      InterfaceInfo candidate{};
+      candidate.number = descriptor.bInterfaceNumber;
+      candidate.alternate_setting = descriptor.bAlternateSetting;
+      for (uint8_t endpoint_index = 0;
+           endpoint_index < descriptor.bNumEndpoints; ++endpoint_index) {
+        const libusb_endpoint_descriptor &endpoint =
+            descriptor.endpoint[endpoint_index];
+        if ((endpoint.bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+            LIBUSB_TRANSFER_TYPE_BULK) {
+          continue;
+        }
+        if ((endpoint.bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) ==
+            LIBUSB_ENDPOINT_IN) {
+          candidate.endpoint_in = endpoint.bEndpointAddress;
+        } else {
+          candidate.endpoint_out = endpoint.bEndpointAddress;
+        }
+      }
+      if (candidate.endpoint_in == 0 || candidate.endpoint_out == 0)
+        continue;
+      if (!has_fallback) {
+        fallback = candidate;
+        has_fallback = true;
+      }
+      if (candidate.alternate_setting == 0) {
+        *result = candidate;
+        found = true;
+        break;
+      }
+    }
+  }
+  if (!found && has_fallback) {
+    *result = fallback;
+    found = true;
+  }
+  libusb_free_config_descriptor(config);
+  return found;
+}
+
+std::vector<InterfaceInfo> FindInterfaces(libusb_device *device) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return {};
+  std::vector<InterfaceInfo> output;
+  for (uint8_t interface_index = 0; interface_index < config->bNumInterfaces;
+       ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    if (usb_interface.num_altsetting <= 0)
+      continue;
+    const uint8_t number = usb_interface.altsetting[0].bInterfaceNumber;
+    InterfaceInfo info{};
+    if (FindInterface(device, number, &info))
+      output.push_back(info);
+  }
+  libusb_free_config_descriptor(config);
+  return output;
+}
+
+std::string PhysicalKey(const DeviceKey &key) {
+  std::ostringstream output;
+  output << static_cast<unsigned>(key.bus) << '/';
+  if (key.ports.empty()) {
+    output << 'a' << static_cast<unsigned>(key.address);
+  } else {
+    output << 'p';
+    for (size_t index = 0; index < key.ports.size(); ++index) {
+      if (index != 0)
+        output << '.';
+      output << static_cast<unsigned>(key.ports[index]);
+    }
+  }
+  return output.str();
+}
+
+std::string PhysicalKey(libusb_device *device) {
+  DeviceKey key;
+  key.bus = libusb_get_bus_number(device);
+  key.address = libusb_get_device_address(device);
+  key.ports = GetPorts(device);
+  return PhysicalKey(key);
+}
+
+std::shared_ptr<SharedUsbDevice> AcquireDevice(const DeviceKey &key,
+                                               vcan_usb_error_t *error) {
+  const std::string physical_key = PhysicalKey(key);
+  std::lock_guard<std::mutex> registry_lock(gOpenDevicesMutex);
+  const auto existing = gOpenDevices.find(physical_key);
+  if (existing != gOpenDevices.end()) {
+    if (auto shared = existing->second.lock())
+      return shared;
+    gOpenDevices.erase(existing);
+  }
+
+  std::shared_ptr<SharedUsbDevice> shared;
+  try {
+    shared = std::make_shared<SharedUsbDevice>();
+  } catch (const std::bad_alloc &) {
+    SetError(error, VCAN_USB_STATUS_SYSTEM_ERROR, "libusb_open",
+             LIBUSB_ERROR_NO_MEM, "unable to allocate the shared USB device");
+    return {};
+  }
+
+  int status = libusb_init(&shared->context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    return {};
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(shared->context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    return {};
+  }
+
+  status = LIBUSB_ERROR_NO_DEVICE;
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid || !Matches(devices[index], key)) {
+      continue;
+    }
+    status = libusb_open(devices[index], &shared->handle);
+    break;
+  }
+  libusb_free_device_list(devices, 1);
+  if (shared->handle == nullptr || status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_open", status);
+    return {};
+  }
+
+  gOpenDevices[physical_key] = shared;
+  return shared;
+}
+std::string ReadLabel(libusb_device_handle *handle,
+                      const libusb_device_descriptor &descriptor) {
+  if (handle == nullptr || descriptor.iProduct == 0)
+    return "VCAN USB";
+  unsigned char value[VCAN_USB_LABEL_CAPACITY]{};
+  const int length = libusb_get_string_descriptor_ascii(
+      handle, descriptor.iProduct, value, static_cast<int>(sizeof(value) - 1));
+  return length > 0 ? std::string(reinterpret_cast<char *>(value), length)
+                    : "VCAN USB";
+}
+
+bool ProbeBusy(libusb_device *device, uint8_t interface_number,
+               std::string *label, const libusb_device_descriptor &descriptor) {
+  std::shared_ptr<SharedUsbDevice> shared;
+  {
+    std::lock_guard<std::mutex> registry_lock(gOpenDevicesMutex);
+    const auto existing = gOpenDevices.find(PhysicalKey(device));
+    if (existing != gOpenDevices.end())
+      shared = existing->second.lock();
+  }
+  if (shared) {
+    *label = ReadLabel(shared->handle, descriptor);
+    std::lock_guard<std::mutex> interface_lock(shared->interface_mutex);
+    return shared->active_interfaces.count(interface_number) != 0;
+  }
+
+  libusb_device_handle *handle = nullptr;
+  const int open_status = libusb_open(device, &handle);
+  if (open_status != LIBUSB_SUCCESS || handle == nullptr)
+    return true;
+  *label = ReadLabel(handle, descriptor);
+  bool busy = false;
+  const int kernel_active =
+      libusb_kernel_driver_active(handle, interface_number);
+  if (kernel_active != 1) {
+    const int claim_status = libusb_claim_interface(handle, interface_number);
+    busy = claim_status != LIBUSB_SUCCESS;
+    if (!busy)
+      libusb_release_interface(handle, interface_number);
+  }
+  libusb_close(handle);
+  return busy;
+}
+
+bool ClaimInterface(SharedUsbDevice *shared, const InterfaceInfo &usb_interface,
+                    vcan_usb_error_t *error) {
+  if (shared->claimed_interfaces.count(usb_interface.number) != 0)
+    return true;
+
+  bool manually_detached = false;
+  const int kernel_active =
+      libusb_kernel_driver_active(shared->handle, usb_interface.number);
+  const int auto_detach =
+      libusb_set_auto_detach_kernel_driver(shared->handle, 1);
+  if (kernel_active == 1 && auto_detach != LIBUSB_SUCCESS) {
+    const int detach_status =
+        libusb_detach_kernel_driver(shared->handle, usb_interface.number);
+    if (detach_status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_detach_kernel_driver", detach_status);
+      return false;
+    }
+    manually_detached = true;
+  }
+
+  const int claim_status =
+      libusb_claim_interface(shared->handle, usb_interface.number);
+  if (claim_status != LIBUSB_SUCCESS) {
+    if (manually_detached)
+      libusb_attach_kernel_driver(shared->handle, usb_interface.number);
+    SetLibusbError(error, "libusb_claim_interface", claim_status);
+    return false;
+  }
+
+  if (usb_interface.alternate_setting != 0) {
+    const int alternate_status = libusb_set_interface_alt_setting(
+        shared->handle, usb_interface.number, usb_interface.alternate_setting);
+    if (alternate_status != LIBUSB_SUCCESS) {
+      libusb_release_interface(shared->handle, usb_interface.number);
+      if (manually_detached)
+        libusb_attach_kernel_driver(shared->handle, usb_interface.number);
+      SetLibusbError(error, "libusb_set_interface_alt_setting",
+                     alternate_status);
+      return false;
+    }
+  }
+
+  shared->claimed_interfaces.insert(usb_interface.number);
+  if (manually_detached)
+    shared->manually_detached_interfaces.insert(usb_interface.number);
+  return true;
+}
+
+bool ValidateOpen(vcan_usb_device_t *device, vcan_usb_error_t *error,
+                  const char *operation);
+
+} // namespace
+
+struct vcan_usb_device {
+  std::shared_ptr<SharedUsbDevice> owner;
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  uint8_t interface_number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+  bool claimed = false;
+  std::atomic<bool> cancelled{false};
+  std::atomic<bool> fd_mode{false};
+  std::mutex protocol_mutex;
+  std::mutex decoder_mutex;
+  bool capabilities_cached = false;
+  vcan_usb_capabilities_t capabilities{};
+  std::vector<uint8_t> decoder_tail;
+};
+
+namespace {
+
+bool ValidateOpen(vcan_usb_device_t *device, vcan_usb_error_t *error,
+                  const char *operation) {
+  if (device != nullptr && device->owner && device->handle != nullptr &&
+      device->claimed) {
+    return true;
+  }
+  SetError(error, VCAN_USB_STATUS_NOT_OPEN, operation, LIBUSB_ERROR_NO_DEVICE,
+           "VCAN USB device is not open");
+  return false;
+}
+
+bool ControlTransfer(vcan_usb_device_t *device, uint8_t request_type,
+                     uint8_t request, uint16_t value, uint16_t index,
+                     uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                     vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "libusb_control_transfer"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_control_transfer", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  std::lock_guard<std::mutex> control_lock(device->owner->control_mutex);
+  const int transferred = libusb_control_transfer(
+      device->handle, request_type, request, value, index, data, length,
+      timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+  if (transferred < 0) {
+    SetLibusbError(error, "libusb_control_transfer", transferred,
+                   device->cancelled.load());
+    return false;
+  }
+  if (transferred != length) {
+    char detail[96]{};
+    std::snprintf(detail, sizeof(detail), "short control transfer: %d/%u",
+                  transferred, length);
+    SetError(error, VCAN_USB_STATUS_SHORT_TRANSFER, "libusb_control_transfer",
+             LIBUSB_ERROR_IO, detail);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+void vcan_usb_error_clear(vcan_usb_error_t *error) {
+  if (error == nullptr)
+    return;
+  std::memset(error, 0, sizeof(*error));
+  error->status = VCAN_USB_STATUS_OK;
+}
+
+bool vcan_usb_list_scan(vcan_usb_device_list_t *list, vcan_usb_error_t *error) {
+  if (list == nullptr) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_list_scan",
+             LIBUSB_ERROR_INVALID_PARAM, "device list is null");
+    return false;
+  }
+  std::memset(list, 0, sizeof(*list));
+  vcan_usb_error_clear(error);
+  libusb_context *context = nullptr;
+  int status = libusb_init(&context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    return false;
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    libusb_exit(context);
+    return false;
+  }
+
+  std::vector<EnumeratedInterface> found;
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid) {
+      continue;
+    }
+    for (const auto &usb_interface : FindInterfaces(devices[index])) {
+      EnumeratedInterface item;
+      item.path = MakePath(devices[index], usb_interface.number);
+      item.interface = usb_interface;
+      item.label = "VCAN USB";
+      item.busy = ProbeBusy(devices[index], usb_interface.number, &item.label,
+                            descriptor);
+      found.push_back(std::move(item));
+    }
+  }
+  libusb_free_device_list(devices, 1);
+  libusb_exit(context);
+
+  std::sort(found.begin(), found.end(),
+            [](const auto &left, const auto &right) {
+              return left.path < right.path;
+            });
+  list->count =
+      std::min(found.size(), static_cast<size_t>(VCAN_USB_MAX_DEVICES));
+  for (size_t index = 0; index < list->count; ++index) {
+    const auto &source = found[index];
+    auto &target = list->devices[index];
+    CopyText(target.path, sizeof(target.path), source.path);
+    CopyText(target.label, sizeof(target.label), source.label);
+    target.interface_number = source.interface.number;
+    target.endpoint_in = source.interface.endpoint_in;
+    target.endpoint_out = source.interface.endpoint_out;
+    target.busy = source.busy;
+  }
+  return true;
+}
+
+vcan_usb_device_t *vcan_usb_open(const char *path, vcan_usb_error_t *error) {
+  vcan_usb_error_clear(error);
+  DeviceKey key;
+  if (!ParsePath(path, &key)) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_open",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid libusb device path");
+    return nullptr;
+  }
+  auto *result = new (std::nothrow) vcan_usb_device_t();
+  if (result == nullptr) {
+    SetError(error, VCAN_USB_STATUS_SYSTEM_ERROR, "vcan_usb_open",
+             LIBUSB_ERROR_NO_MEM, "unable to allocate the USB device");
+    return nullptr;
+  }
+  result->owner = AcquireDevice(key, error);
+  if (!result->owner) {
+    vcan_usb_close(result);
+    return nullptr;
+  }
+  result->context = result->owner->context;
+  result->handle = result->owner->handle;
+
+  InterfaceInfo usb_interface{};
+  libusb_device *usb_device = libusb_get_device(result->handle);
+  if (usb_device == nullptr ||
+      !FindInterface(usb_device, key.interface_number, &usb_interface)) {
+    SetError(error, VCAN_USB_STATUS_ENDPOINT_NOT_FOUND, "vcan_usb_open",
+             LIBUSB_ERROR_NOT_FOUND, "USB interface was not found");
+    vcan_usb_close(result);
+    return nullptr;
+  }
+
+  result->interface_number = usb_interface.number;
+  result->alternate_setting = usb_interface.alternate_setting;
+  result->endpoint_in = usb_interface.endpoint_in;
+  result->endpoint_out = usb_interface.endpoint_out;
+
+  bool interface_ready = false;
+  {
+    std::lock_guard<std::mutex> interface_lock(result->owner->interface_mutex);
+    if (result->owner->active_interfaces.count(result->interface_number) != 0) {
+      char detail[96]{};
+      std::snprintf(detail, sizeof(detail),
+                    "USB interface %u is already open in this process",
+                    static_cast<unsigned>(result->interface_number));
+      SetError(error, VCAN_USB_STATUS_SYSTEM_ERROR, "vcan_usb_open",
+               LIBUSB_ERROR_BUSY, detail);
+    } else if (ClaimInterface(result->owner.get(), usb_interface, error)) {
+      result->owner->active_interfaces.insert(result->interface_number);
+      result->claimed = true;
+      interface_ready = true;
+
+#ifdef _WIN32
+      // WinUSB can reject a sibling interface claim once another endpoint has
+      // an in-flight transfer. Reserve the remaining CAN interfaces before RX.
+      // Other platforms claim only the requested interface so an EcuBus channel
+      // does not unnecessarily detach a SocketCAN interface.
+      for (const auto &candidate : FindInterfaces(usb_device))
+        ClaimInterface(result->owner.get(), candidate, nullptr);
+#endif
+    }
+  }
+
+  if (!interface_ready) {
+    vcan_usb_close(result);
+    return nullptr;
+  }
+  libusb_clear_halt(result->handle, result->endpoint_in);
+  libusb_clear_halt(result->handle, result->endpoint_out);
+  return result;
+}
+
+uint8_t vcan_usb_interface_number(const vcan_usb_device_t *device) {
+  return device != nullptr ? device->interface_number : 0;
+}
+
+bool vcan_usb_control_in(vcan_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vcan_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) == 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_control_in",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control IN arguments");
+    return false;
+  }
+  vcan_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index, data,
+                         length, timeout_ms, error);
+}
+
+bool vcan_usb_control_out(vcan_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vcan_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) != 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_control_out",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control OUT arguments");
+    return false;
+  }
+  vcan_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index,
+                         const_cast<uint8_t *>(data), length, timeout_ms,
+                         error);
+}
+
+bool vcan_usb_bulk_read(vcan_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vcan_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || capacity == 0 || capacity > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_bulk_read",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk read arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(IN)"))
+    return false;
+  vcan_usb_error_clear(error);
+  const unsigned int poll =
+      poll_timeout_ms == 0 ? kDefaultPollMs : poll_timeout_ms;
+  bool retried_stall = false;
+  while (!device->cancelled.load()) {
+    int count = 0;
+    const int status =
+        libusb_bulk_transfer(device->handle, device->endpoint_in, data,
+                             static_cast<int>(capacity), &count, poll);
+    if (count > 0) {
+      *transferred = static_cast<size_t>(count);
+      return true;
+    }
+    if (status == LIBUSB_SUCCESS)
+      return true;
+    if (status == LIBUSB_ERROR_TIMEOUT ||
+        (status == LIBUSB_ERROR_INTERRUPTED && !device->cancelled.load())) {
+      retried_stall = false;
+      continue;
+    }
+    if (status == LIBUSB_ERROR_PIPE && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_in) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    SetLibusbError(error, "libusb_bulk_transfer(IN)", status,
+                   device->cancelled.load());
+    return false;
+  }
+  SetLibusbError(error, "libusb_bulk_transfer(IN)", LIBUSB_ERROR_INTERRUPTED,
+                 true);
+  return false;
+}
+
+bool vcan_usb_bulk_write(vcan_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vcan_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || length == 0 || length > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VCAN_USB_STATUS_INVALID_ARGUMENT, "vcan_usb_bulk_write",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk write arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(OUT)"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  vcan_usb_error_clear(error);
+  bool retried_stall = false;
+  while (true) {
+    int count = 0;
+    const int status = libusb_bulk_transfer(
+        device->handle, device->endpoint_out, const_cast<uint8_t *>(data),
+        static_cast<int>(length), &count,
+        timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+    if (status == LIBUSB_ERROR_PIPE && count == 0 && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_out) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_bulk_transfer(OUT)", status,
+                     device->cancelled.load());
+      return false;
+    }
+    *transferred = static_cast<size_t>(count);
+    if (static_cast<size_t>(count) != length) {
+      char detail[96]{};
+      std::snprintf(detail, sizeof(detail), "short bulk write: %d/%zu", count,
+                    length);
+      SetError(error, VCAN_USB_STATUS_SHORT_TRANSFER,
+               "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_IO, detail);
+      return false;
+    }
+    return true;
+  }
+}
+
+void vcan_usb_cancel(vcan_usb_device_t *device) {
+  if (device != nullptr)
+    device->cancelled.store(true);
+}
+
+void vcan_usb_close(vcan_usb_device_t *device) {
+  if (device == nullptr)
+    return;
+  vcan_usb_cancel(device);
+  if (device->owner) {
+    {
+      std::lock_guard<std::mutex> interface_lock(
+          device->owner->interface_mutex);
+      if (device->claimed) {
+        device->owner->active_interfaces.erase(device->interface_number);
+#ifndef _WIN32
+        if (device->owner->claimed_interfaces.erase(device->interface_number) !=
+            0) {
+          libusb_release_interface(device->handle, device->interface_number);
+        }
+        if (device->owner->manually_detached_interfaces.erase(
+                device->interface_number) != 0) {
+          libusb_attach_kernel_driver(device->handle, device->interface_number);
+        }
+#endif
+        device->claimed = false;
+      }
+    }
+    device->handle = nullptr;
+    device->context = nullptr;
+    device->owner.reset();
+  }
+  delete device;
+}
+
+namespace {
+
+constexpr uint32_t kFeatureListenOnly = 1U << 0;
+constexpr uint32_t kFeatureFd = 1U << 8;
+constexpr uint32_t kFeatureBtConstExt = 1U << 10;
+constexpr uint32_t kFeatureTermination = 1U << 11;
+constexpr uint32_t kFeatureBerrReporting = 1U << 12;
+
+constexpr uint32_t kModeListenOnly = 1U << 0;
+constexpr uint32_t kModeFd = 1U << 8;
+constexpr uint32_t kModeBerrReporting = 1U << 12;
+
+constexpr uint8_t kRequestHostFormat = 0;
+constexpr uint8_t kRequestMode = 1;
+constexpr uint8_t kRequestBtConst = 16;
+constexpr uint8_t kRequestBtConstExt = 17;
+constexpr uint8_t kRequestBitTiming = 24;
+constexpr uint8_t kRequestDataBitTiming = 25;
+constexpr uint8_t kRequestDeviceInfo = 33;
+constexpr uint8_t kRequestBusLoad = 36;
+constexpr uint8_t kRequestTermination = 37;
+
+constexpr uint32_t kEchoTx = 0xa1c95e3dU;
+constexpr uint32_t kEchoRx = 0xa2c95e3dU;
+constexpr uint32_t kEchoState = 0xa4c95e3dU;
+constexpr uint32_t kEchoControl = 0xa5c95e3dU;
+constexpr uint16_t kHeaderSize = 8;
+constexpr uint16_t kFrameDataOffset = 24;
+constexpr uint16_t kOpcodeSizeMask = 0x0fff;
+constexpr uint16_t kOpcodeChannelShift = 12;
+constexpr uint16_t kStateRequest = 3;
+constexpr uint16_t kBerrRequest = 2;
+
+constexpr uint16_t kFlagOverflow = 1U << 0;
+constexpr uint16_t kFlagFd = 1U << 1;
+constexpr uint16_t kFlagBrs = 1U << 2;
+constexpr uint16_t kFlagEsi = 1U << 3;
+constexpr uint16_t kFlagEff = 1U << 4;
+constexpr uint16_t kFlagRtr = 1U << 5;
+constexpr uint16_t kFlagError = 1U << 6;
+
+constexpr uint32_t kCanSffMask = 0x7ffU;
+constexpr uint32_t kCanIdMask = 0x1fffffffU;
+constexpr uint8_t kDlcLengths[16] = {0, 1,  2,  3,  4,  5,  6,  7,
+                                     8, 12, 16, 20, 24, 32, 48, 64};
+
+uint16_t ReadLe16(const uint8_t *data) {
+  return static_cast<uint16_t>(data[0]) |
+         (static_cast<uint16_t>(data[1]) << 8U);
+}
+
+uint32_t ReadLe32(const uint8_t *data) {
+  return static_cast<uint32_t>(data[0]) |
+         (static_cast<uint32_t>(data[1]) << 8U) |
+         (static_cast<uint32_t>(data[2]) << 16U) |
+         (static_cast<uint32_t>(data[3]) << 24U);
+}
+
+uint64_t ReadLe64(const uint8_t *data) {
+  return static_cast<uint64_t>(ReadLe32(data)) |
+         (static_cast<uint64_t>(ReadLe32(data + 4)) << 32U);
+}
+
+void WriteLe16(uint8_t *data, uint16_t value) {
+  data[0] = static_cast<uint8_t>(value);
+  data[1] = static_cast<uint8_t>(value >> 8U);
+}
+
+void WriteLe32(uint8_t *data, uint32_t value) {
+  data[0] = static_cast<uint8_t>(value);
+  data[1] = static_cast<uint8_t>(value >> 8U);
+  data[2] = static_cast<uint8_t>(value >> 16U);
+  data[3] = static_cast<uint8_t>(value >> 24U);
+}
+
+uint16_t Opcode(uint8_t channel, uint16_t size) {
+  return static_cast<uint16_t>(
+      (static_cast<uint16_t>(channel & 0x0fU) << kOpcodeChannelShift) |
+      (size & kOpcodeSizeMask));
+}
+
+bool ProtocolError(vcan_usb_error_t *error, const char *operation,
+                   const std::string &message,
+                   vcan_usb_status_t status = VCAN_USB_STATUS_PROTOCOL_ERROR) {
+  SetError(error, status, operation, 0, message);
+  return false;
+}
+
+bool ControlGet(vcan_usb_device_t *device, uint8_t request,
+                size_t payload_length, std::vector<uint8_t> *payload,
+                vcan_usb_error_t *error) {
+  if (payload == nullptr || payload_length + kHeaderSize > UINT16_MAX)
+    return ProtocolError(error, "VCAN protocol control read",
+                         "invalid response length",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  std::vector<uint8_t> response(payload_length + kHeaderSize);
+  if (!vcan_usb_control_in(device, 0xc1, static_cast<uint8_t>(request | 0x80U),
+                           0, device->interface_number, response.data(),
+                           static_cast<uint16_t>(response.size()),
+                           kDefaultTimeoutMs, error)) {
+    return false;
+  }
+  const uint16_t opcode = ReadLe16(response.data() + 4);
+  if (ReadLe32(response.data()) != kEchoControl ||
+      (opcode & kOpcodeSizeMask) != response.size() ||
+      ((opcode >> kOpcodeChannelShift) & 0x0fU) != device->interface_number ||
+      (ReadLe16(response.data() + 6) & 0x7fU) != request) {
+    return ProtocolError(error, "VCAN protocol control read",
+                         "invalid control response header");
+  }
+  payload->assign(response.begin() + kHeaderSize, response.end());
+  return true;
+}
+
+bool ControlSet(vcan_usb_device_t *device, uint8_t request,
+                const uint8_t *payload, size_t payload_length,
+                vcan_usb_error_t *error) {
+  if ((payload_length > 0 && payload == nullptr) ||
+      payload_length + kHeaderSize > kOpcodeSizeMask) {
+    return ProtocolError(error, "VCAN protocol control write",
+                         "invalid control payload",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  }
+  std::vector<uint8_t> request_data(kHeaderSize + payload_length, 0);
+  WriteLe32(request_data.data(), kEchoControl);
+  WriteLe16(request_data.data() + 4,
+            Opcode(device->interface_number,
+                   static_cast<uint16_t>(request_data.size())));
+  WriteLe16(request_data.data() + 6, request);
+  if (payload_length > 0)
+    std::memcpy(request_data.data() + kHeaderSize, payload, payload_length);
+  return vcan_usb_control_out(
+      device, 0x41, request, 0, device->interface_number, request_data.data(),
+      static_cast<uint16_t>(request_data.size()), kDefaultTimeoutMs, error);
+}
+
+bool LimitsValid(const vcan_usb_timing_limits_t &limits) {
+  return limits.clock_hz > 0 && limits.tseg1_min > 0 &&
+         limits.tseg1_min <= limits.tseg1_max && limits.tseg2_min > 0 &&
+         limits.tseg2_min <= limits.tseg2_max && limits.sjw_max > 0 &&
+         limits.brp_min > 0 && limits.brp_min <= limits.brp_max &&
+         limits.brp_inc > 0;
+}
+
+void ConstrainToHardware(vcan_usb_timing_limits_t *limits, bool data_phase) {
+  if (limits == nullptr)
+    return;
+  if (data_phase) {
+    limits->tseg1_min = std::max(limits->tseg1_min, kDataTseg1Min);
+    limits->tseg1_max = std::min(limits->tseg1_max, kDataTseg1Max);
+    limits->tseg2_min = std::max(limits->tseg2_min, kDataTseg2Min);
+    limits->tseg2_max = std::min(limits->tseg2_max, kDataTseg2Max);
+    limits->sjw_max = std::min(limits->sjw_max, kDataSjwMax);
+    limits->brp_max = std::min(limits->brp_max, kDataBrpMax);
+  } else {
+    limits->tseg1_min = std::max(limits->tseg1_min, kNominalTseg1Min);
+    limits->tseg1_max = std::min(limits->tseg1_max, kNominalTseg1Max);
+    limits->tseg2_min = std::max(limits->tseg2_min, kNominalTseg2Min);
+    limits->tseg2_max = std::min(limits->tseg2_max, kNominalTseg2Max);
+    limits->sjw_max = std::min(limits->sjw_max, kNominalSjwMax);
+    limits->brp_max = std::min(limits->brp_max, kNominalBrpMax);
+  }
+}
+
+bool DecodeLimits(const std::vector<uint8_t> &payload, size_t offset,
+                  uint32_t feature, uint32_t clock_hz,
+                  vcan_usb_timing_limits_t *limits, vcan_usb_error_t *error) {
+  if (limits == nullptr || offset + 32 > payload.size())
+    return ProtocolError(error, "VCAN capabilities",
+                         "capability response is too short");
+  std::memset(limits, 0, sizeof(*limits));
+  limits->feature = feature;
+  limits->clock_hz = clock_hz != 0 ? clock_hz : 80000000U;
+  limits->tseg1_min = ReadLe32(payload.data() + offset);
+  limits->tseg1_max = ReadLe32(payload.data() + offset + 4);
+  limits->tseg2_min = ReadLe32(payload.data() + offset + 8);
+  limits->tseg2_max = ReadLe32(payload.data() + offset + 12);
+  limits->sjw_max = ReadLe32(payload.data() + offset + 16);
+  limits->brp_min = ReadLe32(payload.data() + offset + 20);
+  limits->brp_max = ReadLe32(payload.data() + offset + 24);
+  limits->brp_inc = ReadLe32(payload.data() + offset + 28);
+  if (!LimitsValid(*limits))
+    return ProtocolError(error, "VCAN capabilities",
+                         "capability response contains invalid timing limits");
+  return true;
+}
+
+void FillFallback(vcan_usb_capabilities_t *capabilities) {
+  if (capabilities == nullptr)
+    return;
+  std::memset(capabilities, 0, sizeof(*capabilities));
+  auto &limits = capabilities->nominal;
+  limits.feature = kFeatureListenOnly | kFeatureFd | kFeatureBtConstExt;
+  limits.clock_hz = 80000000U;
+  limits.tseg1_min = kNominalTseg1Min;
+  limits.tseg1_max = kNominalTseg1Max;
+  limits.tseg2_min = kNominalTseg2Min;
+  limits.tseg2_max = kNominalTseg2Max;
+  limits.sjw_max = kNominalSjwMax;
+  limits.brp_min = 1;
+  limits.brp_max = kNominalBrpMax;
+  limits.brp_inc = 1;
+  capabilities->data = limits;
+  capabilities->data.tseg1_min = kDataTseg1Min;
+  capabilities->data.tseg1_max = kDataTseg1Max;
+  capabilities->data.tseg2_min = kDataTseg2Min;
+  capabilities->data.tseg2_max = kDataTseg2Max;
+  capabilities->data.sjw_max = kDataSjwMax;
+  capabilities->data.brp_max = kDataBrpMax;
+  capabilities->has_data_timing = true;
+  capabilities->fd_supported = true;
+  capabilities->listen_only_supported = true;
+}
+
+bool GetCapabilitiesUnlocked(vcan_usb_device_t *device,
+                             vcan_usb_capabilities_t *capabilities,
+                             vcan_usb_error_t *error) {
+  if (device->capabilities_cached) {
+    *capabilities = device->capabilities;
+    return true;
+  }
+  std::vector<uint8_t> base;
+  if (!ControlGet(device, kRequestBtConst, 40, &base, error))
+    return false;
+  const uint32_t feature = ReadLe32(base.data());
+  const uint32_t clock_hz = ReadLe32(base.data() + 4);
+  vcan_usb_capabilities_t result{};
+  if (!DecodeLimits(base, 8, feature, clock_hz, &result.nominal, error))
+    return false;
+  ConstrainToHardware(&result.nominal, false);
+  if (!LimitsValid(result.nominal))
+    return ProtocolError(error, "VCAN capabilities",
+                         "nominal limits do not match HPM MCAN");
+  result.fd_supported = (feature & kFeatureFd) != 0;
+  result.listen_only_supported = (feature & kFeatureListenOnly) != 0;
+  result.termination_supported = (feature & kFeatureTermination) != 0;
+  if ((feature & kFeatureFd) != 0 && (feature & kFeatureBtConstExt) != 0) {
+    std::vector<uint8_t> extended;
+    if (!ControlGet(device, kRequestBtConstExt, 72, &extended, error) ||
+        !DecodeLimits(extended, 40, ReadLe32(extended.data()),
+                      ReadLe32(extended.data() + 4), &result.data, error)) {
+      return false;
+    }
+    ConstrainToHardware(&result.data, true);
+    if (!LimitsValid(result.data))
+      return ProtocolError(error, "VCAN capabilities",
+                           "data limits do not match HPM MCAN");
+    result.has_data_timing = true;
+  }
+  device->capabilities = result;
+  device->capabilities_cached = true;
+  *capabilities = result;
+  return true;
+}
+
+bool ValidateTiming(const vcan_usb_timing_t &timing,
+                    const vcan_usb_timing_limits_t &limits,
+                    vcan_usb_applied_timing_t *applied, vcan_usb_error_t *error,
+                    const char *phase) {
+  if (timing.clock_hz == 0 || timing.bitrate_hz == 0 || timing.prescaler == 0 ||
+      timing.tseg1 == 0 || timing.tseg2 == 0 || timing.sjw == 0) {
+    return ProtocolError(error, phase, "timing values must be positive",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  }
+  if (timing.clock_hz != limits.clock_hz)
+    return ProtocolError(error, phase, "configured clock does not match device",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  if (timing.tseg1 < limits.tseg1_min || timing.tseg1 > limits.tseg1_max ||
+      timing.tseg2 < limits.tseg2_min || timing.tseg2 > limits.tseg2_max ||
+      timing.sjw > limits.sjw_max || timing.sjw > timing.tseg2 ||
+      timing.prescaler < limits.brp_min || timing.prescaler > limits.brp_max ||
+      ((timing.prescaler - limits.brp_min) % limits.brp_inc) != 0) {
+    return ProtocolError(error, phase,
+                         "timing values are outside device limits",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  }
+  const uint64_t total_quanta = 1ULL + timing.tseg1 + timing.tseg2;
+  const uint64_t divisor =
+      static_cast<uint64_t>(timing.prescaler) * total_quanta;
+  const uint32_t actual = static_cast<uint32_t>(timing.clock_hz / divisor);
+  const uint64_t difference = actual > timing.bitrate_hz
+                                  ? actual - timing.bitrate_hz
+                                  : timing.bitrate_hz - actual;
+  if (actual == 0 || difference * 100ULL > timing.bitrate_hz) {
+    return ProtocolError(error, phase,
+                         "timing calculates a bitrate outside 1% tolerance",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  }
+  std::memset(applied, 0, sizeof(*applied));
+  applied->requested_bitrate_hz = timing.bitrate_hz;
+  applied->actual_bitrate_hz = actual;
+  applied->sample_point_permille =
+      static_cast<uint32_t>(((1ULL + timing.tseg1) * 1000ULL) / total_quanta);
+  applied->prescaler = timing.prescaler;
+  applied->tseg1 = timing.tseg1;
+  applied->tseg2 = timing.tseg2;
+  applied->sjw = timing.sjw;
+  applied->wire_prescaler = EncodeTimingRegister(timing.prescaler);
+  applied->wire_tseg1 = EncodeTimingRegister(timing.tseg1);
+  applied->wire_tseg2 = EncodeTimingRegister(timing.tseg2);
+  applied->wire_sjw = EncodeTimingRegister(timing.sjw);
+  return true;
+}
+
+bool SetTiming(vcan_usb_device_t *device, uint8_t request,
+               const vcan_usb_applied_timing_t &timing,
+               vcan_usb_error_t *error) {
+  uint8_t payload[20]{};
+  /* prop_seg stays zero; the firmware uses phase_seg1 as the complete TSEG1. */
+  WriteLe32(payload + 4, timing.wire_tseg1);
+  WriteLe32(payload + 8, timing.wire_tseg2);
+  WriteLe32(payload + 12, timing.wire_sjw);
+  WriteLe32(payload + 16, timing.wire_prescaler);
+  return ControlSet(device, request, payload, sizeof(payload), error);
+}
+
+bool SetMode(vcan_usb_device_t *device, uint32_t mode, uint32_t flags,
+             vcan_usb_error_t *error) {
+  uint8_t payload[8]{};
+  WriteLe32(payload, mode);
+  WriteLe32(payload + 4, flags);
+  return ControlSet(device, kRequestMode, payload, sizeof(payload), error);
+}
+
+bool SetHostFormat(vcan_usb_device_t *device, vcan_usb_error_t *error) {
+  uint8_t payload[4]{};
+  WriteLe32(payload, 0x0000beefU);
+  return ControlSet(device, kRequestHostFormat, payload, sizeof(payload),
+                    error);
+}
+
+bool SetBusLoad(vcan_usb_device_t *device, bool enabled,
+                vcan_usb_error_t *error) {
+  uint8_t payload[4]{};
+  WriteLe32(payload, enabled ? 1U : 0U);
+  return ControlSet(device, kRequestBusLoad, payload, sizeof(payload), error);
+}
+
+bool SetTermination(vcan_usb_device_t *device, bool enabled,
+                    vcan_usb_error_t *error) {
+  uint8_t payload[4]{};
+  WriteLe32(payload, enabled ? 1U : 0U);
+  return ControlSet(device, kRequestTermination, payload, sizeof(payload),
+                    error);
+}
+
+uint8_t LengthToDlc(uint8_t length, bool fd) {
+  if (!fd)
+    return length;
+  for (uint8_t dlc = 0; dlc < 16; ++dlc) {
+    if (kDlcLengths[dlc] >= length)
+      return dlc;
+  }
+  return 0xff;
+}
+
+uint8_t DlcToLength(uint8_t dlc, bool fd) {
+  const uint8_t value = static_cast<uint8_t>(dlc & 0x0fU);
+  return fd ? kDlcLengths[value] : std::min<uint8_t>(value, 8);
+}
+
+bool AppendRecord(vcan_usb_rx_batch_t *batch, vcan_usb_rx_record_t **record,
+                  vcan_usb_error_t *error) {
+  if (batch->count >= VCAN_USB_MAX_RX_RECORDS)
+    return ProtocolError(error, "VCAN decode", "receive batch is too large");
+  *record = &batch->records[batch->count++];
+  std::memset(*record, 0, sizeof(**record));
+  return true;
+}
+
+} // namespace
+
+void vcan_usb_fallback_capabilities(vcan_usb_capabilities_t *capabilities) {
+  FillFallback(capabilities);
+}
+
+bool vcan_usb_get_capabilities(vcan_usb_device_t *device,
+                               vcan_usb_capabilities_t *capabilities,
+                               vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_get_capabilities") ||
+      capabilities == nullptr) {
+    if (capabilities == nullptr)
+      ProtocolError(error, "vcan_usb_get_capabilities",
+                    "capabilities output is null",
+                    VCAN_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  vcan_usb_error_clear(error);
+  return GetCapabilitiesUnlocked(device, capabilities, error);
+}
+
+bool vcan_usb_get_device_info(vcan_usb_device_t *device,
+                              vcan_usb_device_info_t *info,
+                              vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_get_device_info") ||
+      info == nullptr) {
+    if (info == nullptr)
+      ProtocolError(error, "vcan_usb_get_device_info", "info output is null",
+                    VCAN_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  std::vector<uint8_t> payload;
+  if (!ControlGet(device, kRequestDeviceInfo, 40, &payload, error))
+    return false;
+  std::memset(info, 0, sizeof(*info));
+  info->software_version = ReadLe32(payload.data());
+  info->hardware_version = ReadLe32(payload.data() + 4);
+  for (size_t index = 0; index < 4; ++index) {
+    info->uid[index] = ReadLe32(payload.data() + 8 + index * 4);
+    info->uuid[index] = ReadLe32(payload.data() + 24 + index * 4);
+  }
+  return true;
+}
+
+bool vcan_usb_get_termination(vcan_usb_device_t *device, bool *enabled,
+                              vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_get_termination") ||
+      enabled == nullptr) {
+    if (enabled == nullptr)
+      ProtocolError(error, "vcan_usb_get_termination", "state output is null",
+                    VCAN_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  std::vector<uint8_t> payload;
+  if (!ControlGet(device, kRequestTermination, 4, &payload, error))
+    return false;
+  *enabled = ReadLe32(payload.data()) != 0;
+  return true;
+}
+
+bool vcan_usb_configure(vcan_usb_device_t *device,
+                        const vcan_usb_config_t *config,
+                        vcan_usb_applied_config_t *applied,
+                        vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_configure") || config == nullptr ||
+      applied == nullptr) {
+    if (config == nullptr || applied == nullptr)
+      ProtocolError(error, "vcan_usb_configure", "configuration is null",
+                    VCAN_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  vcan_usb_error_clear(error);
+  vcan_usb_capabilities_t capabilities{};
+  if (!GetCapabilitiesUnlocked(device, &capabilities, error))
+    return false;
+  if (config->fd && !capabilities.fd_supported)
+    return ProtocolError(error, "vcan_usb_configure", "CAN FD is not supported",
+                         VCAN_USB_STATUS_UNSUPPORTED);
+  if (config->listen_only && !capabilities.listen_only_supported)
+    return ProtocolError(error, "vcan_usb_configure",
+                         "listen-only mode is not supported",
+                         VCAN_USB_STATUS_UNSUPPORTED);
+
+  vcan_usb_applied_config_t result{};
+  if (!ValidateTiming(config->nominal, capabilities.nominal, &result.nominal,
+                      error, "VCAN nominal timing"))
+    return false;
+  if (config->fd) {
+    const auto &limits =
+        capabilities.has_data_timing ? capabilities.data : capabilities.nominal;
+    if (!ValidateTiming(config->data, limits, &result.data, error,
+                        "VCAN data timing"))
+      return false;
+    result.has_data_timing = true;
+  }
+
+  device->fd_mode.store(false);
+  if (!SetMode(device, 0, 0, error))
+    return false;
+  std::this_thread::sleep_for(std::chrono::milliseconds(kModeSettleMs));
+  if (!SetHostFormat(device, error) ||
+      !SetTiming(device, kRequestBitTiming, result.nominal, error) ||
+      (config->fd &&
+       !SetTiming(device, kRequestDataBitTiming, result.data, error)) ||
+      !SetBusLoad(device, false, error)) {
+    return false;
+  }
+  vcan_usb_error_t termination_error{};
+  if (!SetTermination(device, config->termination, &termination_error) &&
+      (config->termination || capabilities.termination_supported)) {
+    if (error != nullptr)
+      *error = termination_error;
+    return false;
+  }
+
+  uint32_t flags = config->listen_only ? kModeListenOnly : 0;
+  if (config->fd)
+    flags |= kModeFd;
+  if ((capabilities.nominal.feature & kFeatureBerrReporting) != 0)
+    flags |= kModeBerrReporting;
+  vcan_usb_decoder_reset(device);
+  if (!SetMode(device, 1, flags, error))
+    return false;
+  device->fd_mode.store(config->fd);
+  result.hardware_timestamps = false;
+  *applied = result;
+  return true;
+}
+
+bool vcan_usb_stop(vcan_usb_device_t *device, vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_stop"))
+    return false;
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  bool result = SetMode(device, 0, 0, error);
+  if (result)
+    result = SetHostFormat(device, error);
+  device->fd_mode.store(false);
+  return result;
+}
+
+bool vcan_usb_encode_frame(vcan_usb_device_t *device,
+                           const vcan_usb_frame_t *frame, uint8_t *wire,
+                           size_t capacity, size_t *wire_length,
+                           uint8_t *normalized_length,
+                           vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_encode_frame") ||
+      frame == nullptr || wire == nullptr || wire_length == nullptr ||
+      normalized_length == nullptr) {
+    if (frame == nullptr || wire == nullptr || wire_length == nullptr ||
+        normalized_length == nullptr)
+      ProtocolError(error, "vcan_usb_encode_frame", "invalid frame output",
+                    VCAN_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  const uint32_t maximum_id = frame->extended ? kCanIdMask : kCanSffMask;
+  if (frame->id > maximum_id || frame->length > (frame->fd ? 64 : 8) ||
+      (frame->fd && frame->remote) || (frame->fd && !device->fd_mode.load())) {
+    return ProtocolError(error, "vcan_usb_encode_frame",
+                         "invalid CAN frame for the configured mode",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  }
+  const uint8_t dlc = LengthToDlc(frame->length, frame->fd);
+  if (dlc == 0xff)
+    return ProtocolError(error, "vcan_usb_encode_frame",
+                         "CAN payload exceeds protocol limits",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  const uint8_t data_length = DlcToLength(dlc, frame->fd);
+  const size_t size = kFrameDataOffset + (frame->fd ? 64U : 8U);
+  if (capacity < size)
+    return ProtocolError(error, "vcan_usb_encode_frame",
+                         "wire buffer is too small",
+                         VCAN_USB_STATUS_INVALID_ARGUMENT);
+  std::memset(wire, 0, size);
+  uint16_t flags = frame->fd ? kFlagFd : 0;
+  if (frame->fd && frame->brs)
+    flags |= kFlagBrs;
+  if (frame->extended)
+    flags |= kFlagEff;
+  if (frame->remote)
+    flags |= kFlagRtr;
+  WriteLe32(wire, kEchoTx);
+  WriteLe16(wire + 4,
+            Opcode(device->interface_number, static_cast<uint16_t>(size)));
+  WriteLe16(wire + 6, flags);
+  WriteLe32(wire + 8, frame->id & kCanIdMask);
+  wire[12] = dlc;
+  if (frame->length > 0)
+    std::memcpy(wire + kFrameDataOffset, frame->data, frame->length);
+  *wire_length = size;
+  *normalized_length = data_length;
+  return true;
+}
+
+bool vcan_usb_decode(vcan_usb_device_t *device, const uint8_t *wire,
+                     size_t wire_length, vcan_usb_rx_batch_t *batch,
+                     vcan_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vcan_usb_decode") ||
+      (wire_length > 0 && wire == nullptr) || batch == nullptr) {
+    if ((wire_length > 0 && wire == nullptr) || batch == nullptr)
+      ProtocolError(error, "vcan_usb_decode", "invalid decoder input",
+                    VCAN_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->decoder_mutex);
+  std::memset(batch, 0, sizeof(*batch));
+  std::vector<uint8_t> buffer;
+  buffer.reserve(device->decoder_tail.size() + wire_length);
+  buffer.insert(buffer.end(), device->decoder_tail.begin(),
+                device->decoder_tail.end());
+  if (wire_length > 0)
+    buffer.insert(buffer.end(), wire, wire + wire_length);
+  device->decoder_tail.clear();
+  size_t offset = 0;
+  while (offset + kHeaderSize <= buffer.size()) {
+    const uint8_t *item = buffer.data() + offset;
+    const uint32_t echo = ReadLe32(item);
+    if (echo == 0) {
+      offset = buffer.size();
+      break;
+    }
+    const uint16_t opcode = ReadLe16(item + 4);
+    const uint16_t flags = ReadLe16(item + 6);
+    const size_t size = opcode & kOpcodeSizeMask;
+    if (size < kHeaderSize || size > 512) {
+      device->decoder_tail.clear();
+      return ProtocolError(error, "VCAN decode", "invalid bulk frame size");
+    }
+    const uint8_t channel =
+        static_cast<uint8_t>((opcode >> kOpcodeChannelShift) & 0x0fU);
+    if (channel != device->interface_number) {
+      device->decoder_tail.clear();
+      return ProtocolError(error, "VCAN decode",
+                           "bulk frame channel does not match interface");
+    }
+    if (offset + size > buffer.size()) {
+      device->decoder_tail.assign(buffer.begin() + offset, buffer.end());
+      break;
+    }
+    vcan_usb_rx_record_t *record = nullptr;
+    if (echo == kEchoRx && size >= kFrameDataOffset) {
+      const bool fd = (flags & kFlagFd) != 0;
+      const bool extended = (flags & kFlagEff) != 0;
+      const uint8_t length = DlcToLength(item[12], fd);
+      if (kFrameDataOffset + length > size)
+        return ProtocolError(error, "VCAN decode",
+                             "frame payload exceeds declared size");
+      if (!AppendRecord(batch, &record, error))
+        return false;
+      record->kind = VCAN_USB_RX_FRAME;
+      record->frame.id =
+          ReadLe32(item + 8) & (extended ? kCanIdMask : kCanSffMask);
+      record->frame.length = length;
+      if (length > 0)
+        std::memcpy(record->frame.data, item + kFrameDataOffset, length);
+      record->frame.fd = fd;
+      record->frame.brs = fd && (flags & kFlagBrs) != 0;
+      record->frame.extended = extended;
+      record->frame.remote = !fd && (flags & kFlagRtr) != 0;
+      record->frame.timestamp_us = ReadLe64(item + 16);
+      record->frame.overflow = (flags & kFlagOverflow) != 0;
+      record->frame.esi = fd && (flags & kFlagEsi) != 0;
+      record->frame.error = (flags & kFlagError) != 0;
+    } else if (echo == kEchoState && flags == kStateRequest && size >= 28) {
+      if (!AppendRecord(batch, &record, error))
+        return false;
+      record->kind = VCAN_USB_RX_STATE;
+      record->timestamp_us = ReadLe64(item + 8);
+      record->state = ReadLe32(item + 16);
+      record->rx_error_count = ReadLe32(item + 20);
+      record->tx_error_count = ReadLe32(item + 24);
+    } else if (echo == kEchoState && flags == kBerrRequest && size >= 16) {
+      if (!AppendRecord(batch, &record, error))
+        return false;
+      record->kind = VCAN_USB_RX_BUS_ERROR;
+      record->error_flag = item[8];
+      record->error_code = item[9];
+      record->rx_error_count = item[10];
+      record->tx_error_count = item[11];
+      record->error_logging_count = item[12];
+    }
+    offset += size;
+  }
+  if (device->decoder_tail.empty() && offset < buffer.size()) {
+    const auto begin = buffer.begin() + offset;
+    const bool non_zero = std::any_of(begin, buffer.end(),
+                                      [](uint8_t value) { return value != 0; });
+    if (non_zero)
+      device->decoder_tail.assign(begin, buffer.end());
+  }
+  return true;
+}
+
+void vcan_usb_decoder_reset(vcan_usb_device_t *device) {
+  if (device == nullptr)
+    return;
+  std::lock_guard<std::mutex> lock(device->decoder_mutex);
+  device->decoder_tail.clear();
+}

--- a/src/main/docan/vcan_usb/api/vcan_usb.h
+++ b/src/main/docan/vcan_usb/api/vcan_usb.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VCAN_USB_MAX_DEVICES 64
+#define VCAN_USB_PATH_CAPACITY 1024
+#define VCAN_USB_LABEL_CAPACITY 256
+#define VCAN_USB_OPERATION_CAPACITY 64
+#define VCAN_USB_MESSAGE_CAPACITY 512
+
+typedef enum {
+  VCAN_USB_STATUS_OK = 0,
+  VCAN_USB_STATUS_INVALID_ARGUMENT,
+  VCAN_USB_STATUS_SYSTEM_ERROR,
+  VCAN_USB_STATUS_NOT_OPEN,
+  VCAN_USB_STATUS_ENDPOINT_NOT_FOUND,
+  VCAN_USB_STATUS_SHORT_TRANSFER,
+  VCAN_USB_STATUS_TIMEOUT,
+  VCAN_USB_STATUS_CANCELLED,
+  VCAN_USB_STATUS_PROTOCOL_ERROR,
+  VCAN_USB_STATUS_UNSUPPORTED
+} vcan_usb_status_t;
+
+typedef struct {
+  vcan_usb_status_t status;
+  int32_t native_code;
+  char operation[VCAN_USB_OPERATION_CAPACITY];
+  char message[VCAN_USB_MESSAGE_CAPACITY];
+} vcan_usb_error_t;
+
+typedef struct {
+  char path[VCAN_USB_PATH_CAPACITY];
+  char label[VCAN_USB_LABEL_CAPACITY];
+  uint8_t interface_number;
+  uint8_t endpoint_in;
+  uint8_t endpoint_out;
+  bool busy;
+} vcan_usb_interface_t;
+
+typedef struct {
+  size_t count;
+  vcan_usb_interface_t devices[VCAN_USB_MAX_DEVICES];
+} vcan_usb_device_list_t;
+
+typedef struct vcan_usb_device vcan_usb_device_t;
+
+typedef struct {
+  uint32_t feature;
+  uint32_t clock_hz;
+  uint32_t tseg1_min;
+  uint32_t tseg1_max;
+  uint32_t tseg2_min;
+  uint32_t tseg2_max;
+  uint32_t sjw_max;
+  uint32_t brp_min;
+  uint32_t brp_max;
+  uint32_t brp_inc;
+} vcan_usb_timing_limits_t;
+
+typedef struct {
+  vcan_usb_timing_limits_t nominal;
+  vcan_usb_timing_limits_t data;
+  bool has_data_timing;
+  bool fd_supported;
+  bool listen_only_supported;
+  bool termination_supported;
+} vcan_usb_capabilities_t;
+
+typedef struct {
+  uint32_t software_version;
+  uint32_t hardware_version;
+  uint32_t uid[4];
+  uint32_t uuid[4];
+} vcan_usb_device_info_t;
+
+/* All timing fields use human/EcuBus semantics. Unlike Candle/standard
+ * gs_usb, this hardware protocol ignores prop_seg and expects BRP, TSEG1,
+ * TSEG2 and SJW as zero-based register values. This API performs that single
+ * conversion; callers must never pre-decrement the values. */
+typedef struct {
+  uint32_t clock_hz;
+  uint32_t bitrate_hz;
+  uint32_t prescaler;
+  uint32_t tseg1;
+  uint32_t tseg2;
+  uint32_t sjw;
+} vcan_usb_timing_t;
+
+typedef struct {
+  uint32_t requested_bitrate_hz;
+  /* Calculated from the validated semantic values. The current firmware
+   * protocol does not provide an applied-timing register readback. */
+  uint32_t actual_bitrate_hz;
+  uint32_t sample_point_permille;
+  uint32_t prescaler;
+  uint32_t tseg1;
+  uint32_t tseg2;
+  uint32_t sjw;
+  uint32_t wire_prescaler;
+  uint32_t wire_tseg1;
+  uint32_t wire_tseg2;
+  uint32_t wire_sjw;
+} vcan_usb_applied_timing_t;
+
+typedef struct {
+  vcan_usb_timing_t nominal;
+  vcan_usb_timing_t data;
+  bool fd;
+  bool listen_only;
+  bool termination;
+} vcan_usb_config_t;
+
+typedef struct {
+  vcan_usb_applied_timing_t nominal;
+  vcan_usb_applied_timing_t data;
+  bool has_data_timing;
+  bool hardware_timestamps;
+} vcan_usb_applied_config_t;
+
+#define VCAN_USB_MAX_FRAME_DATA 64
+#define VCAN_USB_MAX_WIRE_FRAME 88
+#define VCAN_USB_MAX_RX_RECORDS 64
+
+typedef struct {
+  uint32_t id;
+  uint8_t data[VCAN_USB_MAX_FRAME_DATA];
+  uint8_t length;
+  bool fd;
+  bool brs;
+  bool extended;
+  bool remote;
+  bool overflow;
+  bool esi;
+  bool error;
+  uint64_t timestamp_us;
+} vcan_usb_frame_t;
+
+typedef enum {
+  VCAN_USB_RX_FRAME = 1,
+  VCAN_USB_RX_STATE,
+  VCAN_USB_RX_BUS_ERROR
+} vcan_usb_rx_kind_t;
+
+typedef struct {
+  vcan_usb_rx_kind_t kind;
+  vcan_usb_frame_t frame;
+  uint32_t state;
+  uint32_t rx_error_count;
+  uint32_t tx_error_count;
+  uint64_t timestamp_us;
+  uint8_t error_flag;
+  uint8_t error_code;
+  uint8_t error_logging_count;
+} vcan_usb_rx_record_t;
+
+typedef struct {
+  size_t count;
+  vcan_usb_rx_record_t records[VCAN_USB_MAX_RX_RECORDS];
+} vcan_usb_rx_batch_t;
+
+void vcan_usb_error_clear(vcan_usb_error_t *error);
+
+bool vcan_usb_list_scan(vcan_usb_device_list_t *list, vcan_usb_error_t *error);
+
+void vcan_usb_fallback_capabilities(vcan_usb_capabilities_t *capabilities);
+
+vcan_usb_device_t *vcan_usb_open(const char *path, vcan_usb_error_t *error);
+
+uint8_t vcan_usb_interface_number(const vcan_usb_device_t *device);
+
+bool vcan_usb_get_capabilities(vcan_usb_device_t *device,
+                               vcan_usb_capabilities_t *capabilities,
+                               vcan_usb_error_t *error);
+
+bool vcan_usb_get_device_info(vcan_usb_device_t *device,
+                              vcan_usb_device_info_t *info,
+                              vcan_usb_error_t *error);
+
+bool vcan_usb_get_termination(vcan_usb_device_t *device, bool *enabled,
+                              vcan_usb_error_t *error);
+
+bool vcan_usb_configure(vcan_usb_device_t *device,
+                        const vcan_usb_config_t *config,
+                        vcan_usb_applied_config_t *applied,
+                        vcan_usb_error_t *error);
+
+bool vcan_usb_stop(vcan_usb_device_t *device, vcan_usb_error_t *error);
+
+bool vcan_usb_encode_frame(vcan_usb_device_t *device,
+                           const vcan_usb_frame_t *frame, uint8_t *wire,
+                           size_t capacity, size_t *wire_length,
+                           uint8_t *normalized_length, vcan_usb_error_t *error);
+
+bool vcan_usb_decode(vcan_usb_device_t *device, const uint8_t *wire,
+                     size_t wire_length, vcan_usb_rx_batch_t *batch,
+                     vcan_usb_error_t *error);
+
+void vcan_usb_decoder_reset(vcan_usb_device_t *device);
+
+bool vcan_usb_control_in(vcan_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vcan_usb_error_t *error);
+
+bool vcan_usb_control_out(vcan_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vcan_usb_error_t *error);
+
+bool vcan_usb_bulk_read(vcan_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vcan_usb_error_t *error);
+
+bool vcan_usb_bulk_write(vcan_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vcan_usb_error_t *error);
+
+void vcan_usb_cancel(vcan_usb_device_t *device);
+
+void vcan_usb_close(vcan_usb_device_t *device);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/main/docan/vcan_usb/binding.gyp
+++ b/src/main/docan/vcan_usb/binding.gyp
@@ -1,0 +1,47 @@
+{
+  'variables': {
+    'use_udev%': 0
+  },
+  'targets': [
+    {
+      'target_name': 'vcan_usb',
+      'include_dirs': [
+        './api',
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      'dependencies': [
+        "<!(node -p \"require('node-addon-api').gyp\")",
+        '../../../../node_modules/usb/libusb.gypi:libusb'
+      ],
+      'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
+      'sources': [
+        './native/addon.cpp',
+        './api/vcan_usb.cpp'
+      ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'cflags': [ '-fexceptions' ],
+      'cflags_cc': [ '-fexceptions' ],
+      'conditions': [
+        ['OS=="win"', {
+          'defines': [ 'WIN32_LEAN_AND_MEAN' ],
+          'libraries': [ 'cfgmgr32.lib' ],
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 }
+          }
+        }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'OTHER_LDFLAGS': [
+              '-framework', 'CoreFoundation',
+              '-framework', 'IOKit',
+              '-framework', 'Security'
+            ]
+          }
+        }]
+      ]
+    }
+  ]
+}

--- a/src/main/docan/vcan_usb/devicePath.ts
+++ b/src/main/docan/vcan_usb/devicePath.ts
@@ -1,0 +1,104 @@
+export interface VcanUsbPathCandidate {
+  path: string
+  interfaceNumber: number
+  identitySelector?: string
+}
+
+const CURRENT_PATH_PREFIX = 'libusb://1d50:6080/'
+const LEGACY_DEVICE_ID = 'vid_1d50&pid_6080'
+const IDENTITY_PATH_PREFIX = 'vcan-usb://'
+
+/**
+ * Resolves handles saved by the former WinUSB backend without coupling the
+ * driver to a platform API. A legacy handle is migrated only when its channel
+ * identifies exactly one currently connected libusb interface.
+ */
+export function resolveVcanUsbPath(
+  path: string,
+  channel: number,
+  listDevices: () => readonly VcanUsbPathCandidate[]
+): string {
+  const normalizedPath = path.toLowerCase()
+  if (normalizedPath.startsWith(CURRENT_PATH_PREFIX)) {
+    let devices: readonly VcanUsbPathCandidate[]
+    try {
+      devices = listDevices()
+    } catch (error) {
+      throw new Error(
+        `Unable to validate the stored VCAN USB path: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+
+    const exactMatches = devices.filter(
+      (device) => device.interfaceNumber === channel && device.path.toLowerCase() === normalizedPath
+    )
+    if (exactMatches.length === 1) return exactMatches[0].path
+    if (exactMatches.length > 1) {
+      throw new Error(`Multiple VCAN USB interfaces report the stored path ${path}.`)
+    }
+
+    // USB topology paths can change after personality switches or reconnects.
+    // Migrate a pre-identity handle only when its channel is unambiguous.
+    const channelMatches = devices.filter((device) => device.interfaceNumber === channel)
+    if (channelMatches.length === 1) return channelMatches[0].path
+    if (channelMatches.length === 0) {
+      throw new Error(
+        `The stored VCAN USB path ${path} is no longer connected, and channel ${channel} is unavailable. Reconnect the device and refresh Hardware.`
+      )
+    }
+    throw new Error(
+      `The stored VCAN USB path ${path} is no longer valid and multiple channel ${channel} interfaces are connected. Reselect the intended device in Hardware.`
+    )
+  }
+  if (normalizedPath.startsWith(IDENTITY_PATH_PREFIX)) {
+    let matches: readonly VcanUsbPathCandidate[]
+    try {
+      matches = listDevices().filter(
+        (device) =>
+          device.interfaceNumber === channel &&
+          device.identitySelector?.toLowerCase() === path.toLowerCase()
+      )
+    } catch (error) {
+      throw new Error(
+        `Unable to resolve the stored VCAN USB hardware identity: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+
+    if (matches.length === 1) return matches[0].path
+    if (matches.length === 0) {
+      throw new Error(
+        `VCAN USB device ${path} channel ${channel} is not connected or its hardware identity is unavailable.`
+      )
+    }
+    throw new Error(
+      `Multiple VCAN USB devices report ${path} channel ${channel}; refusing an ambiguous device selection.`
+    )
+  }
+  if (!normalizedPath.includes(LEGACY_DEVICE_ID)) return path
+
+  let matches: readonly VcanUsbPathCandidate[]
+  try {
+    matches = listDevices().filter((device) => device.interfaceNumber === channel)
+  } catch (error) {
+    throw new Error(
+      `Unable to migrate the stored VCAN USB device path: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+
+  if (matches.length === 1) return matches[0].path
+  if (matches.length === 0) {
+    throw new Error(
+      `The stored VCAN USB device path uses the legacy WinUSB format, but channel ${channel} is not connected. Reconnect the device and reselect it in Hardware.`
+    )
+  }
+
+  throw new Error(
+    `The stored VCAN USB device path matches multiple channel ${channel} interfaces. Reselect the intended device in Hardware.`
+  )
+}

--- a/src/main/docan/vcan_usb/identity.ts
+++ b/src/main/docan/vcan_usb/identity.ts
@@ -1,0 +1,47 @@
+export interface VcanUsbIdentitySource {
+  uid: readonly number[]
+  uuid: readonly number[]
+}
+
+export interface VcanUsbIdentity {
+  kind: 'uuid' | 'uid'
+  value: string
+}
+
+const WORD_COUNT = 4
+const INVALID_WORD = 0xffffffff
+const SELECTOR_PREFIX = 'vcan-usb://'
+
+function formatWords(words: readonly number[]): string | undefined {
+  if (
+    words.length !== WORD_COUNT ||
+    words.some((word) => !Number.isInteger(word) || word < 0 || word > INVALID_WORD) ||
+    words.every((word) => word === 0) ||
+    words.every((word) => word === INVALID_WORD)
+  ) {
+    return undefined
+  }
+  return words.map((word) => word.toString(16).padStart(8, '0')).join('')
+}
+
+/** Returns the immutable OTP identity exposed by the VCAN USB firmware. */
+export function getVcanUsbIdentity(source: VcanUsbIdentitySource): VcanUsbIdentity | undefined {
+  const uuid = formatWords(source.uuid)
+  if (uuid) return { kind: 'uuid', value: uuid }
+
+  const uid = formatWords(source.uid)
+  if (uid) return { kind: 'uid', value: uid }
+  return undefined
+}
+
+export function makeVcanUsbIdentitySelector(identity: VcanUsbIdentity): string {
+  return `${SELECTOR_PREFIX}${identity.kind}/${identity.value}`
+}
+
+export function isVcanUsbIdentitySelector(value: string): boolean {
+  return /^vcan-usb:\/\/(?:uuid|uid)\/[0-9a-f]{32}$/i.test(value)
+}
+
+export function formatVcanUsbSerialNumber(identity: VcanUsbIdentity): string {
+  return `${identity.kind.toUpperCase()}:${identity.value}`
+}

--- a/src/main/docan/vcan_usb/index.ts
+++ b/src/main/docan/vcan_usb/index.ts
@@ -1,0 +1,649 @@
+import { EventEmitter } from 'events'
+import { cloneDeep } from 'lodash'
+import {
+  CAN_ERROR_ID,
+  CAN_ID_TYPE,
+  CanBaseInfo,
+  CanDevice,
+  CanError,
+  CanMessage,
+  CanMsgType,
+  getTsUs
+} from '../../share/can'
+import { CanLOG } from '../../log'
+import { CanBase } from '../base'
+import { resolveVcanUsbPath, VcanUsbPathCandidate } from './devicePath'
+import {
+  formatVcanUsbSerialNumber,
+  getVcanUsbIdentity,
+  isVcanUsbIdentitySelector,
+  makeVcanUsbIdentitySelector,
+  VcanUsbIdentity
+} from './identity'
+import {
+  NativeTransportError,
+  VcanUsbAppliedTiming,
+  VcanUsbCapabilities,
+  VcanUsbDeviceInfo,
+  VcanUsbFrame,
+  VcanUsbNative,
+  VcanUsbRxRecord
+} from './native'
+
+interface PendingTransmit {
+  resolve: (timestamp: number) => void
+  reject: (error: CanError) => void
+  id: number
+  msgType: CanMsgType
+  data: Buffer
+  extra?: { database?: string; name?: string }
+}
+
+interface PendingRead {
+  reject: (error: CanError) => void
+  msgType: CanMsgType
+  eventName: string
+  listener: (message: CanMessage | CanError) => void
+  timer: NodeJS.Timeout
+}
+
+const STATE_NAMES = [
+  'error-active',
+  'error-warning',
+  'error-passive',
+  'bus-off',
+  'stopped',
+  'sleeping'
+]
+
+const ERROR_NAMES = ['none', 'stuff', 'form', 'ack', 'bit1', 'bit0', 'crc', 'no-change']
+const identityByPhysicalPath = new Map<string, VcanUsbIdentity>()
+
+function splitHandle(handle: unknown): { path: string; channel: number } {
+  const value = String(handle)
+  const separator = value.lastIndexOf('|')
+  if (separator <= 0) throw new Error('invalid VCAN USB handle')
+  const channel = Number(value.slice(separator + 1))
+  if (!Number.isInteger(channel) || channel < 0 || channel > 0x0f) {
+    throw new Error(`invalid VCAN USB channel in handle: ${value}`)
+  }
+  return { path: value.slice(0, separator), channel }
+}
+
+function formatVersion(version: number) {
+  return `${(version >>> 24) & 0xff}.${(version >>> 16) & 0xff}.${
+    (version >>> 8) & 0xff
+  }.${version & 0xff}`
+}
+
+function physicalPath(path: string) {
+  const separator = path.lastIndexOf('/')
+  return separator > 0 ? path.slice(0, separator) : path
+}
+
+function rememberIdentity(path: string, deviceInfo: VcanUsbDeviceInfo) {
+  const identity = getVcanUsbIdentity(deviceInfo)
+  if (identity) identityByPhysicalPath.set(physicalPath(path), identity)
+  return identity
+}
+
+function probeIdentity(path: string, channel: number): VcanUsbIdentity | undefined {
+  let native: VcanUsbNative | undefined
+  try {
+    native = VcanUsbNative.open(
+      path,
+      () => {},
+      () => {},
+      () => {}
+    )
+    if (native.interfaceNumber !== channel) return undefined
+    return rememberIdentity(path, native.readDeviceInfo())
+  } catch {
+    return undefined
+  } finally {
+    native?.close()
+  }
+}
+
+function listIdentityCandidates(): VcanUsbPathCandidate[] {
+  const probed = new Set<string>()
+  return VcanUsbNative.listDevices().map((item) => {
+    const key = physicalPath(item.path)
+    let identity = identityByPhysicalPath.get(key)
+    if (!identity && !item.busy && !probed.has(key)) {
+      probed.add(key)
+      identity = probeIdentity(item.path, item.interfaceNumber)
+    }
+    return {
+      path: item.path,
+      interfaceNumber: item.interfaceNumber,
+      identitySelector: identity ? makeVcanUsbIdentitySelector(identity) : undefined
+    }
+  })
+}
+
+function formatTiming(name: string, timing: VcanUsbAppliedTiming) {
+  const samplePoint = (timing.samplePointPermille / 10).toFixed(1)
+  return `${name} requested ${timing.requestedBitrate}, calculated ${timing.actualBitrate} bit/s (BRP ${timing.prescaler}, TSEG1 ${timing.tseg1}, TSEG2 ${timing.tseg2}, SJW ${timing.sjw}, sample ${samplePoint}%; USB zero-based fields ${timing.wirePrescaler}/${timing.wireTseg1}/${timing.wireTseg2}/${timing.wireSjw})`
+}
+
+function makeExtra(capabilities: VcanUsbCapabilities, termination?: boolean) {
+  return {
+    candle: {
+      cap: capabilities.nominal,
+      dataCap: capabilities.data,
+      fdSupported: capabilities.fdSupported,
+      Res: capabilities.terminationSupported || termination !== undefined,
+      // The HPMicro MCAN/board combination is stable at 1M/2M BRS with 20 TQ.
+      // This is only an auto-selection preference; explicitly saved timing is preserved.
+      preferredDataTimeQuanta: 20
+    }
+  }
+}
+
+function getVcanUsbDevices(): CanDevice[] {
+  const interfaces = VcanUsbNative.listDevices()
+  const probedIdentities = new Set<string>()
+  for (const item of interfaces) {
+    const key = physicalPath(item.path)
+    if (item.busy || probedIdentities.has(key)) continue
+    probedIdentities.add(key)
+    if (!probeIdentity(item.path, item.interfaceNumber)) {
+      identityByPhysicalPath.delete(key)
+      sysLog.warn(
+        `vcan_usb hardware identity is unavailable on channel ${item.interfaceNumber}; falling back to the transient USB path`
+      )
+    }
+  }
+
+  return interfaces.map((item, index) => {
+    let capabilities = VcanUsbNative.fallbackCapabilities()
+    const physicalDevicePath = physicalPath(item.path)
+    let identity = identityByPhysicalPath.get(physicalDevicePath)
+    let termination: boolean | undefined
+    let busy = item.busy
+
+    if (!busy) {
+      let native: VcanUsbNative | undefined
+      try {
+        native = VcanUsbNative.open(
+          item.path,
+          () => {},
+          () => {},
+          () => {}
+        )
+        capabilities = native.readCapabilities()
+        identity = identityByPhysicalPath.get(physicalDevicePath)
+        try {
+          termination = native.getTermination()
+        } catch (error) {
+          sysLog.warn(
+            `vcan_usb termination query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      } catch (error) {
+        busy = true
+        sysLog.warn(
+          `vcan_usb probe failed for channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      } finally {
+        native?.close()
+      }
+    }
+
+    const identitySelector = identity ? makeVcanUsbIdentitySelector(identity) : undefined
+
+    return {
+      label: `${item.label} CH${item.interfaceNumber}`,
+      id: identity
+        ? `vcan_usb-${identity.kind}-${identity.value}-ch${item.interfaceNumber}`
+        : `vcan_usb-${index}-ch${item.interfaceNumber}`,
+      handle: `${identitySelector ?? item.path}|${item.interfaceNumber}`,
+      serialNumber: identity ? formatVcanUsbSerialNumber(identity) : undefined,
+      busy,
+      extra: makeExtra(capabilities, termination)
+    }
+  })
+}
+
+export class VCAN_USB_CAN extends CanBase {
+  readonly event = new EventEmitter()
+  readonly info: CanBaseInfo
+  readonly log: CanLOG
+  closed = false
+
+  private readonly native: VcanUsbNative
+  private readonly startTime = getTsUs()
+  private timestampOffset?: number
+  private nextToken = 1
+  private nextRead = 1
+  private lastState = -1
+  private fatalTransportError = false
+  private readonly pendingTransmits = new Map<number, PendingTransmit>()
+  private readonly pendingReads = new Map<number, PendingRead>()
+
+  constructor(info: CanBaseInfo) {
+    super()
+    this.info = cloneDeep(info)
+    const { path: storedPath, channel } = splitHandle(info.handle)
+    const identitySelected = isVcanUsbIdentitySelector(storedPath)
+    const path = resolveVcanUsbPath(storedPath, channel, listIdentityCandidates)
+    this.info.handle = `${identitySelected ? storedPath : path}|${channel}`
+    this.native = VcanUsbNative.open(
+      path,
+      (records) => this.receive(records),
+      (error) => this.transportError(error),
+      (result) => this.transmitComplete(result)
+    )
+    try {
+      if (this.native.interfaceNumber !== channel) {
+        throw new Error(
+          `VCAN USB interface mismatch: selected channel ${channel}, opened ${this.native.interfaceNumber}`
+        )
+      }
+      this.log = new CanLOG('VCAN_USB', info.name, info.id, this.event)
+    } catch (error) {
+      this.native.close()
+      throw error
+    }
+    try {
+      const capabilities = this.native.readCapabilities()
+      this.validateTiming(info, capabilities)
+      try {
+        const deviceInfo = this.native.readDeviceInfo()
+        const identity = rememberIdentity(path, deviceInfo)
+        if (
+          identitySelected &&
+          (!identity ||
+            makeVcanUsbIdentitySelector(identity).toLowerCase() !== storedPath.toLowerCase())
+        ) {
+          throw new Error(
+            `VCAN USB hardware identity changed while opening ${storedPath}; refusing to configure a different adapter.`
+          )
+        }
+        sysLog.info(
+          `vcan_usb ${info.name}: SW ${formatVersion(deviceInfo.swVersion)}, HW ${formatVersion(deviceInfo.hwVersion)}, ${identity ? formatVcanUsbSerialNumber(identity) : 'identity unavailable'}, channel ${channel}`
+        )
+      } catch (error) {
+        if (identitySelected) throw error
+        sysLog.warn(
+          `vcan_usb ${info.name}: device-info query unavailable: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+      // Arm bulk IN before the first configuration write so startup state/error
+      // events cannot race receiver registration.
+      this.native.startReceive()
+      const applied = this.native.configure(info, !!info.candleRes)
+      const timing = [formatTiming('nominal', applied.nominal)]
+      if (applied.data) timing.push(formatTiming('data', applied.data))
+      sysLog.info(`vcan_usb ${info.name}: timing validated and sent: ${timing.join('; ')}`)
+      this.attachCanMessage(this.busloadCb)
+    } catch (error) {
+      try {
+        this.native.stop()
+      } catch {
+        // Preserve the original configuration/open error.
+      }
+      this.native.close()
+      this.log.close()
+      throw error
+    }
+  }
+
+  private validateTiming(info: CanBaseInfo, capabilities: VcanUsbCapabilities) {
+    const validate = (
+      name: string,
+      timing: CanBaseInfo['bitrate'],
+      cap: typeof capabilities.nominal
+    ) => {
+      const timingValues = [
+        timing.freq,
+        timing.preScaler,
+        timing.timeSeg1,
+        timing.timeSeg2,
+        timing.sjw
+      ]
+      if (timingValues.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+        throw new Error(`${name} timing values must be positive integers`)
+      }
+      const clockMHz = Number(timing.clock)
+      if (!Number.isFinite(clockMHz) || clockMHz <= 0) {
+        throw new Error(`${name} clock must be a positive number`)
+      }
+      const clock = clockMHz * 1_000_000
+      const calculated = Math.floor(
+        clock / (timing.preScaler * (1 + timing.timeSeg1 + timing.timeSeg2))
+      )
+      if (clock !== cap.fclk_can) {
+        throw new Error(`${name} clock must be ${cap.fclk_can / 1_000_000} MHz`)
+      }
+      if (Math.abs(calculated - timing.freq) / timing.freq > 0.01) {
+        throw new Error(`${name} timing calculates ${calculated} Hz, expected ${timing.freq} Hz`)
+      }
+      if (timing.timeSeg1 < cap.tseg1_min || timing.timeSeg1 > cap.tseg1_max) {
+        throw new Error(`${name} timeSeg1 is outside ${cap.tseg1_min}..${cap.tseg1_max}`)
+      }
+      if (timing.timeSeg2 < cap.tseg2_min || timing.timeSeg2 > cap.tseg2_max) {
+        throw new Error(`${name} timeSeg2 is outside ${cap.tseg2_min}..${cap.tseg2_max}`)
+      }
+      if (timing.sjw < 1 || timing.sjw > cap.sjw_max) {
+        throw new Error(`${name} sjw is outside 1..${cap.sjw_max}`)
+      }
+      if (timing.sjw > timing.timeSeg2) {
+        throw new Error(`${name} sjw must not exceed timeSeg2`)
+      }
+      if (timing.preScaler < cap.brp_min || timing.preScaler > cap.brp_max) {
+        throw new Error(`${name} prescaler is outside ${cap.brp_min}..${cap.brp_max}`)
+      }
+      if ((timing.preScaler - cap.brp_min) % Math.max(1, cap.brp_inc) !== 0) {
+        throw new Error(`${name} prescaler does not match the device increment ${cap.brp_inc}`)
+      }
+    }
+
+    validate('CAN', info.bitrate, capabilities.nominal)
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('CAN FD data timing is required')
+      validate('CAN FD', info.bitratefd, capabilities.data || capabilities.nominal)
+    }
+  }
+
+  private receive(records: VcanUsbRxRecord[]) {
+    if (this.closed) return
+    for (const record of records) {
+      if (record.kind === 'frame') this.handleFrame(record)
+      else this.handleWireEvent(record)
+    }
+  }
+
+  private relativeTimestamp(deviceTimestampUs: number) {
+    const hostTimestamp = getTsUs() - this.startTime
+    if (!Number.isSafeInteger(deviceTimestampUs) || deviceTimestampUs <= 0) return hostTimestamp
+    if (this.timestampOffset === undefined) {
+      this.timestampOffset = deviceTimestampUs - hostTimestamp
+    }
+    const timestamp = deviceTimestampUs - this.timestampOffset
+    if (timestamp >= 0) return timestamp
+    // Recover defensively if a firmware timestamp epoch changes unexpectedly.
+    this.timestampOffset = deviceTimestampUs - hostTimestamp
+    return hostTimestamp
+  }
+
+  private handleFrame(frame: VcanUsbFrame) {
+    const timestamp = this.relativeTimestamp(frame.timestampUs)
+    if (frame.overflow) {
+      this.log.error(
+        timestamp,
+        `CAN receive overflow reported with frame 0x${frame.id.toString(16)}`
+      )
+    }
+    const msgType: CanMsgType = {
+      idType: frame.extended ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+      canfd: frame.fd,
+      brs: frame.brs,
+      remote: frame.remote
+    }
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'IN',
+      id: frame.id,
+      data: frame.remote ? Buffer.alloc(0) : frame.data,
+      ts: timestamp,
+      msgType,
+      database: this.info.database
+    }
+    this.log.canBase(message)
+    this.event.emit(this.getReadBaseId(frame.id, msgType), message)
+  }
+
+  private handleWireEvent(event: Exclude<VcanUsbRxRecord, VcanUsbFrame>) {
+    if (event.kind === 'state') {
+      const timestamp = this.relativeTimestamp(event.timestampUs)
+      if (event.state === this.lastState) return
+      this.lastState = event.state
+      if (event.state !== 0) {
+        this.log.error(
+          timestamp,
+          `CAN state ${STATE_NAMES[event.state] || event.state}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+        )
+      }
+      return
+    }
+    if (event.errorCode !== 0) {
+      this.log.error(
+        getTsUs() - this.startTime,
+        `CAN bus error ${ERROR_NAMES[event.errorCode] || event.errorCode}, flags:0x${event.errorFlag.toString(16)}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}, LOG_CNT:${event.errorLoggingCount}`
+      )
+    }
+  }
+
+  private transmitComplete(result: { token: number; ok: boolean; error?: string }) {
+    const pending = this.pendingTransmits.get(result.token)
+    if (!pending) return
+    this.pendingTransmits.delete(result.token)
+    if (!result.ok) {
+      pending.reject(
+        new CanError(CAN_ERROR_ID.CAN_INTERNAL_ERROR, pending.msgType, pending.data, result.error)
+      )
+      return
+    }
+    const timestamp = getTsUs() - this.startTime
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'OUT',
+      id: pending.id,
+      data: pending.data,
+      ts: timestamp,
+      msgType: pending.msgType,
+      database: pending.extra?.database,
+      name: pending.extra?.name
+    }
+    this.log.canBase(message)
+    pending.resolve(timestamp)
+  }
+
+  private transportError(error: NativeTransportError) {
+    if (this.closed) return
+    if (!error.fatal) {
+      this.log.error(getTsUs() - this.startTime, error.message)
+      return
+    }
+    this.fatalTransportError = true
+    this.log.error(getTsUs() - this.startTime, error.message)
+    this.rejectAll(CAN_ERROR_ID.CAN_INTERNAL_ERROR, error)
+    setImmediate(() => this.close())
+  }
+
+  private rejectAll(errorId: CAN_ERROR_ID, cause?: unknown) {
+    for (const pending of this.pendingTransmits.values()) {
+      pending.reject(
+        new CanError(
+          errorId,
+          pending.msgType,
+          pending.data,
+          cause instanceof Error ? cause.message : cause === undefined ? undefined : String(cause)
+        )
+      )
+    }
+    this.pendingTransmits.clear()
+    for (const pending of this.pendingReads.values()) {
+      clearTimeout(pending.timer)
+      this.event.off(pending.eventName, pending.listener)
+      pending.reject(new CanError(errorId, pending.msgType))
+    }
+    this.pendingReads.clear()
+  }
+
+  setOption(cmd: string, value: unknown): unknown {
+    return this._setOption(cmd, value)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    this.rejectAll(CAN_ERROR_ID.CAN_BUS_CLOSED)
+    if (!this.fatalTransportError) {
+      try {
+        this.native.stop()
+      } catch (error) {
+        sysLog.warn(
+          `vcan_usb stop failed: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    this.native.close()
+    this.detachCanMessage(this.busloadCb)
+    this.log.close()
+    this._close()
+  }
+
+  private validateMessage(id: number, msgType: CanMsgType): string | undefined {
+    if (msgType.idType !== CAN_ID_TYPE.STANDARD && msgType.idType !== CAN_ID_TYPE.EXTENDED) {
+      return 'CAN ID type is invalid'
+    }
+    const maximumId = msgType.idType === CAN_ID_TYPE.EXTENDED ? 0x1fffffff : 0x7ff
+    if (!Number.isInteger(id) || id < 0 || id > maximumId) {
+      return `CAN identifier must be an integer in 0..0x${maximumId.toString(16)}`
+    }
+    if (msgType.canfd && !this.info.canfd) {
+      return 'CAN FD frame requested while the channel is configured for classic CAN'
+    }
+    if (msgType.canfd && msgType.remote) return 'CAN FD does not support remote frames'
+    return undefined
+  }
+
+  writeBase(
+    id: number,
+    msgType: CanMsgType,
+    data: Buffer,
+    extra?: { database?: string; name?: string }
+  ): Promise<number> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType, data))
+    }
+    const parameterError = this.validateMessage(id, msgType)
+    if (parameterError) {
+      return Promise.reject(
+        new CanError(CAN_ERROR_ID.CAN_PARAM_ERROR, msgType, data, parameterError)
+      )
+    }
+    if (this.info.silent) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_DRIVER_SILENT, msgType, data))
+    }
+
+    const effectiveMsgType: CanMsgType = {
+      ...msgType,
+      // EcuBus can retain a disabled BRS checkbox after switching a send item
+      // from CAN FD to classic CAN. The VCAN firmware applies BRS only to FD,
+      // so normalize the value at the driver boundary.
+      brs: msgType.canfd && msgType.brs
+    }
+
+    const token = this.nextTransmitToken()
+    let normalized: Buffer | undefined
+    try {
+      normalized = this.native.writeFrame(
+        {
+          id,
+          data,
+          fd: effectiveMsgType.canfd,
+          brs: effectiveMsgType.brs,
+          extended: effectiveMsgType.idType === CAN_ID_TYPE.EXTENDED,
+          remote: effectiveMsgType.remote
+        },
+        token
+      )
+    } catch (error) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          effectiveMsgType,
+          data,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    if (!normalized) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+          effectiveMsgType,
+          data,
+          'VCAN USB transmit queue is full'
+        )
+      )
+    }
+    return new Promise<number>((resolve, reject) => {
+      this.pendingTransmits.set(token, {
+        resolve,
+        reject,
+        id,
+        msgType: effectiveMsgType,
+        data: normalized,
+        extra
+      })
+    })
+  }
+
+  private nextTransmitToken() {
+    while (this.pendingTransmits.has(this.nextToken)) {
+      this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    }
+    const token = this.nextToken
+    this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    return token
+  }
+
+  readBase(
+    id: number,
+    msgType: CanMsgType,
+    timeout: number
+  ): Promise<{ data: Buffer; ts: number }> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType))
+    }
+    const parameterError = this.validateMessage(id, msgType)
+    if (parameterError || !Number.isFinite(timeout) || timeout < 0) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          msgType,
+          undefined,
+          parameterError || 'CAN read timeout must be a non-negative finite number'
+        )
+      )
+    }
+    const eventName = this.getReadBaseId(id, msgType)
+    const readId = this.nextRead++
+    return new Promise((resolve, reject) => {
+      const listener = (value: CanMessage | CanError) => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        clearTimeout(pending.timer)
+        this.pendingReads.delete(readId)
+        if (value instanceof CanError) reject(value)
+        else resolve({ data: value.data, ts: value.ts! })
+      }
+      const timer = setTimeout(() => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        this.pendingReads.delete(readId)
+        this.event.off(eventName, listener)
+        reject(new CanError(CAN_ERROR_ID.CAN_READ_TIMEOUT, msgType))
+      }, timeout)
+      this.pendingReads.set(readId, { reject, msgType, eventName, listener, timer })
+      this.event.once(eventName, listener)
+    })
+  }
+
+  getReadBaseId(id: number, msgType: CanMsgType): string {
+    return `${id}-${msgType.canfd ? msgType.brs : false}-${msgType.remote}-${msgType.canfd}-${msgType.idType}`
+  }
+
+  static override getValidDevices(): CanDevice[] {
+    return getVcanUsbDevices()
+  }
+
+  static override getLibVersion(): string {
+    return '1.0.0 (libusb)'
+  }
+}

--- a/src/main/docan/vcan_usb/native.ts
+++ b/src/main/docan/vcan_usb/native.ts
@@ -1,0 +1,249 @@
+import { CanBaseInfo, CandleCapability } from '../../share/can'
+import NativeVcanUsb from './build/Release/vcan_usb.node'
+
+export interface NativeUsbInterface {
+  path: string
+  label: string
+  interfaceNumber: number
+  endpointIn: number
+  endpointOut: number
+  busy: boolean
+}
+
+export interface VcanUsbDeviceInfo {
+  swVersion: number
+  hwVersion: number
+  uid: number[]
+  uuid: number[]
+}
+
+export interface VcanUsbCapabilities {
+  nominal: CandleCapability
+  data?: CandleCapability
+  fdSupported: boolean
+  listenOnlySupported: boolean
+  terminationSupported: boolean
+}
+
+export interface VcanUsbAppliedTiming {
+  requestedBitrate: number
+  actualBitrate: number
+  samplePointPermille: number
+  prescaler: number
+  tseg1: number
+  tseg2: number
+  sjw: number
+  wirePrescaler: number
+  wireTseg1: number
+  wireTseg2: number
+  wireSjw: number
+}
+
+export interface VcanUsbAppliedConfig {
+  nominal: VcanUsbAppliedTiming
+  data?: VcanUsbAppliedTiming
+  hardwareTimestamps: boolean
+}
+
+export interface VcanUsbFrame {
+  kind: 'frame'
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+  timestampUs: number
+  overflow: boolean
+  esi: boolean
+  error: boolean
+}
+
+export interface VcanUsbStateEvent {
+  kind: 'state'
+  state: number
+  rxErrorCount: number
+  txErrorCount: number
+  timestampUs: number
+}
+
+export interface VcanUsbBusErrorEvent {
+  kind: 'bus-error'
+  errorFlag: number
+  errorCode: number
+  rxErrorCount: number
+  txErrorCount: number
+  errorLoggingCount: number
+}
+
+export type VcanUsbRxRecord = VcanUsbFrame | VcanUsbStateEvent | VcanUsbBusErrorEvent
+
+export interface NativeTransportError {
+  operation: string
+  code: number
+  message: string
+  fatal: boolean
+}
+
+interface NativeTxResult {
+  token: number
+  ok: boolean
+  error?: string
+}
+
+interface NativeOpenResult {
+  handle: number
+  interfaceNumber: number
+}
+
+interface NativeTiming {
+  clockHz: number
+  bitrateHz: number
+  prescaler: number
+  tseg1: number
+  tseg2: number
+  sjw: number
+}
+
+interface NativeConfig {
+  nominal: NativeTiming
+  data?: NativeTiming
+  fd: boolean
+  listenOnly: boolean
+  termination: boolean
+}
+
+interface NativeFrame {
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+}
+
+interface NativeApi {
+  listDevices(): NativeUsbInterface[]
+  fallbackCapabilities(): VcanUsbCapabilities
+  open(
+    path: string,
+    onReceive: (records: VcanUsbRxRecord[]) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): NativeOpenResult
+  startRx(handle: number): void
+  readCapabilities(handle: number): VcanUsbCapabilities
+  readDeviceInfo(handle: number): VcanUsbDeviceInfo
+  getTermination(handle: number): boolean
+  configure(handle: number, config: NativeConfig): VcanUsbAppliedConfig
+  stop(handle: number): void
+  writeFrame(
+    handle: number,
+    frame: NativeFrame,
+    token: number,
+    delayBeforeMs: number,
+    delayAfterMs: number
+  ): Buffer | null
+  close(handle: number): void
+}
+
+const native = NativeVcanUsb as NativeApi
+
+function toNativeTiming(timing: CanBaseInfo['bitrate']): NativeTiming {
+  return {
+    clockHz: Number(timing.clock) * 1_000_000,
+    bitrateHz: timing.freq,
+    prescaler: timing.preScaler,
+    tseg1: timing.timeSeg1,
+    tseg2: timing.timeSeg2,
+    sjw: timing.sjw
+  }
+}
+
+export class VcanUsbNative {
+  readonly handle: number
+  readonly interfaceNumber: number
+  private closed = false
+
+  private constructor(result: NativeOpenResult) {
+    this.handle = result.handle
+    this.interfaceNumber = result.interfaceNumber
+  }
+
+  static listDevices(): NativeUsbInterface[] {
+    return native.listDevices()
+  }
+
+  static fallbackCapabilities(): VcanUsbCapabilities {
+    return native.fallbackCapabilities()
+  }
+
+  static open(
+    path: string,
+    onReceive: (records: VcanUsbRxRecord[]) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): VcanUsbNative {
+    return new VcanUsbNative(native.open(path, onReceive, onError, onTransmit))
+  }
+
+  startReceive() {
+    this.assertOpen()
+    native.startRx(this.handle)
+  }
+
+  readCapabilities(): VcanUsbCapabilities {
+    this.assertOpen()
+    return native.readCapabilities(this.handle)
+  }
+
+  readDeviceInfo(): VcanUsbDeviceInfo {
+    this.assertOpen()
+    return native.readDeviceInfo(this.handle)
+  }
+
+  getTermination(): boolean {
+    this.assertOpen()
+    return native.getTermination(this.handle)
+  }
+
+  configure(info: CanBaseInfo, termination: boolean): VcanUsbAppliedConfig {
+    this.assertOpen()
+    const config: NativeConfig = {
+      nominal: toNativeTiming(info.bitrate),
+      fd: !!info.canfd,
+      listenOnly: !!info.silent,
+      termination
+    }
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('VCAN USB CAN FD data timing is required')
+      config.data = toNativeTiming(info.bitratefd)
+    }
+    return native.configure(this.handle, config)
+  }
+
+  stop() {
+    this.assertOpen()
+    native.stop(this.handle)
+  }
+
+  writeFrame(
+    frame: Omit<VcanUsbFrame, 'kind' | 'timestampUs' | 'overflow' | 'esi' | 'error'>,
+    token: number,
+    delayBeforeMs = 0,
+    delayAfterMs = 0
+  ): Buffer | undefined {
+    this.assertOpen()
+    return native.writeFrame(this.handle, frame, token, delayBeforeMs, delayAfterMs) ?? undefined
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    native.close(this.handle)
+  }
+
+  private assertOpen() {
+    if (this.closed) throw new Error('VCAN USB native driver is closed')
+  }
+}

--- a/src/main/docan/vcan_usb/native/addon.cpp
+++ b/src/main/docan/vcan_usb/native/addon.cpp
@@ -1,0 +1,712 @@
+#include <napi.h>
+
+#include "../api/vcan_usb.h"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr size_t kTransferSize = 512;
+constexpr size_t kTxQueueLimit = 512;
+constexpr uint32_t kIoTimeoutMs = 2000;
+constexpr uint32_t kRxPollMs = 100;
+
+struct TxJob {
+  uint32_t token = 0;
+  std::vector<uint8_t> bytes;
+  uint32_t delayBeforeMs = 0;
+  uint32_t delayAfterMs = 0;
+};
+
+struct TxResult {
+  uint32_t token = 0;
+  bool ok = false;
+  std::string error;
+};
+
+struct ErrorResult {
+  int32_t code = 0;
+  std::string operation;
+  std::string detail;
+  bool fatal = true;
+};
+
+std::mutex gDevicesMutex;
+std::map<uint32_t, std::shared_ptr<class UsbTransport>> gDevices;
+std::atomic<uint32_t> gNextHandle{1};
+
+std::string ApiErrorMessage(const vcan_usb_error_t &error) {
+  std::ostringstream output;
+  output << (error.operation[0] != '\0' ? error.operation : "VCAN USB");
+  if (error.message[0] != '\0')
+    output << " failed: " << error.message;
+  if (error.native_code != 0)
+    output << " (code " << error.native_code << ')';
+  return output.str();
+}
+
+int32_t ApiErrorCode(const vcan_usb_error_t &error) {
+  return error.native_code != 0 ? error.native_code
+                                : static_cast<int32_t>(error.status);
+}
+
+uint32_t ReadUint32Value(const Napi::Value &value, const char *name) {
+  if (!value.IsNumber())
+    throw std::runtime_error(std::string(name) + " must be numeric");
+  const double number = value.As<Napi::Number>().DoubleValue();
+  if (!std::isfinite(number) || number < 0 || number > UINT32_MAX ||
+      std::floor(number) != number)
+    throw std::runtime_error(std::string(name) +
+                             " must be an unsigned 32-bit integer");
+  return static_cast<uint32_t>(number);
+}
+
+uint32_t ReadUint32(const Napi::Object &object, const char *name) {
+  return ReadUint32Value(object.Get(name), name);
+}
+
+bool ReadBoolean(const Napi::Object &object, const char *name) {
+  const Napi::Value value = object.Get(name);
+  if (!value.IsBoolean())
+    throw std::runtime_error(std::string(name) + " must be boolean");
+  return value.As<Napi::Boolean>().Value();
+}
+
+vcan_usb_timing_t ReadTiming(const Napi::Value &value, const char *name) {
+  if (!value.IsObject())
+    throw std::runtime_error(std::string(name) + " timing is required");
+  const Napi::Object object = value.As<Napi::Object>();
+  return vcan_usb_timing_t{
+      ReadUint32(object, "clockHz"),   ReadUint32(object, "bitrateHz"),
+      ReadUint32(object, "prescaler"), ReadUint32(object, "tseg1"),
+      ReadUint32(object, "tseg2"),     ReadUint32(object, "sjw")};
+}
+
+Napi::Object TimingLimitsToJs(Napi::Env env,
+                              const vcan_usb_timing_limits_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("feature", Napi::Number::New(env, value.feature));
+  output.Set("fclk_can", Napi::Number::New(env, value.clock_hz));
+  output.Set("tseg1_min", Napi::Number::New(env, value.tseg1_min));
+  output.Set("tseg1_max", Napi::Number::New(env, value.tseg1_max));
+  output.Set("tseg2_min", Napi::Number::New(env, value.tseg2_min));
+  output.Set("tseg2_max", Napi::Number::New(env, value.tseg2_max));
+  output.Set("sjw_max", Napi::Number::New(env, value.sjw_max));
+  output.Set("brp_min", Napi::Number::New(env, value.brp_min));
+  output.Set("brp_max", Napi::Number::New(env, value.brp_max));
+  output.Set("brp_inc", Napi::Number::New(env, value.brp_inc));
+  return output;
+}
+
+Napi::Object CapabilitiesToJs(Napi::Env env,
+                              const vcan_usb_capabilities_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("nominal", TimingLimitsToJs(env, value.nominal));
+  if (value.has_data_timing)
+    output.Set("data", TimingLimitsToJs(env, value.data));
+  output.Set("fdSupported", Napi::Boolean::New(env, value.fd_supported));
+  output.Set("listenOnlySupported",
+             Napi::Boolean::New(env, value.listen_only_supported));
+  output.Set("terminationSupported",
+             Napi::Boolean::New(env, value.termination_supported));
+  return output;
+}
+
+Napi::Object AppliedTimingToJs(Napi::Env env,
+                               const vcan_usb_applied_timing_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("requestedBitrate",
+             Napi::Number::New(env, value.requested_bitrate_hz));
+  output.Set("actualBitrate", Napi::Number::New(env, value.actual_bitrate_hz));
+  output.Set("samplePointPermille",
+             Napi::Number::New(env, value.sample_point_permille));
+  output.Set("prescaler", Napi::Number::New(env, value.prescaler));
+  output.Set("tseg1", Napi::Number::New(env, value.tseg1));
+  output.Set("tseg2", Napi::Number::New(env, value.tseg2));
+  output.Set("sjw", Napi::Number::New(env, value.sjw));
+  output.Set("wirePrescaler", Napi::Number::New(env, value.wire_prescaler));
+  output.Set("wireTseg1", Napi::Number::New(env, value.wire_tseg1));
+  output.Set("wireTseg2", Napi::Number::New(env, value.wire_tseg2));
+  output.Set("wireSjw", Napi::Number::New(env, value.wire_sjw));
+  return output;
+}
+
+Napi::Object DeviceInfoToJs(Napi::Env env,
+                            const vcan_usb_device_info_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("swVersion", Napi::Number::New(env, value.software_version));
+  output.Set("hwVersion", Napi::Number::New(env, value.hardware_version));
+  Napi::Array uid = Napi::Array::New(env, 4);
+  Napi::Array uuid = Napi::Array::New(env, 4);
+  for (uint32_t index = 0; index < 4; ++index) {
+    uid.Set(index, Napi::Number::New(env, value.uid[index]));
+    uuid.Set(index, Napi::Number::New(env, value.uuid[index]));
+  }
+  output.Set("uid", uid);
+  output.Set("uuid", uuid);
+  return output;
+}
+
+Napi::Object AppliedConfigToJs(Napi::Env env,
+                               const vcan_usb_applied_config_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("nominal", AppliedTimingToJs(env, value.nominal));
+  if (value.has_data_timing)
+    output.Set("data", AppliedTimingToJs(env, value.data));
+  output.Set("hardwareTimestamps",
+             Napi::Boolean::New(env, value.hardware_timestamps));
+  return output;
+}
+
+Napi::Object RxRecordToJs(Napi::Env env, const vcan_usb_rx_record_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  if (value.kind == VCAN_USB_RX_FRAME) {
+    output.Set("kind", "frame");
+    output.Set("id", Napi::Number::New(env, value.frame.id));
+    output.Set("data", Napi::Buffer<uint8_t>::Copy(env, value.frame.data,
+                                                   value.frame.length));
+    output.Set("fd", Napi::Boolean::New(env, value.frame.fd));
+    output.Set("brs", Napi::Boolean::New(env, value.frame.brs));
+    output.Set("extended", Napi::Boolean::New(env, value.frame.extended));
+    output.Set("remote", Napi::Boolean::New(env, value.frame.remote));
+    output.Set("overflow", Napi::Boolean::New(env, value.frame.overflow));
+    output.Set("esi", Napi::Boolean::New(env, value.frame.esi));
+    output.Set("error", Napi::Boolean::New(env, value.frame.error));
+    output.Set(
+        "timestampUs",
+        Napi::Number::New(env, static_cast<double>(value.frame.timestamp_us)));
+  } else if (value.kind == VCAN_USB_RX_STATE) {
+    output.Set("kind", "state");
+    output.Set("state", Napi::Number::New(env, value.state));
+    output.Set("rxErrorCount", Napi::Number::New(env, value.rx_error_count));
+    output.Set("txErrorCount", Napi::Number::New(env, value.tx_error_count));
+    output.Set("timestampUs",
+               Napi::Number::New(env, static_cast<double>(value.timestamp_us)));
+  } else {
+    output.Set("kind", "bus-error");
+    output.Set("errorFlag", Napi::Number::New(env, value.error_flag));
+    output.Set("errorCode", Napi::Number::New(env, value.error_code));
+    output.Set("rxErrorCount", Napi::Number::New(env, value.rx_error_count));
+    output.Set("txErrorCount", Napi::Number::New(env, value.tx_error_count));
+    output.Set("errorLoggingCount",
+               Napi::Number::New(env, value.error_logging_count));
+  }
+  return output;
+}
+
+class UsbTransport {
+public:
+  UsbTransport(Napi::Env env, std::string path, Napi::Function rxCallback,
+               Napi::Function errorCallback, Napi::Function txCallback)
+      : path_(std::move(path)), rxTsfn_(Napi::ThreadSafeFunction::New(
+                                    env, rxCallback, "vcan-usb-rx", 4096, 1)),
+        errorTsfn_(Napi::ThreadSafeFunction::New(env, errorCallback,
+                                                 "vcan-usb-error", 8, 1)),
+        txTsfn_(Napi::ThreadSafeFunction::New(env, txCallback, "vcan-usb-tx",
+                                              1024, 1)) {}
+
+  ~UsbTransport() { Close(); }
+
+  void Open() {
+    vcan_usb_error_t error{};
+    device_ = vcan_usb_open(path_.c_str(), &error);
+    if (device_ == nullptr)
+      throw std::runtime_error(ApiErrorMessage(error));
+    txThread_ = std::thread(&UsbTransport::TxLoop, this);
+  }
+
+  uint8_t InterfaceNumber() const { return vcan_usb_interface_number(device_); }
+
+  void StartRx() {
+    EnsureOpen();
+    bool expected = false;
+    if (!rxStarted_.compare_exchange_strong(expected, true))
+      return;
+    rxThread_ = std::thread(&UsbTransport::RxLoop, this);
+  }
+
+  vcan_usb_capabilities_t Capabilities() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vcan_usb_capabilities_t result{};
+    vcan_usb_error_t error{};
+    if (!vcan_usb_get_capabilities(device_, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  vcan_usb_device_info_t DeviceInfo() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vcan_usb_device_info_t result{};
+    vcan_usb_error_t error{};
+    if (!vcan_usb_get_device_info(device_, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  bool Termination() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    bool result = false;
+    vcan_usb_error_t error{};
+    if (!vcan_usb_get_termination(device_, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  vcan_usb_applied_config_t Configure(const vcan_usb_config_t &config) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vcan_usb_applied_config_t result{};
+    vcan_usb_error_t error{};
+    if (!vcan_usb_configure(device_, &config, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  void Stop() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vcan_usb_error_t error{};
+    if (!vcan_usb_stop(device_, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+  }
+
+  bool EnqueueFrame(uint32_t token, const vcan_usb_frame_t &frame,
+                    uint32_t delayBeforeMs, uint32_t delayAfterMs,
+                    std::vector<uint8_t> *normalized) {
+    EnsureOpen();
+    uint8_t wire[VCAN_USB_MAX_WIRE_FRAME]{};
+    size_t wireLength = 0;
+    uint8_t normalizedLength = 0;
+    vcan_usb_error_t error{};
+    if (!vcan_usb_encode_frame(device_, &frame, wire, sizeof(wire), &wireLength,
+                               &normalizedLength, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    normalized->assign(frame.data, frame.data + frame.length);
+    normalized->resize(normalizedLength, 0);
+    return Enqueue(token, wire, wireLength, delayBeforeMs, delayAfterMs);
+  }
+
+  bool Enqueue(uint32_t token, const uint8_t *data, size_t length,
+               uint32_t delayBeforeMs, uint32_t delayAfterMs) {
+    if (data == nullptr || length == 0)
+      return false;
+    std::lock_guard<std::mutex> lock(txMutex_);
+    if (closing_ || txQueue_.size() >= kTxQueueLimit)
+      return false;
+    txQueue_.push_back(TxJob{token, std::vector<uint8_t>(data, data + length),
+                             delayBeforeMs, delayAfterMs});
+    txCondition_.notify_one();
+    return true;
+  }
+
+  void Close() {
+    bool expected = false;
+    if (!closing_.compare_exchange_strong(expected, true))
+      return;
+    txCondition_.notify_all();
+    vcan_usb_cancel(device_);
+    if (rxThread_.joinable())
+      rxThread_.join();
+    if (txThread_.joinable())
+      txThread_.join();
+    vcan_usb_close(device_);
+    device_ = nullptr;
+    rxTsfn_.Release();
+    errorTsfn_.Release();
+    txTsfn_.Release();
+  }
+
+private:
+  void EnsureOpen() const {
+    if (closing_ || device_ == nullptr) {
+      throw std::runtime_error("VCAN USB transport is closed");
+    }
+  }
+
+  bool WaitDelay(uint32_t delayMs) {
+    if (delayMs == 0)
+      return !closing_;
+    std::unique_lock<std::mutex> lock(txMutex_);
+    return !txCondition_.wait_for(lock, std::chrono::milliseconds(delayMs),
+                                  [&] { return closing_.load(); });
+  }
+
+  void RxLoop() {
+    while (!closing_) {
+      std::vector<uint8_t> bytes(kTransferSize);
+      size_t transferred = 0;
+      vcan_usb_error_t error{};
+      if (!vcan_usb_bulk_read(device_, bytes.data(), bytes.size(), &transferred,
+                              kRxPollMs, &error)) {
+        if (!closing_ && error.status != VCAN_USB_STATUS_CANCELLED)
+          ReportError(error);
+        break;
+      }
+      if (transferred == 0)
+        continue;
+      vcan_usb_rx_batch_t batch{};
+      if (!vcan_usb_decode(device_, bytes.data(), transferred, &batch,
+                           &error)) {
+        vcan_usb_decoder_reset(device_);
+        ReportError(error, false);
+        continue;
+      }
+      if (batch.count == 0)
+        continue;
+      auto *payload = new std::vector<vcan_usb_rx_record_t>(
+          batch.records, batch.records + batch.count);
+      const napi_status status = rxTsfn_.NonBlockingCall(
+          payload, [](Napi::Env env, Napi::Function callback,
+                      std::vector<vcan_usb_rx_record_t> *value) {
+            Napi::Array records = Napi::Array::New(env, value->size());
+            for (size_t index = 0; index < value->size(); ++index)
+              records.Set(index, RxRecordToJs(env, (*value)[index]));
+            callback.Call({records});
+            delete value;
+          });
+      if (status != napi_ok) {
+        delete payload;
+        if (!closing_ && status != napi_closing) {
+          vcan_usb_error_t queueError{};
+          queueError.status = VCAN_USB_STATUS_SYSTEM_ERROR;
+          queueError.native_code = 0;
+          std::snprintf(queueError.operation, sizeof(queueError.operation),
+                        "RX callback queue");
+          std::snprintf(queueError.message, sizeof(queueError.message),
+                        "callback queue is full");
+          ReportError(queueError, true);
+          break;
+        }
+      }
+    }
+  }
+
+  void TxLoop() {
+    while (true) {
+      TxJob job;
+      {
+        std::unique_lock<std::mutex> lock(txMutex_);
+        txCondition_.wait(lock, [&] { return closing_ || !txQueue_.empty(); });
+        if (closing_ && txQueue_.empty())
+          break;
+        job = std::move(txQueue_.front());
+        txQueue_.pop_front();
+      }
+
+      bool ok = WaitDelay(job.delayBeforeMs);
+      vcan_usb_error_t error{};
+      size_t transferred = 0;
+      if (ok) {
+        ok = vcan_usb_bulk_write(device_, job.bytes.data(), job.bytes.size(),
+                                 &transferred, kIoTimeoutMs, &error);
+      }
+      if (ok)
+        ok = WaitDelay(job.delayAfterMs);
+      std::string detail;
+      if (!ok) {
+        detail = error.status != VCAN_USB_STATUS_OK
+                     ? ApiErrorMessage(error)
+                     : "VCAN USB transport is closed";
+      }
+      PostTxResult(new TxResult{job.token, ok, std::move(detail)});
+    }
+
+    std::deque<TxJob> abandoned;
+    {
+      std::lock_guard<std::mutex> lock(txMutex_);
+      abandoned.swap(txQueue_);
+    }
+    for (const auto &job : abandoned) {
+      PostTxResult(
+          new TxResult{job.token, false, "VCAN USB transport is closed"});
+    }
+  }
+
+  void PostTxResult(TxResult *result) {
+    const napi_status status = txTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, TxResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("token", Napi::Number::New(env, value->token));
+          object.Set("ok", Napi::Boolean::New(env, value->ok));
+          if (!value->ok)
+            object.Set("error", Napi::String::New(env, value->error));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  void ReportError(const vcan_usb_error_t &error, bool fatal = true) {
+    auto *result = new ErrorResult{ApiErrorCode(error), error.operation,
+                                   ApiErrorMessage(error), fatal};
+    const napi_status status = errorTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, ErrorResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("operation", Napi::String::New(env, value->operation));
+          object.Set("code", Napi::Number::New(env, value->code));
+          object.Set("message", Napi::String::New(env, value->detail));
+          object.Set("fatal", Napi::Boolean::New(env, value->fatal));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  std::string path_;
+  vcan_usb_device_t *device_ = nullptr;
+  std::atomic<bool> closing_{false};
+  std::atomic<bool> rxStarted_{false};
+  std::thread rxThread_;
+  std::thread txThread_;
+  std::mutex controlMutex_;
+  std::mutex txMutex_;
+  std::condition_variable txCondition_;
+  std::deque<TxJob> txQueue_;
+  Napi::ThreadSafeFunction rxTsfn_;
+  Napi::ThreadSafeFunction errorTsfn_;
+  Napi::ThreadSafeFunction txTsfn_;
+};
+
+std::shared_ptr<UsbTransport> Lookup(uint32_t handle) {
+  std::lock_guard<std::mutex> lock(gDevicesMutex);
+  const auto found = gDevices.find(handle);
+  if (found == gDevices.end())
+    throw std::runtime_error("invalid VCAN USB transport handle");
+  return found->second;
+}
+
+uint32_t ReadHandle(const Napi::CallbackInfo &info) {
+  if (info.Length() == 0 || !info[0].IsNumber()) {
+    throw Napi::TypeError::New(info.Env(),
+                               "a numeric transport handle is required");
+  }
+  return info[0].As<Napi::Number>().Uint32Value();
+}
+
+Napi::Value ListDevices(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  vcan_usb_device_list_t list{};
+  vcan_usb_error_t error{};
+  if (!vcan_usb_list_scan(&list, &error)) {
+    throw Napi::Error::New(env, ApiErrorMessage(error));
+  }
+  Napi::Array output = Napi::Array::New(env, list.count);
+  for (size_t index = 0; index < list.count; ++index) {
+    const auto &item = list.devices[index];
+    Napi::Object object = Napi::Object::New(env);
+    object.Set("path", Napi::String::New(env, item.path));
+    object.Set("label", Napi::String::New(env, item.label));
+    object.Set("interfaceNumber",
+               Napi::Number::New(env, item.interface_number));
+    object.Set("endpointIn", Napi::Number::New(env, item.endpoint_in));
+    object.Set("endpointOut", Napi::Number::New(env, item.endpoint_out));
+    object.Set("busy", Napi::Boolean::New(env, item.busy));
+    output.Set(index, object);
+  }
+  return output;
+}
+
+Napi::Value Open(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 4 || !info[0].IsString() || !info[1].IsFunction() ||
+      !info[2].IsFunction() || !info[3].IsFunction()) {
+    throw Napi::TypeError::New(
+        env, "open expects path, rx callback, error callback, tx callback");
+  }
+  try {
+    auto device = std::make_shared<UsbTransport>(
+        env, info[0].As<Napi::String>().Utf8Value(),
+        info[1].As<Napi::Function>(), info[2].As<Napi::Function>(),
+        info[3].As<Napi::Function>());
+    device->Open();
+    const uint32_t handle = gNextHandle.fetch_add(1);
+    {
+      std::lock_guard<std::mutex> lock(gDevicesMutex);
+      gDevices.emplace(handle, device);
+    }
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("handle", Napi::Number::New(env, handle));
+    result.Set("interfaceNumber",
+               Napi::Number::New(env, device->InterfaceNumber()));
+    return result;
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value StartRx(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(ReadHandle(info))->StartRx();
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value FallbackCapabilities(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  vcan_usb_capabilities_t capabilities{};
+  vcan_usb_fallback_capabilities(&capabilities);
+  return CapabilitiesToJs(env, capabilities);
+}
+
+Napi::Value ReadCapabilities(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    return CapabilitiesToJs(env, Lookup(ReadHandle(info))->Capabilities());
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value ReadDeviceInfo(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    return DeviceInfoToJs(env, Lookup(ReadHandle(info))->DeviceInfo());
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value GetTermination(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    return Napi::Boolean::New(env, Lookup(ReadHandle(info))->Termination());
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Configure(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[1].IsObject())
+    throw Napi::TypeError::New(env, "configure expects handle and config");
+  try {
+    const Napi::Object input = info[1].As<Napi::Object>();
+    vcan_usb_config_t config{};
+    config.nominal = ReadTiming(input.Get("nominal"), "nominal");
+    config.fd = ReadBoolean(input, "fd");
+    config.listen_only = ReadBoolean(input, "listenOnly");
+    config.termination = ReadBoolean(input, "termination");
+    if (config.fd)
+      config.data = ReadTiming(input.Get("data"), "data");
+    return AppliedConfigToJs(env, Lookup(ReadHandle(info))->Configure(config));
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Stop(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(ReadHandle(info))->Stop();
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value WriteFrame(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 5 || !info[1].IsObject()) {
+    throw Napi::TypeError::New(
+        env,
+        "writeFrame expects handle, frame, token, delayBeforeMs, delayAfterMs");
+  }
+  try {
+    const Napi::Object input = info[1].As<Napi::Object>();
+    const Napi::Value dataValue = input.Get("data");
+    if (!dataValue.IsBuffer())
+      throw std::runtime_error("frame data must be a Buffer");
+    const auto data = dataValue.As<Napi::Buffer<uint8_t>>();
+    if (data.Length() > VCAN_USB_MAX_FRAME_DATA)
+      throw std::runtime_error("frame data exceeds 64 bytes");
+    vcan_usb_frame_t frame{};
+    frame.id = ReadUint32(input, "id");
+    frame.length = static_cast<uint8_t>(data.Length());
+    if (frame.length > 0)
+      std::memcpy(frame.data, data.Data(), frame.length);
+    frame.fd = ReadBoolean(input, "fd");
+    frame.brs = ReadBoolean(input, "brs");
+    frame.extended = ReadBoolean(input, "extended");
+    frame.remote = ReadBoolean(input, "remote");
+    std::vector<uint8_t> normalized;
+    const bool queued =
+        Lookup(ReadHandle(info))
+            ->EnqueueFrame(ReadUint32Value(info[2], "token"), frame,
+                           ReadUint32Value(info[3], "delayBeforeMs"),
+                           ReadUint32Value(info[4], "delayAfterMs"),
+                           &normalized);
+    return queued ? Napi::Buffer<uint8_t>::Copy(env, normalized.data(),
+                                                normalized.size())
+                  : env.Null();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Close(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  std::shared_ptr<UsbTransport> device;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    const auto found = gDevices.find(ReadHandle(info));
+    if (found == gDevices.end())
+      return env.Undefined();
+    device = found->second;
+    gDevices.erase(found);
+  }
+  device->Close();
+  return env.Undefined();
+}
+
+void Cleanup(void *) {
+  std::map<uint32_t, std::shared_ptr<UsbTransport>> devices;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    devices.swap(gDevices);
+  }
+  for (auto &entry : devices)
+    entry.second->Close();
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("listDevices", Napi::Function::New(env, ListDevices));
+  exports.Set("open", Napi::Function::New(env, Open));
+  exports.Set("startRx", Napi::Function::New(env, StartRx));
+  exports.Set("fallbackCapabilities",
+              Napi::Function::New(env, FallbackCapabilities));
+  exports.Set("readCapabilities", Napi::Function::New(env, ReadCapabilities));
+  exports.Set("readDeviceInfo", Napi::Function::New(env, ReadDeviceInfo));
+  exports.Set("getTermination", Napi::Function::New(env, GetTermination));
+  exports.Set("configure", Napi::Function::New(env, Configure));
+  exports.Set("stop", Napi::Function::New(env, Stop));
+  exports.Set("writeFrame", Napi::Function::New(env, WriteFrame));
+  exports.Set("close", Napi::Function::New(env, Close));
+  napi_add_env_cleanup_hook(env, Cleanup, nullptr);
+  return exports;
+}
+
+} // namespace
+
+NODE_API_MODULE(vcan_usb, Init)

--- a/src/main/docan/vkgs_usb/api/vkgs_usb.cpp
+++ b/src/main/docan/vkgs_usb/api/vkgs_usb.cpp
@@ -1,0 +1,1541 @@
+#include "vkgs_usb.h"
+
+#include <libusb.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint16_t kDeviceVid = 0x1d50;
+constexpr uint16_t kDevicePid = 0x606f;
+constexpr uint32_t kDefaultTimeoutMs = 2000;
+constexpr uint32_t kDefaultPollMs = 100;
+constexpr size_t kMaxPortDepth = 16;
+constexpr const char *kPathPrefix = "libusb://1d50:606f/";
+
+/* Effective HPM MCAN limits after the firmware translates the USB fields to
+ * the SDK's low-level timing structure.  Keep these local to this driver: the
+ * similarly shaped Candle protocol does not use the same wire semantics. */
+constexpr uint32_t kNominalTseg1Min = 1;
+constexpr uint32_t kNominalTseg1Max = 128;
+constexpr uint32_t kNominalTseg2Min = 2;
+constexpr uint32_t kNominalTseg2Max = 32;
+constexpr uint32_t kNominalSjwMax = 64;
+constexpr uint32_t kNominalBrpMax = 256;
+constexpr uint32_t kDataTseg1Min = 1;
+constexpr uint32_t kDataTseg1Max = 30;
+constexpr uint32_t kDataTseg2Min = 1;
+constexpr uint32_t kDataTseg2Max = 15;
+constexpr uint32_t kDataSjwMax = 15;
+constexpr uint32_t kDataBrpMax = 32;
+
+/* VKGS firmware consumes zero-based register fields, unlike Candle's
+ * host-semantic gs_usb timing values.  Validation guarantees value > 0. */
+constexpr uint32_t EncodeTimingRegister(uint32_t value) { return value - 1U; }
+static_assert(EncodeTimingRegister(1U) == 0U);
+static_assert(EncodeTimingRegister(128U) == 127U);
+
+struct DeviceKey {
+  uint8_t bus = 0;
+  uint8_t address = 0;
+  uint8_t interface_number = 0;
+  std::vector<uint8_t> ports;
+};
+
+struct InterfaceInfo {
+  uint8_t number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+};
+
+struct EnumeratedInterface {
+  std::string path;
+  std::string label;
+  InterfaceInfo interface;
+  bool busy = false;
+};
+struct SharedUsbDevice {
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  std::mutex interface_mutex;
+  std::mutex control_mutex;
+  std::set<uint8_t> claimed_interfaces;
+
+  ~SharedUsbDevice() {
+    if (handle != nullptr)
+      libusb_close(handle);
+    if (context != nullptr)
+      libusb_exit(context);
+  }
+};
+
+std::mutex gOpenDevicesMutex;
+std::map<std::string, std::weak_ptr<SharedUsbDevice>> gOpenDevices;
+
+void CopyText(char *destination, size_t capacity, const std::string &source) {
+  if (destination == nullptr || capacity == 0)
+    return;
+  const size_t length = std::min(capacity - 1, source.size());
+  if (length > 0)
+    std::memcpy(destination, source.data(), length);
+  destination[length] = '\0';
+}
+
+vkgs_usb_status_t StatusFromLibusb(int code, bool cancelled) {
+  if (cancelled) {
+    return VKGS_USB_STATUS_CANCELLED;
+  }
+  if (code == LIBUSB_ERROR_INVALID_PARAM) {
+    return VKGS_USB_STATUS_INVALID_ARGUMENT;
+  }
+  if (code == LIBUSB_ERROR_TIMEOUT)
+    return VKGS_USB_STATUS_TIMEOUT;
+  if (code == LIBUSB_ERROR_NOT_FOUND) {
+    return VKGS_USB_STATUS_ENDPOINT_NOT_FOUND;
+  }
+  return VKGS_USB_STATUS_SYSTEM_ERROR;
+}
+
+std::string LibusbMessage(int code) {
+  const char *name = libusb_error_name(code);
+  const char *detail = libusb_strerror(static_cast<libusb_error>(code));
+  std::string message = name != nullptr ? name : "LIBUSB_ERROR_UNKNOWN";
+  if (detail != nullptr && detail[0] != '\0' && message != detail) {
+    message += ": ";
+    message += detail;
+  }
+  return message;
+}
+
+void SetError(vkgs_usb_error_t *error, vkgs_usb_status_t status,
+              const char *operation, int32_t native_code,
+              const std::string &detail) {
+  if (error == nullptr)
+    return;
+  vkgs_usb_error_clear(error);
+  error->status = status;
+  error->native_code = native_code;
+  CopyText(error->operation, sizeof(error->operation),
+           operation != nullptr ? operation : "libusb");
+  CopyText(error->message, sizeof(error->message),
+           detail.empty() ? "operation failed" : detail);
+}
+
+void SetLibusbError(vkgs_usb_error_t *error, const char *operation, int code,
+                    bool cancelled = false) {
+  SetError(error, StatusFromLibusb(code, cancelled), operation, code,
+           cancelled ? "USB transfer was cancelled" : LibusbMessage(code));
+}
+
+bool ParseByte(const std::string &text, uint8_t *output) {
+  if (text.empty() || output == nullptr)
+    return false;
+  errno = 0;
+  char *end = nullptr;
+  const unsigned long value = std::strtoul(text.c_str(), &end, 10);
+  if (errno != 0 || end == text.c_str() || *end != '\0' || value > UINT8_MAX) {
+    return false;
+  }
+  *output = static_cast<uint8_t>(value);
+  return true;
+}
+
+std::vector<uint8_t> GetPorts(libusb_device *device) {
+  uint8_t ports[kMaxPortDepth]{};
+  const int count =
+      libusb_get_port_numbers(device, ports, static_cast<int>(kMaxPortDepth));
+  if (count <= 0)
+    return {};
+  return std::vector<uint8_t>(ports, ports + count);
+}
+
+std::string MakePath(libusb_device *device, uint8_t interface_number) {
+  std::ostringstream output;
+  output << kPathPrefix << static_cast<unsigned>(libusb_get_bus_number(device))
+         << '/';
+  const auto ports = GetPorts(device);
+  if (ports.empty()) {
+    output << 'a' << static_cast<unsigned>(libusb_get_device_address(device));
+  } else {
+    output << 'p';
+    for (size_t index = 0; index < ports.size(); ++index) {
+      if (index != 0)
+        output << '.';
+      output << static_cast<unsigned>(ports[index]);
+    }
+  }
+  output << '/' << static_cast<unsigned>(interface_number);
+  return output.str();
+}
+
+bool ParsePath(const char *path, DeviceKey *key) {
+  if (path == nullptr || key == nullptr)
+    return false;
+  const std::string value(path);
+  if (value.compare(0, std::strlen(kPathPrefix), kPathPrefix) != 0)
+    return false;
+  const std::string body = value.substr(std::strlen(kPathPrefix));
+  const size_t first = body.find('/');
+  const size_t second = first == std::string::npos ? std::string::npos
+                                                   : body.find('/', first + 1);
+  if (first == std::string::npos || second == std::string::npos ||
+      body.find('/', second + 1) != std::string::npos) {
+    return false;
+  }
+  DeviceKey parsed;
+  if (!ParseByte(body.substr(0, first), &parsed.bus) ||
+      !ParseByte(body.substr(second + 1), &parsed.interface_number)) {
+    return false;
+  }
+  const std::string location = body.substr(first + 1, second - first - 1);
+  if (location.size() < 2)
+    return false;
+  if (location[0] == 'a') {
+    if (!ParseByte(location.substr(1), &parsed.address))
+      return false;
+  } else if (location[0] == 'p') {
+    size_t start = 1;
+    while (start < location.size()) {
+      const size_t end = location.find('.', start);
+      uint8_t port = 0;
+      if (!ParseByte(location.substr(start, end - start), &port) || port == 0) {
+        return false;
+      }
+      parsed.ports.push_back(port);
+      if (parsed.ports.size() > kMaxPortDepth)
+        return false;
+      if (end == std::string::npos)
+        break;
+      if (end + 1 >= location.size())
+        return false;
+      start = end + 1;
+    }
+    if (parsed.ports.empty())
+      return false;
+  } else {
+    return false;
+  }
+  *key = std::move(parsed);
+  return true;
+}
+
+bool Matches(libusb_device *device, const DeviceKey &key) {
+  if (libusb_get_bus_number(device) != key.bus)
+    return false;
+  if (!key.ports.empty())
+    return GetPorts(device) == key.ports;
+  return libusb_get_device_address(device) == key.address;
+}
+
+bool FindInterface(libusb_device *device, uint8_t interface_number,
+                   InterfaceInfo *result) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return false;
+
+  bool found = false;
+  InterfaceInfo fallback{};
+  bool has_fallback = false;
+  for (uint8_t interface_index = 0;
+       interface_index < config->bNumInterfaces && !found; ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    for (int alternate_index = 0;
+         alternate_index < usb_interface.num_altsetting; ++alternate_index) {
+      const libusb_interface_descriptor &descriptor =
+          usb_interface.altsetting[alternate_index];
+      if (descriptor.bInterfaceNumber != interface_number)
+        continue;
+      InterfaceInfo candidate{};
+      candidate.number = descriptor.bInterfaceNumber;
+      candidate.alternate_setting = descriptor.bAlternateSetting;
+      for (uint8_t endpoint_index = 0;
+           endpoint_index < descriptor.bNumEndpoints; ++endpoint_index) {
+        const libusb_endpoint_descriptor &endpoint =
+            descriptor.endpoint[endpoint_index];
+        if ((endpoint.bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+            LIBUSB_TRANSFER_TYPE_BULK) {
+          continue;
+        }
+        if ((endpoint.bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) ==
+            LIBUSB_ENDPOINT_IN) {
+          candidate.endpoint_in = endpoint.bEndpointAddress;
+        } else {
+          candidate.endpoint_out = endpoint.bEndpointAddress;
+        }
+      }
+      if (candidate.endpoint_in == 0 || candidate.endpoint_out == 0)
+        continue;
+      if (!has_fallback) {
+        fallback = candidate;
+        has_fallback = true;
+      }
+      if (candidate.alternate_setting == 0) {
+        *result = candidate;
+        found = true;
+        break;
+      }
+    }
+  }
+  if (!found && has_fallback) {
+    *result = fallback;
+    found = true;
+  }
+  libusb_free_config_descriptor(config);
+  return found;
+}
+
+std::vector<InterfaceInfo> FindInterfaces(libusb_device *device) {
+  libusb_config_descriptor *config = nullptr;
+  int status = libusb_get_active_config_descriptor(device, &config);
+  if (status != LIBUSB_SUCCESS) {
+    status = libusb_get_config_descriptor(device, 0, &config);
+  }
+  if (status != LIBUSB_SUCCESS || config == nullptr)
+    return {};
+  std::vector<InterfaceInfo> output;
+  for (uint8_t interface_index = 0; interface_index < config->bNumInterfaces;
+       ++interface_index) {
+    const libusb_interface &usb_interface = config->interface[interface_index];
+    if (usb_interface.num_altsetting <= 0)
+      continue;
+    const uint8_t number = usb_interface.altsetting[0].bInterfaceNumber;
+    InterfaceInfo info{};
+    if (FindInterface(device, number, &info))
+      output.push_back(info);
+  }
+  libusb_free_config_descriptor(config);
+  return output;
+}
+
+std::string PhysicalKey(const DeviceKey &key) {
+  std::ostringstream output;
+  output << static_cast<unsigned>(key.bus) << '/';
+  if (key.ports.empty()) {
+    output << 'a' << static_cast<unsigned>(key.address);
+  } else {
+    output << 'p';
+    for (size_t index = 0; index < key.ports.size(); ++index) {
+      if (index != 0)
+        output << '.';
+      output << static_cast<unsigned>(key.ports[index]);
+    }
+  }
+  return output.str();
+}
+
+std::string PhysicalKey(libusb_device *device) {
+  DeviceKey key;
+  key.bus = libusb_get_bus_number(device);
+  key.address = libusb_get_device_address(device);
+  key.ports = GetPorts(device);
+  return PhysicalKey(key);
+}
+
+std::shared_ptr<SharedUsbDevice> AcquireDevice(const DeviceKey &key,
+                                               vkgs_usb_error_t *error) {
+  const std::string physical_key = PhysicalKey(key);
+  std::lock_guard<std::mutex> registry_lock(gOpenDevicesMutex);
+  const auto existing = gOpenDevices.find(physical_key);
+  if (existing != gOpenDevices.end()) {
+    if (auto shared = existing->second.lock())
+      return shared;
+    gOpenDevices.erase(existing);
+  }
+
+  std::shared_ptr<SharedUsbDevice> shared;
+  try {
+    shared = std::make_shared<SharedUsbDevice>();
+  } catch (const std::bad_alloc &) {
+    SetError(error, VKGS_USB_STATUS_SYSTEM_ERROR, "libusb_open",
+             LIBUSB_ERROR_NO_MEM, "unable to allocate the shared USB device");
+    return {};
+  }
+
+  int status = libusb_init(&shared->context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    return {};
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(shared->context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    return {};
+  }
+
+  status = LIBUSB_ERROR_NO_DEVICE;
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid || !Matches(devices[index], key)) {
+      continue;
+    }
+    status = libusb_open(devices[index], &shared->handle);
+    break;
+  }
+  libusb_free_device_list(devices, 1);
+  if (shared->handle == nullptr || status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_open", status);
+    return {};
+  }
+
+  gOpenDevices[physical_key] = shared;
+  return shared;
+}
+std::string ReadLabel(libusb_device_handle *handle,
+                      const libusb_device_descriptor &descriptor) {
+  if (handle == nullptr || descriptor.iProduct == 0)
+    return "VKGS USB";
+  unsigned char value[VKGS_USB_LABEL_CAPACITY]{};
+  const int length = libusb_get_string_descriptor_ascii(
+      handle, descriptor.iProduct, value, static_cast<int>(sizeof(value) - 1));
+  return length > 0 ? std::string(reinterpret_cast<char *>(value), length)
+                    : "VKGS USB";
+}
+
+bool ProbeBusy(libusb_device *device, uint8_t interface_number,
+               std::string *label, const libusb_device_descriptor &descriptor) {
+  std::shared_ptr<SharedUsbDevice> shared;
+  {
+    std::lock_guard<std::mutex> registry_lock(gOpenDevicesMutex);
+    const auto existing = gOpenDevices.find(PhysicalKey(device));
+    if (existing != gOpenDevices.end())
+      shared = existing->second.lock();
+  }
+  if (shared) {
+    *label = ReadLabel(shared->handle, descriptor);
+    std::lock_guard<std::mutex> interface_lock(shared->interface_mutex);
+    return shared->claimed_interfaces.count(interface_number) != 0;
+  }
+
+  libusb_device_handle *handle = nullptr;
+  const int open_status = libusb_open(device, &handle);
+  if (open_status != LIBUSB_SUCCESS || handle == nullptr)
+    return true;
+  *label = ReadLabel(handle, descriptor);
+  bool busy = false;
+  const int kernel_active =
+      libusb_kernel_driver_active(handle, interface_number);
+  if (kernel_active != 1) {
+    const int claim_status = libusb_claim_interface(handle, interface_number);
+    busy = claim_status != LIBUSB_SUCCESS;
+    if (!busy)
+      libusb_release_interface(handle, interface_number);
+  }
+  libusb_close(handle);
+  return busy;
+}
+bool ValidateOpen(vkgs_usb_device_t *device, vkgs_usb_error_t *error,
+                  const char *operation);
+
+} // namespace
+
+struct vkgs_usb_device {
+  std::shared_ptr<SharedUsbDevice> owner;
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  uint8_t interface_number = 0;
+  uint8_t alternate_setting = 0;
+  uint8_t endpoint_in = 0;
+  uint8_t endpoint_out = 0;
+  bool claimed = false;
+  bool manually_detached = false;
+  std::atomic<bool> cancelled{false};
+  std::atomic<bool> fd_mode{false};
+  std::atomic<bool> timestamps_enabled{false};
+  std::mutex protocol_mutex;
+  std::mutex decoder_mutex;
+  bool capabilities_cached = false;
+  vkgs_usb_capabilities_t capabilities{};
+  std::vector<uint8_t> decoder_tail;
+};
+
+namespace {
+
+constexpr uint32_t kFeatureListenOnly = 1U << 0;
+constexpr uint32_t kFeatureHardwareTimestamp = 1U << 4;
+constexpr uint32_t kFeatureFd = 1U << 8;
+constexpr uint32_t kFeatureBtConstExt = 1U << 10;
+constexpr uint32_t kFeatureTermination = 1U << 11;
+constexpr uint32_t kFeatureBerrReporting = 1U << 12;
+constexpr uint32_t kModeListenOnly = 1U << 0;
+constexpr uint32_t kModeHardwareTimestamp = 1U << 4;
+constexpr uint32_t kModeFd = 1U << 8;
+constexpr uint32_t kModeBerrReporting = 1U << 12;
+constexpr uint8_t kRequestHostFormat = 0;
+constexpr uint8_t kRequestBitTiming = 1;
+constexpr uint8_t kRequestMode = 2;
+constexpr uint8_t kRequestBtConst = 4;
+constexpr uint8_t kRequestDataBitTiming = 10;
+constexpr uint8_t kRequestBtConstExt = 11;
+constexpr uint8_t kRequestFallbackSetTermination = 12;
+constexpr uint8_t kRequestFallbackGetTermination = 13;
+constexpr uint8_t kRequestDeviceInfo = 33;
+constexpr uint8_t kRequestBusLoad = 36;
+constexpr uint8_t kRequestTermination = 37;
+constexpr uint32_t kEchoRx = 0xffffffffU;
+constexpr uint32_t kEchoLoad = 0xa3c95e3dU;
+constexpr uint32_t kEchoState = 0xa4c95e3dU;
+constexpr uint32_t kEchoBerr = 0xa6c95e3dU;
+constexpr size_t kHeaderSize = 12;
+constexpr size_t kStateSize = 28;
+constexpr size_t kBerrSize = 16;
+constexpr size_t kLoadSize = 28;
+constexpr uint8_t kFlagOverflow = 1U << 0;
+constexpr uint8_t kFlagFd = 1U << 1;
+constexpr uint8_t kFlagBrs = 1U << 2;
+constexpr uint8_t kFlagEsi = 1U << 3;
+constexpr uint32_t kCanEffFlag = 0x80000000U;
+constexpr uint32_t kCanRtrFlag = 0x40000000U;
+constexpr uint32_t kCanErrorFlag = 0x20000000U;
+constexpr uint32_t kCanSffMask = 0x7ffU;
+constexpr uint32_t kCanIdMask = 0x1fffffffU;
+constexpr uint8_t kDlcLengths[16] = {0, 1,  2,  3,  4,  5,  6,  7,
+                                     8, 12, 16, 20, 24, 32, 48, 64};
+
+uint32_t ReadLe32(const uint8_t *data);
+uint64_t ReadLe64(const uint8_t *data);
+void WriteLe32(uint8_t *data, uint32_t value);
+bool ProtocolError(vkgs_usb_error_t *error, const char *operation,
+                   const std::string &message,
+                   vkgs_usb_status_t status = VKGS_USB_STATUS_PROTOCOL_ERROR);
+bool ControlGet(vkgs_usb_device_t *device, uint8_t request, size_t length,
+                std::vector<uint8_t> *payload, vkgs_usb_error_t *error);
+void FillFallback(vkgs_usb_capabilities_t *capabilities);
+bool GetCapabilitiesUnlocked(vkgs_usb_device_t *device,
+                             vkgs_usb_capabilities_t *capabilities,
+                             vkgs_usb_error_t *error);
+bool ValidateTiming(const vkgs_usb_timing_t &timing,
+                    const vkgs_usb_timing_limits_t &limits,
+                    vkgs_usb_applied_timing_t *applied, vkgs_usb_error_t *error,
+                    const char *phase);
+bool SetTiming(vkgs_usb_device_t *device, uint8_t request,
+               const vkgs_usb_applied_timing_t &timing,
+               vkgs_usb_error_t *error);
+bool SetMode(vkgs_usb_device_t *device, uint32_t mode, uint32_t flags,
+             vkgs_usb_error_t *error);
+bool SetHostFormat(vkgs_usb_device_t *device, vkgs_usb_error_t *error);
+bool SetBusLoad(vkgs_usb_device_t *device, bool enabled,
+                vkgs_usb_error_t *error);
+bool SetTermination(vkgs_usb_device_t *device, bool enabled,
+                    vkgs_usb_error_t *error);
+uint8_t LengthToDlc(uint8_t length, bool fd);
+uint8_t DlcToLength(uint8_t dlc, bool fd);
+bool AppendRecord(vkgs_usb_rx_batch_t *batch, vkgs_usb_rx_record_t **record,
+                  vkgs_usb_error_t *error);
+
+} // namespace
+
+void vkgs_usb_fallback_capabilities(vkgs_usb_capabilities_t *capabilities) {
+  FillFallback(capabilities);
+}
+
+bool vkgs_usb_get_capabilities(vkgs_usb_device_t *device,
+                               vkgs_usb_capabilities_t *capabilities,
+                               vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_get_capabilities") ||
+      capabilities == nullptr) {
+    if (capabilities == nullptr)
+      ProtocolError(error, "vkgs_usb_get_capabilities",
+                    "capabilities output is null",
+                    VKGS_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  vkgs_usb_error_clear(error);
+  return GetCapabilitiesUnlocked(device, capabilities, error);
+}
+
+bool vkgs_usb_get_device_info(vkgs_usb_device_t *device,
+                              vkgs_usb_device_info_t *info,
+                              vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_get_device_info") ||
+      info == nullptr) {
+    if (info == nullptr)
+      ProtocolError(error, "vkgs_usb_get_device_info", "info output is null",
+                    VKGS_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  vkgs_usb_error_clear(error);
+  std::vector<uint8_t> payload;
+  if (!ControlGet(device, kRequestDeviceInfo, 40, &payload, error))
+    return false;
+  std::memset(info, 0, sizeof(*info));
+  info->software_version = ReadLe32(payload.data());
+  info->hardware_version = ReadLe32(payload.data() + 4);
+  for (size_t index = 0; index < 4; ++index) {
+    info->uid[index] = ReadLe32(payload.data() + 8 + index * 4);
+    info->uuid[index] = ReadLe32(payload.data() + 24 + index * 4);
+  }
+  return true;
+}
+
+bool vkgs_usb_get_termination(vkgs_usb_device_t *device, bool *enabled,
+                              vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_get_termination") ||
+      enabled == nullptr) {
+    if (enabled == nullptr)
+      ProtocolError(error, "vkgs_usb_get_termination", "state output is null",
+                    VKGS_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  std::vector<uint8_t> payload;
+  vkgs_usb_error_t primary_error{};
+  if (!ControlGet(device, kRequestTermination, 4, &payload, &primary_error) &&
+      !ControlGet(device, kRequestFallbackGetTermination, 4, &payload, error))
+    return false;
+  *enabled = ReadLe32(payload.data()) != 0;
+  return true;
+}
+
+bool vkgs_usb_configure(vkgs_usb_device_t *device,
+                        const vkgs_usb_config_t *config,
+                        vkgs_usb_applied_config_t *applied,
+                        vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_configure") || config == nullptr ||
+      applied == nullptr) {
+    if (config == nullptr || applied == nullptr)
+      ProtocolError(error, "vkgs_usb_configure", "configuration is null",
+                    VKGS_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  vkgs_usb_error_clear(error);
+  vkgs_usb_capabilities_t capabilities{};
+  if (!GetCapabilitiesUnlocked(device, &capabilities, error))
+    return false;
+  if (config->fd && !capabilities.fd_supported)
+    return ProtocolError(error, "vkgs_usb_configure", "CAN FD is not supported",
+                         VKGS_USB_STATUS_UNSUPPORTED);
+  if (config->listen_only && !capabilities.listen_only_supported)
+    return ProtocolError(error, "vkgs_usb_configure",
+                         "listen-only mode is not supported",
+                         VKGS_USB_STATUS_UNSUPPORTED);
+
+  vkgs_usb_applied_config_t result{};
+  if (!ValidateTiming(config->nominal, capabilities.nominal, &result.nominal,
+                      error, "VKGS nominal timing"))
+    return false;
+  if (config->fd) {
+    const auto &limits =
+        capabilities.has_data_timing ? capabilities.data : capabilities.nominal;
+    if (!ValidateTiming(config->data, limits, &result.data, error,
+                        "VKGS data timing"))
+      return false;
+    result.has_data_timing = true;
+  }
+
+  device->fd_mode.store(false);
+  device->timestamps_enabled.store(false);
+  if (!SetMode(device, 0, 0, error) || !SetHostFormat(device, error) ||
+      !SetTiming(device, kRequestBitTiming, result.nominal, error) ||
+      (config->fd &&
+       !SetTiming(device, kRequestDataBitTiming, result.data, error)) ||
+      !SetBusLoad(device, false, error))
+    return false;
+  vkgs_usb_error_t termination_error{};
+  if (!SetTermination(device, config->termination, &termination_error) &&
+      (config->termination || capabilities.termination_supported)) {
+    if (error != nullptr)
+      *error = termination_error;
+    return false;
+  }
+
+  uint32_t flags = config->listen_only ? kModeListenOnly : 0;
+  if (config->fd)
+    flags |= kModeFd;
+  if ((capabilities.nominal.feature & kFeatureBerrReporting) != 0)
+    flags |= kModeBerrReporting;
+  const bool timestamps =
+      (capabilities.nominal.feature & kFeatureHardwareTimestamp) != 0;
+  if (timestamps)
+    flags |= kModeHardwareTimestamp;
+  vkgs_usb_decoder_reset(device);
+  /* RX already runs while START is issued. Publish the expected record format
+   * before firmware can deliver the first timestamped frame. */
+  device->fd_mode.store(config->fd);
+  device->timestamps_enabled.store(timestamps);
+  if (!SetMode(device, 1, flags, error)) {
+    device->fd_mode.store(false);
+    device->timestamps_enabled.store(false);
+    return false;
+  }
+  result.hardware_timestamps = timestamps;
+  *applied = result;
+  return true;
+}
+
+bool vkgs_usb_stop(vkgs_usb_device_t *device, vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_stop"))
+    return false;
+  std::lock_guard<std::mutex> lock(device->protocol_mutex);
+  bool result = SetMode(device, 0, 0, error);
+  if (result)
+    result = SetHostFormat(device, error);
+  device->fd_mode.store(false);
+  device->timestamps_enabled.store(false);
+  return result;
+}
+
+bool vkgs_usb_encode_frame(vkgs_usb_device_t *device,
+                           const vkgs_usb_frame_t *frame, uint8_t *wire,
+                           size_t capacity, size_t *wire_length,
+                           uint8_t *normalized_length,
+                           vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_encode_frame") ||
+      frame == nullptr || wire == nullptr || wire_length == nullptr ||
+      normalized_length == nullptr) {
+    if (frame == nullptr || wire == nullptr || wire_length == nullptr ||
+        normalized_length == nullptr)
+      ProtocolError(error, "vkgs_usb_encode_frame", "invalid frame output",
+                    VKGS_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  const uint32_t maximum_id = frame->extended ? kCanIdMask : kCanSffMask;
+  if (frame->id > maximum_id || frame->length > (frame->fd ? 64 : 8) ||
+      (frame->fd && frame->remote) || (frame->fd && !device->fd_mode.load()))
+    return ProtocolError(error, "vkgs_usb_encode_frame",
+                         "invalid CAN frame for the configured mode",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  const uint8_t dlc = LengthToDlc(frame->length, frame->fd);
+  if (dlc == 0xff)
+    return ProtocolError(error, "vkgs_usb_encode_frame",
+                         "CAN payload exceeds protocol limits",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  const uint8_t data_length = DlcToLength(dlc, frame->fd);
+  const bool wide_frame = device->fd_mode.load() || frame->fd;
+  const size_t size = kHeaderSize + (wide_frame ? 64U : 8U);
+  if (capacity < size)
+    return ProtocolError(error, "vkgs_usb_encode_frame",
+                         "wire buffer is too small",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  std::memset(wire, 0, size);
+  uint32_t can_id = frame->id & kCanIdMask;
+  if (frame->extended)
+    can_id |= kCanEffFlag;
+  if (frame->remote)
+    can_id |= kCanRtrFlag;
+  uint8_t flags = frame->fd ? kFlagFd : 0;
+  if (frame->fd && frame->brs)
+    flags |= kFlagBrs;
+  WriteLe32(wire, 0);
+  WriteLe32(wire + 4, can_id);
+  wire[8] = dlc;
+  wire[9] = device->interface_number;
+  wire[10] = flags;
+  if (frame->length > 0)
+    std::memcpy(wire + kHeaderSize, frame->data, frame->length);
+  *wire_length = size;
+  *normalized_length = data_length;
+  return true;
+}
+
+bool vkgs_usb_decode(vkgs_usb_device_t *device, const uint8_t *wire,
+                     size_t wire_length, vkgs_usb_rx_batch_t *batch,
+                     vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "vkgs_usb_decode") ||
+      (wire_length > 0 && wire == nullptr) || batch == nullptr) {
+    if ((wire_length > 0 && wire == nullptr) || batch == nullptr)
+      ProtocolError(error, "vkgs_usb_decode", "invalid decoder input",
+                    VKGS_USB_STATUS_INVALID_ARGUMENT);
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(device->decoder_mutex);
+  std::memset(batch, 0, sizeof(*batch));
+  std::vector<uint8_t> buffer;
+  buffer.reserve(device->decoder_tail.size() + wire_length);
+  buffer.insert(buffer.end(), device->decoder_tail.begin(),
+                device->decoder_tail.end());
+  if (wire_length > 0)
+    buffer.insert(buffer.end(), wire, wire + wire_length);
+  device->decoder_tail.clear();
+  size_t offset = 0;
+  const bool timestamps = device->timestamps_enabled.load();
+  while (offset < buffer.size()) {
+    const size_t remaining = buffer.size() - offset;
+    if (remaining < 4) {
+      const auto begin = buffer.begin() + offset;
+      if (std::any_of(begin, buffer.end(),
+                      [](uint8_t value) { return value != 0; }))
+        device->decoder_tail.assign(begin, buffer.end());
+      break;
+    }
+    const uint8_t *item = buffer.data() + offset;
+    const uint32_t echo = ReadLe32(item);
+    if (echo == 0) {
+      offset = buffer.size();
+      break;
+    }
+    if (remaining < kHeaderSize) {
+      device->decoder_tail.assign(buffer.begin() + offset, buffer.end());
+      break;
+    }
+    const bool is_event =
+        echo == kEchoState || echo == kEchoBerr || echo == kEchoLoad;
+    size_t size = 0;
+    if (echo == kEchoState)
+      size = kStateSize;
+    else if (echo == kEchoBerr)
+      size = kBerrSize;
+    else if (echo == kEchoLoad)
+      size = kLoadSize;
+    else
+      size = kHeaderSize + ((item[10] & kFlagFd) != 0 ? 64U : 8U) +
+             (timestamps ? 8U : 0U);
+    const uint8_t channel = item[is_event ? 4 : 9];
+    if (channel != device->interface_number) {
+      device->decoder_tail.clear();
+      return ProtocolError(error, "VKGS decode",
+                           "bulk frame channel does not match interface");
+    }
+    if (offset + size > buffer.size()) {
+      device->decoder_tail.assign(buffer.begin() + offset, buffer.end());
+      break;
+    }
+    vkgs_usb_rx_record_t *record = nullptr;
+    if (echo == kEchoRx) {
+      const uint32_t raw_id = ReadLe32(item + 4);
+      const uint8_t flags = item[10];
+      const bool fd = (flags & kFlagFd) != 0;
+      const bool extended = (raw_id & kCanEffFlag) != 0;
+      const uint8_t length = DlcToLength(item[8], fd);
+      if (!AppendRecord(batch, &record, error))
+        return false;
+      record->kind = VKGS_USB_RX_FRAME;
+      record->frame.id = raw_id & (extended ? kCanIdMask : kCanSffMask);
+      record->frame.length = length;
+      if (length > 0)
+        std::memcpy(record->frame.data, item + kHeaderSize, length);
+      record->frame.fd = fd;
+      record->frame.brs = fd && (flags & kFlagBrs) != 0;
+      record->frame.extended = extended;
+      record->frame.remote = !fd && (raw_id & kCanRtrFlag) != 0;
+      record->frame.timestamp_us = timestamps ? ReadLe64(item + size - 8) : 0;
+      record->frame.overflow = (flags & kFlagOverflow) != 0;
+      record->frame.esi = fd && (flags & kFlagEsi) != 0;
+      record->frame.error = (raw_id & kCanErrorFlag) != 0;
+    } else if (echo == kEchoState) {
+      if (!AppendRecord(batch, &record, error))
+        return false;
+      record->kind = VKGS_USB_RX_STATE;
+      record->timestamp_us = ReadLe64(item + 8);
+      record->state = ReadLe32(item + 16);
+      record->rx_error_count = ReadLe32(item + 20);
+      record->tx_error_count = ReadLe32(item + 24);
+    } else if (echo == kEchoBerr) {
+      if (!AppendRecord(batch, &record, error))
+        return false;
+      record->kind = VKGS_USB_RX_BUS_ERROR;
+      record->error_flag = item[8];
+      record->error_code = item[9];
+      record->rx_error_count = item[10];
+      record->tx_error_count = item[11];
+      record->error_logging_count = item[12];
+    }
+    offset += size;
+  }
+  return true;
+}
+
+void vkgs_usb_decoder_reset(vkgs_usb_device_t *device) {
+  if (device == nullptr)
+    return;
+  std::lock_guard<std::mutex> lock(device->decoder_mutex);
+  device->decoder_tail.clear();
+}
+
+namespace {
+
+bool ValidateOpen(vkgs_usb_device_t *device, vkgs_usb_error_t *error,
+                  const char *operation) {
+  if (device != nullptr && device->owner && device->handle != nullptr &&
+      device->claimed) {
+    return true;
+  }
+  SetError(error, VKGS_USB_STATUS_NOT_OPEN, operation, LIBUSB_ERROR_NO_DEVICE,
+           "VKGS USB device is not open");
+  return false;
+}
+
+bool ControlTransfer(vkgs_usb_device_t *device, uint8_t request_type,
+                     uint8_t request, uint16_t value, uint16_t index,
+                     uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                     vkgs_usb_error_t *error) {
+  if (!ValidateOpen(device, error, "libusb_control_transfer"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_control_transfer", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  std::lock_guard<std::mutex> control_lock(device->owner->control_mutex);
+  const int transferred = libusb_control_transfer(
+      device->handle, request_type, request, value, index, data, length,
+      timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+  if (transferred < 0) {
+    SetLibusbError(error, "libusb_control_transfer", transferred,
+                   device->cancelled.load());
+    return false;
+  }
+  if (transferred != length) {
+    char detail[96]{};
+    std::snprintf(detail, sizeof(detail), "short control transfer: %d/%u",
+                  transferred, length);
+    SetError(error, VKGS_USB_STATUS_SHORT_TRANSFER, "libusb_control_transfer",
+             LIBUSB_ERROR_IO, detail);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+void vkgs_usb_error_clear(vkgs_usb_error_t *error) {
+  if (error == nullptr)
+    return;
+  std::memset(error, 0, sizeof(*error));
+  error->status = VKGS_USB_STATUS_OK;
+}
+
+bool vkgs_usb_list_scan(vkgs_usb_device_list_t *list, vkgs_usb_error_t *error) {
+  if (list == nullptr) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_list_scan",
+             LIBUSB_ERROR_INVALID_PARAM, "device list is null");
+    return false;
+  }
+  std::memset(list, 0, sizeof(*list));
+  vkgs_usb_error_clear(error);
+  libusb_context *context = nullptr;
+  int status = libusb_init(&context);
+  if (status != LIBUSB_SUCCESS) {
+    SetLibusbError(error, "libusb_init", status);
+    return false;
+  }
+  libusb_device **devices = nullptr;
+  const ssize_t count = libusb_get_device_list(context, &devices);
+  if (count < 0) {
+    SetLibusbError(error, "libusb_get_device_list", static_cast<int>(count));
+    libusb_exit(context);
+    return false;
+  }
+
+  std::vector<EnumeratedInterface> found;
+  for (ssize_t index = 0; index < count; ++index) {
+    libusb_device_descriptor descriptor{};
+    if (libusb_get_device_descriptor(devices[index], &descriptor) !=
+            LIBUSB_SUCCESS ||
+        descriptor.idVendor != kDeviceVid ||
+        descriptor.idProduct != kDevicePid) {
+      continue;
+    }
+    for (const auto &usb_interface : FindInterfaces(devices[index])) {
+      EnumeratedInterface item;
+      item.path = MakePath(devices[index], usb_interface.number);
+      item.interface = usb_interface;
+      item.label = "VKGS USB";
+      item.busy = ProbeBusy(devices[index], usb_interface.number, &item.label,
+                            descriptor);
+      found.push_back(std::move(item));
+    }
+  }
+  libusb_free_device_list(devices, 1);
+  libusb_exit(context);
+
+  std::sort(found.begin(), found.end(),
+            [](const auto &left, const auto &right) {
+              return left.path < right.path;
+            });
+  list->count =
+      std::min(found.size(), static_cast<size_t>(VKGS_USB_MAX_DEVICES));
+  for (size_t index = 0; index < list->count; ++index) {
+    const auto &source = found[index];
+    auto &target = list->devices[index];
+    CopyText(target.path, sizeof(target.path), source.path);
+    CopyText(target.label, sizeof(target.label), source.label);
+    target.interface_number = source.interface.number;
+    target.endpoint_in = source.interface.endpoint_in;
+    target.endpoint_out = source.interface.endpoint_out;
+    target.busy = source.busy;
+  }
+  return true;
+}
+
+vkgs_usb_device_t *vkgs_usb_open(const char *path, vkgs_usb_error_t *error) {
+  vkgs_usb_error_clear(error);
+  DeviceKey key;
+  if (!ParsePath(path, &key)) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_open",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid libusb device path");
+    return nullptr;
+  }
+  auto *result = new (std::nothrow) vkgs_usb_device_t();
+  if (result == nullptr) {
+    SetError(error, VKGS_USB_STATUS_SYSTEM_ERROR, "vkgs_usb_open",
+             LIBUSB_ERROR_NO_MEM, "unable to allocate the USB device");
+    return nullptr;
+  }
+  result->owner = AcquireDevice(key, error);
+  if (!result->owner) {
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+  result->context = result->owner->context;
+  result->handle = result->owner->handle;
+
+  InterfaceInfo usb_interface{};
+  libusb_device *usb_device = libusb_get_device(result->handle);
+  if (usb_device == nullptr ||
+      !FindInterface(usb_device, key.interface_number, &usb_interface)) {
+    SetError(error, VKGS_USB_STATUS_ENDPOINT_NOT_FOUND, "vkgs_usb_open",
+             LIBUSB_ERROR_NOT_FOUND, "USB interface was not found");
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+
+  result->interface_number = usb_interface.number;
+  result->alternate_setting = usb_interface.alternate_setting;
+  result->endpoint_in = usb_interface.endpoint_in;
+  result->endpoint_out = usb_interface.endpoint_out;
+
+  bool interface_ready = false;
+  {
+    std::lock_guard<std::mutex> interface_lock(result->owner->interface_mutex);
+    if (result->owner->claimed_interfaces.count(result->interface_number) !=
+        0) {
+      SetLibusbError(error, "libusb_claim_interface", LIBUSB_ERROR_BUSY);
+    } else {
+      bool can_claim = true;
+      const int kernel_active =
+          libusb_kernel_driver_active(result->handle, result->interface_number);
+      const int auto_detach =
+          libusb_set_auto_detach_kernel_driver(result->handle, 1);
+      if (kernel_active == 1 && auto_detach != LIBUSB_SUCCESS) {
+        const int detach_status = libusb_detach_kernel_driver(
+            result->handle, result->interface_number);
+        if (detach_status != LIBUSB_SUCCESS) {
+          SetLibusbError(error, "libusb_detach_kernel_driver", detach_status);
+          can_claim = false;
+        } else {
+          result->manually_detached = true;
+        }
+      }
+
+      if (can_claim) {
+        const int claim_status =
+            libusb_claim_interface(result->handle, result->interface_number);
+        if (claim_status != LIBUSB_SUCCESS) {
+          SetLibusbError(error, "libusb_claim_interface", claim_status);
+        } else {
+          result->claimed = true;
+          result->owner->claimed_interfaces.insert(result->interface_number);
+          if (result->alternate_setting != 0) {
+            const int alternate_status = libusb_set_interface_alt_setting(
+                result->handle, result->interface_number,
+                result->alternate_setting);
+            if (alternate_status != LIBUSB_SUCCESS) {
+              SetLibusbError(error, "libusb_set_interface_alt_setting",
+                             alternate_status);
+            } else {
+              interface_ready = true;
+            }
+          } else {
+            interface_ready = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (!interface_ready) {
+    vkgs_usb_close(result);
+    return nullptr;
+  }
+  libusb_clear_halt(result->handle, result->endpoint_in);
+  libusb_clear_halt(result->handle, result->endpoint_out);
+  return result;
+}
+
+uint8_t vkgs_usb_interface_number(const vkgs_usb_device_t *device) {
+  return device != nullptr ? device->interface_number : 0;
+}
+
+bool vkgs_usb_control_in(vkgs_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vkgs_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) == 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_control_in",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control IN arguments");
+    return false;
+  }
+  vkgs_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index, data,
+                         length, timeout_ms, error);
+}
+
+bool vkgs_usb_control_out(vkgs_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vkgs_usb_error_t *error) {
+  if ((request_type & LIBUSB_ENDPOINT_IN) != 0 ||
+      (length > 0 && data == nullptr)) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_control_out",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid control OUT arguments");
+    return false;
+  }
+  vkgs_usb_error_clear(error);
+  return ControlTransfer(device, request_type, request, value, index,
+                         const_cast<uint8_t *>(data), length, timeout_ms,
+                         error);
+}
+
+bool vkgs_usb_bulk_read(vkgs_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vkgs_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || capacity == 0 || capacity > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_bulk_read",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk read arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(IN)"))
+    return false;
+  vkgs_usb_error_clear(error);
+  const unsigned int poll =
+      poll_timeout_ms == 0 ? kDefaultPollMs : poll_timeout_ms;
+  bool retried_stall = false;
+  while (!device->cancelled.load()) {
+    int count = 0;
+    const int status =
+        libusb_bulk_transfer(device->handle, device->endpoint_in, data,
+                             static_cast<int>(capacity), &count, poll);
+    if (count > 0) {
+      *transferred = static_cast<size_t>(count);
+      return true;
+    }
+    if (status == LIBUSB_SUCCESS)
+      return true;
+    if (status == LIBUSB_ERROR_TIMEOUT ||
+        (status == LIBUSB_ERROR_INTERRUPTED && !device->cancelled.load())) {
+      retried_stall = false;
+      continue;
+    }
+    if (status == LIBUSB_ERROR_PIPE && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_in) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    SetLibusbError(error, "libusb_bulk_transfer(IN)", status,
+                   device->cancelled.load());
+    return false;
+  }
+  SetLibusbError(error, "libusb_bulk_transfer(IN)", LIBUSB_ERROR_INTERRUPTED,
+                 true);
+  return false;
+}
+
+bool vkgs_usb_bulk_write(vkgs_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vkgs_usb_error_t *error) {
+  if (transferred != nullptr)
+    *transferred = 0;
+  if (data == nullptr || length == 0 || length > INT_MAX ||
+      transferred == nullptr) {
+    SetError(error, VKGS_USB_STATUS_INVALID_ARGUMENT, "vkgs_usb_bulk_write",
+             LIBUSB_ERROR_INVALID_PARAM, "invalid bulk write arguments");
+    return false;
+  }
+  if (!ValidateOpen(device, error, "libusb_bulk_transfer(OUT)"))
+    return false;
+  if (device->cancelled.load()) {
+    SetLibusbError(error, "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_INTERRUPTED,
+                   true);
+    return false;
+  }
+  vkgs_usb_error_clear(error);
+  bool retried_stall = false;
+  while (true) {
+    int count = 0;
+    const int status = libusb_bulk_transfer(
+        device->handle, device->endpoint_out, const_cast<uint8_t *>(data),
+        static_cast<int>(length), &count,
+        timeout_ms == 0 ? kDefaultTimeoutMs : timeout_ms);
+    if (status == LIBUSB_ERROR_PIPE && count == 0 && !retried_stall) {
+      retried_stall = true;
+      if (libusb_clear_halt(device->handle, device->endpoint_out) ==
+          LIBUSB_SUCCESS) {
+        continue;
+      }
+    }
+    if (status != LIBUSB_SUCCESS) {
+      SetLibusbError(error, "libusb_bulk_transfer(OUT)", status,
+                     device->cancelled.load());
+      return false;
+    }
+    *transferred = static_cast<size_t>(count);
+    if (static_cast<size_t>(count) != length) {
+      char detail[96]{};
+      std::snprintf(detail, sizeof(detail), "short bulk write: %d/%zu", count,
+                    length);
+      SetError(error, VKGS_USB_STATUS_SHORT_TRANSFER,
+               "libusb_bulk_transfer(OUT)", LIBUSB_ERROR_IO, detail);
+      return false;
+    }
+    return true;
+  }
+}
+
+void vkgs_usb_cancel(vkgs_usb_device_t *device) {
+  if (device != nullptr)
+    device->cancelled.store(true);
+}
+
+void vkgs_usb_close(vkgs_usb_device_t *device) {
+  if (device == nullptr)
+    return;
+  vkgs_usb_cancel(device);
+  if (device->owner) {
+    {
+      std::lock_guard<std::mutex> interface_lock(
+          device->owner->interface_mutex);
+      if (device->claimed) {
+        libusb_release_interface(device->handle, device->interface_number);
+        device->owner->claimed_interfaces.erase(device->interface_number);
+        device->claimed = false;
+      }
+      if (device->manually_detached) {
+        libusb_attach_kernel_driver(device->handle, device->interface_number);
+        device->manually_detached = false;
+      }
+    }
+    device->handle = nullptr;
+    device->context = nullptr;
+    device->owner.reset();
+  }
+  delete device;
+}
+
+namespace {
+
+uint32_t ReadLe32(const uint8_t *data) {
+  return static_cast<uint32_t>(data[0]) |
+         (static_cast<uint32_t>(data[1]) << 8U) |
+         (static_cast<uint32_t>(data[2]) << 16U) |
+         (static_cast<uint32_t>(data[3]) << 24U);
+}
+
+uint64_t ReadLe64(const uint8_t *data) {
+  return static_cast<uint64_t>(ReadLe32(data)) |
+         (static_cast<uint64_t>(ReadLe32(data + 4)) << 32U);
+}
+
+void WriteLe32(uint8_t *data, uint32_t value) {
+  data[0] = static_cast<uint8_t>(value);
+  data[1] = static_cast<uint8_t>(value >> 8U);
+  data[2] = static_cast<uint8_t>(value >> 16U);
+  data[3] = static_cast<uint8_t>(value >> 24U);
+}
+
+bool ProtocolError(vkgs_usb_error_t *error, const char *operation,
+                   const std::string &message, vkgs_usb_status_t status) {
+  SetError(error, status, operation, 0, message);
+  return false;
+}
+
+bool ControlGet(vkgs_usb_device_t *device, uint8_t request, size_t length,
+                std::vector<uint8_t> *payload, vkgs_usb_error_t *error) {
+  if (payload == nullptr || length > UINT16_MAX)
+    return ProtocolError(error, "VKGS protocol control read",
+                         "invalid response length",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  payload->assign(length, 0);
+  return vkgs_usb_control_in(device, 0xc1, request, 0, device->interface_number,
+                             payload->data(), static_cast<uint16_t>(length),
+                             kDefaultTimeoutMs, error);
+}
+
+bool ControlSet(vkgs_usb_device_t *device, uint8_t request,
+                const uint8_t *payload, size_t length,
+                vkgs_usb_error_t *error) {
+  if ((length > 0 && payload == nullptr) || length > UINT16_MAX)
+    return ProtocolError(error, "VKGS protocol control write",
+                         "invalid control payload",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  const bool result = vkgs_usb_control_out(
+      device, 0x41, request, device->interface_number, device->interface_number,
+      payload, static_cast<uint16_t>(length), kDefaultTimeoutMs, error);
+  if (result)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  return result;
+}
+
+bool LimitsValid(const vkgs_usb_timing_limits_t &limits) {
+  return limits.clock_hz > 0 && limits.tseg1_min > 0 &&
+         limits.tseg1_min <= limits.tseg1_max && limits.tseg2_min > 0 &&
+         limits.tseg2_min <= limits.tseg2_max && limits.sjw_max > 0 &&
+         limits.brp_min > 0 && limits.brp_min <= limits.brp_max &&
+         limits.brp_inc > 0;
+}
+
+void ConstrainToHardware(vkgs_usb_timing_limits_t *limits, bool data_phase) {
+  if (limits == nullptr)
+    return;
+  if (data_phase) {
+    limits->tseg1_min = std::max(limits->tseg1_min, kDataTseg1Min);
+    limits->tseg1_max = std::min(limits->tseg1_max, kDataTseg1Max);
+    limits->tseg2_min = std::max(limits->tseg2_min, kDataTseg2Min);
+    limits->tseg2_max = std::min(limits->tseg2_max, kDataTseg2Max);
+    limits->sjw_max = std::min(limits->sjw_max, kDataSjwMax);
+    limits->brp_max = std::min(limits->brp_max, kDataBrpMax);
+  } else {
+    limits->tseg1_min = std::max(limits->tseg1_min, kNominalTseg1Min);
+    limits->tseg1_max = std::min(limits->tseg1_max, kNominalTseg1Max);
+    limits->tseg2_min = std::max(limits->tseg2_min, kNominalTseg2Min);
+    limits->tseg2_max = std::min(limits->tseg2_max, kNominalTseg2Max);
+    limits->sjw_max = std::min(limits->sjw_max, kNominalSjwMax);
+    limits->brp_max = std::min(limits->brp_max, kNominalBrpMax);
+  }
+}
+
+bool DecodeLimits(const std::vector<uint8_t> &payload, size_t offset,
+                  uint32_t feature, uint32_t clock_hz,
+                  vkgs_usb_timing_limits_t *limits, vkgs_usb_error_t *error) {
+  if (limits == nullptr || offset + 32 > payload.size())
+    return ProtocolError(error, "VKGS capabilities",
+                         "capability response is too short");
+  std::memset(limits, 0, sizeof(*limits));
+  limits->feature = feature;
+  limits->clock_hz = clock_hz != 0 ? clock_hz : 80000000U;
+  limits->tseg1_min = ReadLe32(payload.data() + offset);
+  limits->tseg1_max = ReadLe32(payload.data() + offset + 4);
+  limits->tseg2_min = ReadLe32(payload.data() + offset + 8);
+  limits->tseg2_max = ReadLe32(payload.data() + offset + 12);
+  limits->sjw_max = ReadLe32(payload.data() + offset + 16);
+  limits->brp_min = ReadLe32(payload.data() + offset + 20);
+  limits->brp_max = ReadLe32(payload.data() + offset + 24);
+  limits->brp_inc = ReadLe32(payload.data() + offset + 28);
+  if (!LimitsValid(*limits))
+    return ProtocolError(error, "VKGS capabilities",
+                         "capability response contains invalid timing limits");
+  return true;
+}
+
+void FillFallback(vkgs_usb_capabilities_t *capabilities) {
+  if (capabilities == nullptr)
+    return;
+  std::memset(capabilities, 0, sizeof(*capabilities));
+  auto &limits = capabilities->nominal;
+  limits.feature = kFeatureListenOnly | kFeatureHardwareTimestamp | kFeatureFd |
+                   kFeatureBtConstExt;
+  limits.clock_hz = 80000000U;
+  limits.tseg1_min = kNominalTseg1Min;
+  limits.tseg1_max = kNominalTseg1Max;
+  limits.tseg2_min = kNominalTseg2Min;
+  limits.tseg2_max = kNominalTseg2Max;
+  limits.sjw_max = kNominalSjwMax;
+  limits.brp_min = 1;
+  limits.brp_max = kNominalBrpMax;
+  limits.brp_inc = 1;
+  capabilities->data = limits;
+  capabilities->data.tseg1_min = kDataTseg1Min;
+  capabilities->data.tseg1_max = kDataTseg1Max;
+  capabilities->data.tseg2_min = kDataTseg2Min;
+  capabilities->data.tseg2_max = kDataTseg2Max;
+  capabilities->data.sjw_max = kDataSjwMax;
+  capabilities->data.brp_max = kDataBrpMax;
+  capabilities->has_data_timing = true;
+  capabilities->fd_supported = true;
+  capabilities->listen_only_supported = true;
+}
+
+bool GetCapabilitiesUnlocked(vkgs_usb_device_t *device,
+                             vkgs_usb_capabilities_t *capabilities,
+                             vkgs_usb_error_t *error) {
+  if (device->capabilities_cached) {
+    *capabilities = device->capabilities;
+    return true;
+  }
+  std::vector<uint8_t> base;
+  if (!ControlGet(device, kRequestBtConst, 40, &base, error))
+    return false;
+  const uint32_t feature = ReadLe32(base.data());
+  const uint32_t clock_hz = ReadLe32(base.data() + 4);
+  vkgs_usb_capabilities_t result{};
+  if (!DecodeLimits(base, 8, feature, clock_hz, &result.nominal, error))
+    return false;
+  ConstrainToHardware(&result.nominal, false);
+  if (!LimitsValid(result.nominal))
+    return ProtocolError(error, "VKGS capabilities",
+                         "nominal limits do not match HPM MCAN");
+  result.fd_supported = (feature & kFeatureFd) != 0;
+  result.listen_only_supported = (feature & kFeatureListenOnly) != 0;
+  result.termination_supported = (feature & kFeatureTermination) != 0;
+  if ((feature & kFeatureFd) != 0 && (feature & kFeatureBtConstExt) != 0) {
+    std::vector<uint8_t> extended;
+    if (!ControlGet(device, kRequestBtConstExt, 72, &extended, error) ||
+        !DecodeLimits(extended, 40, ReadLe32(extended.data()),
+                      ReadLe32(extended.data() + 4), &result.data, error))
+      return false;
+    ConstrainToHardware(&result.data, true);
+    if (!LimitsValid(result.data))
+      return ProtocolError(error, "VKGS capabilities",
+                           "data limits do not match HPM MCAN");
+    result.has_data_timing = true;
+  }
+  device->capabilities = result;
+  device->capabilities_cached = true;
+  *capabilities = result;
+  return true;
+}
+
+bool ValidateTiming(const vkgs_usb_timing_t &timing,
+                    const vkgs_usb_timing_limits_t &limits,
+                    vkgs_usb_applied_timing_t *applied, vkgs_usb_error_t *error,
+                    const char *phase) {
+  if (timing.clock_hz == 0 || timing.bitrate_hz == 0 || timing.prescaler == 0 ||
+      timing.tseg1 == 0 || timing.tseg2 == 0 || timing.sjw == 0)
+    return ProtocolError(error, phase, "timing values must be positive",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  if (timing.clock_hz != limits.clock_hz)
+    return ProtocolError(error, phase, "configured clock does not match device",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  if (timing.tseg1 < limits.tseg1_min || timing.tseg1 > limits.tseg1_max ||
+      timing.tseg2 < limits.tseg2_min || timing.tseg2 > limits.tseg2_max ||
+      timing.sjw > limits.sjw_max || timing.sjw > timing.tseg2 ||
+      timing.prescaler < limits.brp_min || timing.prescaler > limits.brp_max ||
+      ((timing.prescaler - limits.brp_min) % limits.brp_inc) != 0)
+    return ProtocolError(error, phase,
+                         "timing values are outside device limits",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  const uint64_t total_quanta = 1ULL + timing.tseg1 + timing.tseg2;
+  const uint64_t divisor =
+      static_cast<uint64_t>(timing.prescaler) * total_quanta;
+  const uint32_t actual = static_cast<uint32_t>(timing.clock_hz / divisor);
+  const uint64_t difference = actual > timing.bitrate_hz
+                                  ? actual - timing.bitrate_hz
+                                  : timing.bitrate_hz - actual;
+  if (actual == 0 || difference * 100ULL > timing.bitrate_hz)
+    return ProtocolError(error, phase,
+                         "timing calculates a bitrate outside 1% tolerance",
+                         VKGS_USB_STATUS_INVALID_ARGUMENT);
+  std::memset(applied, 0, sizeof(*applied));
+  applied->requested_bitrate_hz = timing.bitrate_hz;
+  applied->actual_bitrate_hz = actual;
+  applied->sample_point_permille =
+      static_cast<uint32_t>(((1ULL + timing.tseg1) * 1000ULL) / total_quanta);
+  applied->prescaler = timing.prescaler;
+  applied->tseg1 = timing.tseg1;
+  applied->tseg2 = timing.tseg2;
+  applied->sjw = timing.sjw;
+  applied->wire_prescaler = EncodeTimingRegister(timing.prescaler);
+  applied->wire_tseg1 = EncodeTimingRegister(timing.tseg1);
+  applied->wire_tseg2 = EncodeTimingRegister(timing.tseg2);
+  applied->wire_sjw = EncodeTimingRegister(timing.sjw);
+  return true;
+}
+
+bool SetTiming(vkgs_usb_device_t *device, uint8_t request,
+               const vkgs_usb_applied_timing_t &timing,
+               vkgs_usb_error_t *error) {
+  uint8_t payload[20]{};
+  /* prop_seg stays zero; the firmware uses phase_seg1 as the complete TSEG1. */
+  WriteLe32(payload + 4, timing.wire_tseg1);
+  WriteLe32(payload + 8, timing.wire_tseg2);
+  WriteLe32(payload + 12, timing.wire_sjw);
+  WriteLe32(payload + 16, timing.wire_prescaler);
+  return ControlSet(device, request, payload, sizeof(payload), error);
+}
+
+bool SetMode(vkgs_usb_device_t *device, uint32_t mode, uint32_t flags,
+             vkgs_usb_error_t *error) {
+  uint8_t payload[8]{};
+  WriteLe32(payload, mode);
+  WriteLe32(payload + 4, flags);
+  if (!ControlSet(device, kRequestMode, payload, sizeof(payload), error))
+    return false;
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  return true;
+}
+
+bool SetHostFormat(vkgs_usb_device_t *device, vkgs_usb_error_t *error) {
+  uint8_t payload[4]{};
+  WriteLe32(payload, 0x0000beefU);
+  return ControlSet(device, kRequestHostFormat, payload, sizeof(payload),
+                    error);
+}
+
+bool SetBusLoad(vkgs_usb_device_t *device, bool enabled,
+                vkgs_usb_error_t *error) {
+  uint8_t payload[4]{};
+  WriteLe32(payload, enabled ? 1U : 0U);
+  return ControlSet(device, kRequestBusLoad, payload, sizeof(payload), error);
+}
+
+bool SetTermination(vkgs_usb_device_t *device, bool enabled,
+                    vkgs_usb_error_t *error) {
+  uint8_t payload[4]{};
+  WriteLe32(payload, enabled ? 1U : 0U);
+  vkgs_usb_error_t primary_error{};
+  if (ControlSet(device, kRequestTermination, payload, sizeof(payload),
+                 &primary_error))
+    return true;
+  return ControlSet(device, kRequestFallbackSetTermination, payload,
+                    sizeof(payload), error);
+}
+
+uint8_t LengthToDlc(uint8_t length, bool fd) {
+  if (!fd)
+    return length;
+  for (uint8_t dlc = 0; dlc < 16; ++dlc) {
+    if (kDlcLengths[dlc] >= length)
+      return dlc;
+  }
+  return 0xff;
+}
+
+uint8_t DlcToLength(uint8_t dlc, bool fd) {
+  const uint8_t value = static_cast<uint8_t>(dlc & 0x0fU);
+  return fd ? kDlcLengths[value] : std::min<uint8_t>(value, 8);
+}
+
+bool AppendRecord(vkgs_usb_rx_batch_t *batch, vkgs_usb_rx_record_t **record,
+                  vkgs_usb_error_t *error) {
+  if (batch->count >= VKGS_USB_MAX_RX_RECORDS)
+    return ProtocolError(error, "VKGS decode", "receive batch is too large");
+  *record = &batch->records[batch->count++];
+  std::memset(*record, 0, sizeof(**record));
+  return true;
+}
+
+} // namespace

--- a/src/main/docan/vkgs_usb/api/vkgs_usb.h
+++ b/src/main/docan/vkgs_usb/api/vkgs_usb.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VKGS_USB_MAX_DEVICES 64
+#define VKGS_USB_PATH_CAPACITY 1024
+#define VKGS_USB_LABEL_CAPACITY 256
+#define VKGS_USB_OPERATION_CAPACITY 64
+#define VKGS_USB_MESSAGE_CAPACITY 512
+
+typedef enum {
+  VKGS_USB_STATUS_OK = 0,
+  VKGS_USB_STATUS_INVALID_ARGUMENT,
+  VKGS_USB_STATUS_SYSTEM_ERROR,
+  VKGS_USB_STATUS_NOT_OPEN,
+  VKGS_USB_STATUS_ENDPOINT_NOT_FOUND,
+  VKGS_USB_STATUS_SHORT_TRANSFER,
+  VKGS_USB_STATUS_TIMEOUT,
+  VKGS_USB_STATUS_CANCELLED,
+  VKGS_USB_STATUS_PROTOCOL_ERROR,
+  VKGS_USB_STATUS_UNSUPPORTED
+} vkgs_usb_status_t;
+
+typedef struct {
+  vkgs_usb_status_t status;
+  int32_t native_code;
+  char operation[VKGS_USB_OPERATION_CAPACITY];
+  char message[VKGS_USB_MESSAGE_CAPACITY];
+} vkgs_usb_error_t;
+
+typedef struct {
+  char path[VKGS_USB_PATH_CAPACITY];
+  char label[VKGS_USB_LABEL_CAPACITY];
+  uint8_t interface_number;
+  uint8_t endpoint_in;
+  uint8_t endpoint_out;
+  bool busy;
+} vkgs_usb_interface_t;
+
+typedef struct {
+  size_t count;
+  vkgs_usb_interface_t devices[VKGS_USB_MAX_DEVICES];
+} vkgs_usb_device_list_t;
+
+typedef struct vkgs_usb_device vkgs_usb_device_t;
+
+typedef struct {
+  uint32_t feature;
+  uint32_t clock_hz;
+  uint32_t tseg1_min;
+  uint32_t tseg1_max;
+  uint32_t tseg2_min;
+  uint32_t tseg2_max;
+  uint32_t sjw_max;
+  uint32_t brp_min;
+  uint32_t brp_max;
+  uint32_t brp_inc;
+} vkgs_usb_timing_limits_t;
+
+typedef struct {
+  vkgs_usb_timing_limits_t nominal;
+  vkgs_usb_timing_limits_t data;
+  bool has_data_timing;
+  bool fd_supported;
+  bool listen_only_supported;
+  bool termination_supported;
+} vkgs_usb_capabilities_t;
+
+typedef struct {
+  uint32_t software_version;
+  uint32_t hardware_version;
+  uint32_t uid[4];
+  uint32_t uuid[4];
+} vkgs_usb_device_info_t;
+
+/* All timing fields use human/EcuBus semantics. Unlike Candle/standard
+ * gs_usb, this hardware protocol ignores prop_seg and expects BRP, TSEG1,
+ * TSEG2 and SJW as zero-based register values. This API performs that single
+ * conversion; callers must never pre-decrement the values. */
+typedef struct {
+  uint32_t clock_hz;
+  uint32_t bitrate_hz;
+  uint32_t prescaler;
+  uint32_t tseg1;
+  uint32_t tseg2;
+  uint32_t sjw;
+} vkgs_usb_timing_t;
+
+typedef struct {
+  uint32_t requested_bitrate_hz;
+  /* Calculated from the validated semantic values. The current firmware
+   * protocol does not provide an applied-timing register readback. */
+  uint32_t actual_bitrate_hz;
+  uint32_t sample_point_permille;
+  uint32_t prescaler;
+  uint32_t tseg1;
+  uint32_t tseg2;
+  uint32_t sjw;
+  uint32_t wire_prescaler;
+  uint32_t wire_tseg1;
+  uint32_t wire_tseg2;
+  uint32_t wire_sjw;
+} vkgs_usb_applied_timing_t;
+
+typedef struct {
+  vkgs_usb_timing_t nominal;
+  vkgs_usb_timing_t data;
+  bool fd;
+  bool listen_only;
+  bool termination;
+} vkgs_usb_config_t;
+
+typedef struct {
+  vkgs_usb_applied_timing_t nominal;
+  vkgs_usb_applied_timing_t data;
+  bool has_data_timing;
+  bool hardware_timestamps;
+} vkgs_usb_applied_config_t;
+
+#define VKGS_USB_MAX_FRAME_DATA 64
+#define VKGS_USB_MAX_WIRE_FRAME 84
+#define VKGS_USB_MAX_RX_RECORDS 64
+
+typedef struct {
+  uint32_t id;
+  uint8_t data[VKGS_USB_MAX_FRAME_DATA];
+  uint8_t length;
+  bool fd;
+  bool brs;
+  bool extended;
+  bool remote;
+  bool overflow;
+  bool esi;
+  bool error;
+  uint64_t timestamp_us;
+} vkgs_usb_frame_t;
+
+typedef enum {
+  VKGS_USB_RX_FRAME = 1,
+  VKGS_USB_RX_STATE,
+  VKGS_USB_RX_BUS_ERROR
+} vkgs_usb_rx_kind_t;
+
+typedef struct {
+  vkgs_usb_rx_kind_t kind;
+  vkgs_usb_frame_t frame;
+  uint32_t state;
+  uint32_t rx_error_count;
+  uint32_t tx_error_count;
+  uint64_t timestamp_us;
+  uint8_t error_flag;
+  uint8_t error_code;
+  uint8_t error_logging_count;
+} vkgs_usb_rx_record_t;
+
+typedef struct {
+  size_t count;
+  vkgs_usb_rx_record_t records[VKGS_USB_MAX_RX_RECORDS];
+} vkgs_usb_rx_batch_t;
+
+void vkgs_usb_error_clear(vkgs_usb_error_t *error);
+
+bool vkgs_usb_list_scan(vkgs_usb_device_list_t *list, vkgs_usb_error_t *error);
+
+void vkgs_usb_fallback_capabilities(vkgs_usb_capabilities_t *capabilities);
+
+vkgs_usb_device_t *vkgs_usb_open(const char *path, vkgs_usb_error_t *error);
+
+uint8_t vkgs_usb_interface_number(const vkgs_usb_device_t *device);
+
+bool vkgs_usb_get_capabilities(vkgs_usb_device_t *device,
+                               vkgs_usb_capabilities_t *capabilities,
+                               vkgs_usb_error_t *error);
+
+bool vkgs_usb_get_device_info(vkgs_usb_device_t *device,
+                              vkgs_usb_device_info_t *info,
+                              vkgs_usb_error_t *error);
+
+bool vkgs_usb_get_termination(vkgs_usb_device_t *device, bool *enabled,
+                              vkgs_usb_error_t *error);
+
+bool vkgs_usb_configure(vkgs_usb_device_t *device,
+                        const vkgs_usb_config_t *config,
+                        vkgs_usb_applied_config_t *applied,
+                        vkgs_usb_error_t *error);
+
+bool vkgs_usb_stop(vkgs_usb_device_t *device, vkgs_usb_error_t *error);
+
+bool vkgs_usb_encode_frame(vkgs_usb_device_t *device,
+                           const vkgs_usb_frame_t *frame, uint8_t *wire,
+                           size_t capacity, size_t *wire_length,
+                           uint8_t *normalized_length, vkgs_usb_error_t *error);
+
+bool vkgs_usb_decode(vkgs_usb_device_t *device, const uint8_t *wire,
+                     size_t wire_length, vkgs_usb_rx_batch_t *batch,
+                     vkgs_usb_error_t *error);
+
+void vkgs_usb_decoder_reset(vkgs_usb_device_t *device);
+
+bool vkgs_usb_control_in(vkgs_usb_device_t *device, uint8_t request_type,
+                         uint8_t request, uint16_t value, uint16_t index,
+                         uint8_t *data, uint16_t length, uint32_t timeout_ms,
+                         vkgs_usb_error_t *error);
+
+bool vkgs_usb_control_out(vkgs_usb_device_t *device, uint8_t request_type,
+                          uint8_t request, uint16_t value, uint16_t index,
+                          const uint8_t *data, uint16_t length,
+                          uint32_t timeout_ms, vkgs_usb_error_t *error);
+
+bool vkgs_usb_bulk_read(vkgs_usb_device_t *device, uint8_t *data,
+                        size_t capacity, size_t *transferred,
+                        uint32_t poll_timeout_ms, vkgs_usb_error_t *error);
+
+bool vkgs_usb_bulk_write(vkgs_usb_device_t *device, const uint8_t *data,
+                         size_t length, size_t *transferred,
+                         uint32_t timeout_ms, vkgs_usb_error_t *error);
+
+void vkgs_usb_cancel(vkgs_usb_device_t *device);
+
+void vkgs_usb_close(vkgs_usb_device_t *device);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/main/docan/vkgs_usb/binding.gyp
+++ b/src/main/docan/vkgs_usb/binding.gyp
@@ -1,0 +1,47 @@
+{
+  'variables': {
+    'use_udev%': 0
+  },
+  'targets': [
+    {
+      'target_name': 'vkgs_usb',
+      'include_dirs': [
+        './api',
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      'dependencies': [
+        "<!(node -p \"require('node-addon-api').gyp\")",
+        '../../../../node_modules/usb/libusb.gypi:libusb'
+      ],
+      'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
+      'sources': [
+        './native/addon.cpp',
+        './api/vkgs_usb.cpp'
+      ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'cflags': [ '-fexceptions' ],
+      'cflags_cc': [ '-fexceptions' ],
+      'conditions': [
+        ['OS=="win"', {
+          'defines': [ 'WIN32_LEAN_AND_MEAN' ],
+          'libraries': [ 'cfgmgr32.lib' ],
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 }
+          }
+        }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'OTHER_LDFLAGS': [
+              '-framework', 'CoreFoundation',
+              '-framework', 'IOKit',
+              '-framework', 'Security'
+            ]
+          }
+        }]
+      ]
+    }
+  ]
+}

--- a/src/main/docan/vkgs_usb/devicePath.ts
+++ b/src/main/docan/vkgs_usb/devicePath.ts
@@ -1,0 +1,106 @@
+export interface VkgsUsbPathCandidate {
+  path: string
+  interfaceNumber: number
+  identitySelector?: string
+}
+
+const CURRENT_PATH_PREFIX = 'libusb://1d50:606f/'
+const LEGACY_DEVICE_ID = 'vid_1d50&pid_606f'
+const IDENTITY_PATH_PREFIX = 'vkgs-usb://'
+
+/**
+ * Resolves handles saved by the former WinUSB backend without coupling the
+ * driver to a platform API. A legacy handle is migrated only when its channel
+ * identifies exactly one currently connected libusb interface.
+ */
+export function resolveVkgsUsbPath(
+  path: string,
+  channel: number,
+  listDevices: () => readonly VkgsUsbPathCandidate[]
+): string {
+  const normalizedPath = path.toLowerCase()
+  if (normalizedPath.startsWith(CURRENT_PATH_PREFIX)) {
+    let devices: readonly VkgsUsbPathCandidate[]
+    try {
+      devices = listDevices()
+    } catch (error) {
+      throw new Error(
+        `Unable to validate the stored VKGS USB path: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+
+    const exactMatches = devices.filter(
+      (device) => device.interfaceNumber === channel && device.path.toLowerCase() === normalizedPath
+    )
+    if (exactMatches.length === 1) return exactMatches[0].path
+    if (exactMatches.length > 1) {
+      throw new Error(`Multiple VKGS USB interfaces report the stored path ${path}.`)
+    }
+
+    // A libusb topology path can change after firmware personality switching,
+    // reconnecting through another hub port, or USB re-enumeration. Existing
+    // projects may still contain such a pre-identity handle. Migrate it only
+    // when the channel identifies exactly one connected interface.
+    const channelMatches = devices.filter((device) => device.interfaceNumber === channel)
+    if (channelMatches.length === 1) return channelMatches[0].path
+    if (channelMatches.length === 0) {
+      throw new Error(
+        `The stored VKGS USB path ${path} is no longer connected, and channel ${channel} is unavailable. Reconnect the device and refresh Hardware.`
+      )
+    }
+    throw new Error(
+      `The stored VKGS USB path ${path} is no longer valid and multiple channel ${channel} interfaces are connected. Reselect the intended device in Hardware.`
+    )
+  }
+  if (normalizedPath.startsWith(IDENTITY_PATH_PREFIX)) {
+    let matches: readonly VkgsUsbPathCandidate[]
+    try {
+      matches = listDevices().filter(
+        (device) =>
+          device.interfaceNumber === channel &&
+          device.identitySelector?.toLowerCase() === path.toLowerCase()
+      )
+    } catch (error) {
+      throw new Error(
+        `Unable to resolve the stored VKGS USB hardware identity: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+
+    if (matches.length === 1) return matches[0].path
+    if (matches.length === 0) {
+      throw new Error(
+        `VKGS USB device ${path} channel ${channel} is not connected or its hardware identity is unavailable.`
+      )
+    }
+    throw new Error(
+      `Multiple VKGS USB devices report ${path} channel ${channel}; refusing an ambiguous device selection.`
+    )
+  }
+  if (!normalizedPath.includes(LEGACY_DEVICE_ID)) return path
+
+  let matches: readonly VkgsUsbPathCandidate[]
+  try {
+    matches = listDevices().filter((device) => device.interfaceNumber === channel)
+  } catch (error) {
+    throw new Error(
+      `Unable to migrate the stored VKGS USB device path: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+
+  if (matches.length === 1) return matches[0].path
+  if (matches.length === 0) {
+    throw new Error(
+      `The stored VKGS USB device path uses the legacy WinUSB format, but channel ${channel} is not connected. Reconnect the device and reselect it in Hardware.`
+    )
+  }
+
+  throw new Error(
+    `The stored VKGS USB device path matches multiple channel ${channel} interfaces. Reselect the intended device in Hardware.`
+  )
+}

--- a/src/main/docan/vkgs_usb/identity.ts
+++ b/src/main/docan/vkgs_usb/identity.ts
@@ -1,0 +1,47 @@
+export interface VkgsUsbIdentitySource {
+  uid: readonly number[]
+  uuid: readonly number[]
+}
+
+export interface VkgsUsbIdentity {
+  kind: 'uuid' | 'uid'
+  value: string
+}
+
+const WORD_COUNT = 4
+const INVALID_WORD = 0xffffffff
+const SELECTOR_PREFIX = 'vkgs-usb://'
+
+function formatWords(words: readonly number[]): string | undefined {
+  if (
+    words.length !== WORD_COUNT ||
+    words.some((word) => !Number.isInteger(word) || word < 0 || word > INVALID_WORD) ||
+    words.every((word) => word === 0) ||
+    words.every((word) => word === INVALID_WORD)
+  ) {
+    return undefined
+  }
+  return words.map((word) => word.toString(16).padStart(8, '0')).join('')
+}
+
+/** Returns the immutable OTP identity exposed by the VKGS USB firmware. */
+export function getVkgsUsbIdentity(source: VkgsUsbIdentitySource): VkgsUsbIdentity | undefined {
+  const uuid = formatWords(source.uuid)
+  if (uuid) return { kind: 'uuid', value: uuid }
+
+  const uid = formatWords(source.uid)
+  if (uid) return { kind: 'uid', value: uid }
+  return undefined
+}
+
+export function makeVkgsUsbIdentitySelector(identity: VkgsUsbIdentity): string {
+  return `${SELECTOR_PREFIX}${identity.kind}/${identity.value}`
+}
+
+export function isVkgsUsbIdentitySelector(value: string): boolean {
+  return /^vkgs-usb:\/\/(?:uuid|uid)\/[0-9a-f]{32}$/i.test(value)
+}
+
+export function formatVkgsUsbSerialNumber(identity: VkgsUsbIdentity): string {
+  return `${identity.kind.toUpperCase()}:${identity.value}`
+}

--- a/src/main/docan/vkgs_usb/index.ts
+++ b/src/main/docan/vkgs_usb/index.ts
@@ -1,0 +1,648 @@
+import { EventEmitter } from 'events'
+import { cloneDeep } from 'lodash'
+import {
+  CAN_ERROR_ID,
+  CAN_ID_TYPE,
+  CanBaseInfo,
+  CanDevice,
+  CanError,
+  CanMessage,
+  CanMsgType,
+  getTsUs
+} from '../../share/can'
+import { CanLOG } from '../../log'
+import { CanBase } from '../base'
+import { resolveVkgsUsbPath, VkgsUsbPathCandidate } from './devicePath'
+import {
+  formatVkgsUsbSerialNumber,
+  getVkgsUsbIdentity,
+  isVkgsUsbIdentitySelector,
+  makeVkgsUsbIdentitySelector,
+  VkgsUsbIdentity
+} from './identity'
+import {
+  NativeTransportError,
+  VkgsUsbAppliedTiming,
+  VkgsUsbCapabilities,
+  VkgsUsbDeviceInfo,
+  VkgsUsbFrame,
+  VkgsUsbNative,
+  VkgsUsbRxRecord
+} from './native'
+
+interface PendingTransmit {
+  resolve: (timestamp: number) => void
+  reject: (error: CanError) => void
+  id: number
+  msgType: CanMsgType
+  data: Buffer
+  extra?: { database?: string; name?: string }
+}
+
+interface PendingRead {
+  reject: (error: CanError) => void
+  msgType: CanMsgType
+  eventName: string
+  listener: (message: CanMessage | CanError) => void
+  timer: NodeJS.Timeout
+}
+
+const STATE_NAMES = [
+  'error-active',
+  'error-warning',
+  'error-passive',
+  'bus-off',
+  'stopped',
+  'sleeping'
+]
+
+const ERROR_NAMES = ['none', 'stuff', 'form', 'ack', 'bit1', 'bit0', 'crc', 'no-change']
+const identityByPhysicalPath = new Map<string, VkgsUsbIdentity>()
+
+function splitHandle(handle: unknown): { path: string; channel: number } {
+  const value = String(handle)
+  const separator = value.lastIndexOf('|')
+  if (separator <= 0) throw new Error('invalid VKGS USB handle')
+  const channel = Number(value.slice(separator + 1))
+  if (!Number.isInteger(channel) || channel < 0 || channel > 255) {
+    throw new Error(`invalid VKGS USB channel in handle: ${value}`)
+  }
+  return { path: value.slice(0, separator), channel }
+}
+
+function formatVersion(version: number) {
+  return `${(version >>> 24) & 0xff}.${(version >>> 16) & 0xff}.${
+    (version >>> 8) & 0xff
+  }.${version & 0xff}`
+}
+
+function physicalPath(path: string) {
+  const separator = path.lastIndexOf('/')
+  return separator > 0 ? path.slice(0, separator) : path
+}
+
+function rememberIdentity(path: string, deviceInfo: VkgsUsbDeviceInfo) {
+  const identity = getVkgsUsbIdentity(deviceInfo)
+  if (identity) identityByPhysicalPath.set(physicalPath(path), identity)
+  return identity
+}
+
+function probeIdentity(path: string, channel: number): VkgsUsbIdentity | undefined {
+  let native: VkgsUsbNative | undefined
+  try {
+    native = VkgsUsbNative.open(
+      path,
+      () => {},
+      () => {},
+      () => {}
+    )
+    if (native.interfaceNumber !== channel) return undefined
+    return rememberIdentity(path, native.readDeviceInfo())
+  } catch {
+    return undefined
+  } finally {
+    native?.close()
+  }
+}
+
+function listIdentityCandidates(): VkgsUsbPathCandidate[] {
+  const probed = new Set<string>()
+  return VkgsUsbNative.listDevices().map((item) => {
+    const key = physicalPath(item.path)
+    let identity = identityByPhysicalPath.get(key)
+    if (!identity && !item.busy && !probed.has(key)) {
+      probed.add(key)
+      identity = probeIdentity(item.path, item.interfaceNumber)
+    }
+    return {
+      path: item.path,
+      interfaceNumber: item.interfaceNumber,
+      identitySelector: identity ? makeVkgsUsbIdentitySelector(identity) : undefined
+    }
+  })
+}
+
+function formatTiming(name: string, timing: VkgsUsbAppliedTiming) {
+  const samplePoint = (timing.samplePointPermille / 10).toFixed(1)
+  return `${name} requested ${timing.requestedBitrate}, calculated ${timing.actualBitrate} bit/s (BRP ${timing.prescaler}, TSEG1 ${timing.tseg1}, TSEG2 ${timing.tseg2}, SJW ${timing.sjw}, sample ${samplePoint}%; USB zero-based fields ${timing.wirePrescaler}/${timing.wireTseg1}/${timing.wireTseg2}/${timing.wireSjw})`
+}
+
+function makeExtra(capabilities: VkgsUsbCapabilities, termination?: boolean) {
+  return {
+    candle: {
+      cap: capabilities.nominal,
+      dataCap: capabilities.data,
+      fdSupported: capabilities.fdSupported,
+      Res: capabilities.terminationSupported || termination !== undefined,
+      // The same HPMicro MCAN data path is stable at 1M/2M BRS with 20 TQ.
+      // This affects only automatic UI selection; saved timing stays untouched.
+      preferredDataTimeQuanta: 20
+    }
+  }
+}
+
+function getVkgsUsbDevices(): CanDevice[] {
+  const interfaces = VkgsUsbNative.listDevices()
+  const probedIdentities = new Set<string>()
+  for (const item of interfaces) {
+    const key = physicalPath(item.path)
+    if (item.busy || probedIdentities.has(key)) continue
+    probedIdentities.add(key)
+    if (!probeIdentity(item.path, item.interfaceNumber)) {
+      identityByPhysicalPath.delete(key)
+      sysLog.warn(
+        `vkgs_usb hardware identity is unavailable on channel ${item.interfaceNumber}; falling back to the transient USB path`
+      )
+    }
+  }
+
+  return interfaces.map((item, index) => {
+    let capabilities = VkgsUsbNative.fallbackCapabilities()
+    const physicalDevicePath = physicalPath(item.path)
+    let identity = identityByPhysicalPath.get(physicalDevicePath)
+    let termination: boolean | undefined
+    let busy = item.busy
+
+    if (!busy) {
+      let native: VkgsUsbNative | undefined
+      try {
+        native = VkgsUsbNative.open(
+          item.path,
+          () => {},
+          () => {},
+          () => {}
+        )
+        capabilities = native.readCapabilities()
+        identity = identityByPhysicalPath.get(physicalDevicePath)
+        try {
+          termination = native.getTermination()
+        } catch (error) {
+          sysLog.warn(
+            `vkgs_usb termination query is unavailable on channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      } catch (error) {
+        busy = true
+        sysLog.warn(
+          `vkgs_usb probe failed for channel ${item.interfaceNumber}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      } finally {
+        native?.close()
+      }
+    }
+
+    const identitySelector = identity ? makeVkgsUsbIdentitySelector(identity) : undefined
+
+    return {
+      label: `${item.label} CH${item.interfaceNumber}`,
+      id: identity
+        ? `vkgs_usb-${identity.kind}-${identity.value}-ch${item.interfaceNumber}`
+        : `vkgs_usb-${index}-ch${item.interfaceNumber}`,
+      handle: `${identitySelector ?? item.path}|${item.interfaceNumber}`,
+      serialNumber: identity ? formatVkgsUsbSerialNumber(identity) : undefined,
+      busy,
+      extra: makeExtra(capabilities, termination)
+    }
+  })
+}
+
+export class VKGS_USB_CAN extends CanBase {
+  readonly event = new EventEmitter()
+  readonly info: CanBaseInfo
+  readonly log: CanLOG
+  closed = false
+
+  private readonly native: VkgsUsbNative
+  private readonly startTime = getTsUs()
+  private timestampOffset?: number
+  private nextToken = 1
+  private nextRead = 1
+  private lastState = -1
+  private fatalTransportError = false
+  private readonly pendingTransmits = new Map<number, PendingTransmit>()
+  private readonly pendingReads = new Map<number, PendingRead>()
+
+  constructor(info: CanBaseInfo) {
+    super()
+    this.info = cloneDeep(info)
+    const { path: storedPath, channel } = splitHandle(info.handle)
+    const identitySelected = isVkgsUsbIdentitySelector(storedPath)
+    const path = resolveVkgsUsbPath(storedPath, channel, listIdentityCandidates)
+    this.info.handle = `${identitySelected ? storedPath : path}|${channel}`
+    this.native = VkgsUsbNative.open(
+      path,
+      (records) => this.receive(records),
+      (error) => this.transportError(error),
+      (result) => this.transmitComplete(result)
+    )
+    try {
+      if (this.native.interfaceNumber !== channel) {
+        throw new Error(
+          `VKGS USB interface mismatch: selected channel ${channel}, opened ${this.native.interfaceNumber}`
+        )
+      }
+      this.log = new CanLOG('VKGS_USB', info.name, info.id, this.event)
+    } catch (error) {
+      this.native.close()
+      throw error
+    }
+    try {
+      const capabilities = this.native.readCapabilities()
+      this.validateTiming(info, capabilities)
+      try {
+        const deviceInfo = this.native.readDeviceInfo()
+        const identity = rememberIdentity(path, deviceInfo)
+        if (
+          identitySelected &&
+          (!identity ||
+            makeVkgsUsbIdentitySelector(identity).toLowerCase() !== storedPath.toLowerCase())
+        ) {
+          throw new Error(
+            `VKGS USB hardware identity changed while opening ${storedPath}; refusing to configure a different adapter.`
+          )
+        }
+        sysLog.info(
+          `vkgs_usb ${info.name}: SW ${formatVersion(deviceInfo.swVersion)}, HW ${formatVersion(deviceInfo.hwVersion)}, ${identity ? formatVkgsUsbSerialNumber(identity) : 'identity unavailable'}, channel ${channel}`
+        )
+      } catch (error) {
+        if (identitySelected) throw error
+        sysLog.warn(
+          `vkgs_usb ${info.name}: device-info query unavailable: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+      // Arm bulk IN before the first configuration write so startup state/error
+      // events cannot race receiver registration.
+      this.native.startReceive()
+      const applied = this.native.configure(info, !!info.candleRes)
+      const timing = [formatTiming('nominal', applied.nominal)]
+      if (applied.data) timing.push(formatTiming('data', applied.data))
+      sysLog.info(`vkgs_usb ${info.name}: timing validated and sent: ${timing.join('; ')}`)
+      this.attachCanMessage(this.busloadCb)
+    } catch (error) {
+      try {
+        this.native.stop()
+      } catch {
+        // Preserve the original configuration/open error.
+      }
+      this.native.close()
+      this.log.close()
+      throw error
+    }
+  }
+
+  private validateTiming(info: CanBaseInfo, capabilities: VkgsUsbCapabilities) {
+    const validate = (
+      name: string,
+      timing: CanBaseInfo['bitrate'],
+      cap: typeof capabilities.nominal
+    ) => {
+      const timingValues = [
+        timing.freq,
+        timing.preScaler,
+        timing.timeSeg1,
+        timing.timeSeg2,
+        timing.sjw
+      ]
+      if (timingValues.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+        throw new Error(`${name} timing values must be positive integers`)
+      }
+      const clockMHz = Number(timing.clock)
+      if (!Number.isFinite(clockMHz) || clockMHz <= 0) {
+        throw new Error(`${name} clock must be a positive number`)
+      }
+      const clock = clockMHz * 1_000_000
+      const calculated = Math.floor(
+        clock / (timing.preScaler * (1 + timing.timeSeg1 + timing.timeSeg2))
+      )
+      if (clock !== cap.fclk_can) {
+        throw new Error(`${name} clock must be ${cap.fclk_can / 1_000_000} MHz`)
+      }
+      if (Math.abs(calculated - timing.freq) / timing.freq > 0.01) {
+        throw new Error(`${name} timing calculates ${calculated} Hz, expected ${timing.freq} Hz`)
+      }
+      if (timing.timeSeg1 < cap.tseg1_min || timing.timeSeg1 > cap.tseg1_max) {
+        throw new Error(`${name} timeSeg1 is outside ${cap.tseg1_min}..${cap.tseg1_max}`)
+      }
+      if (timing.timeSeg2 < cap.tseg2_min || timing.timeSeg2 > cap.tseg2_max) {
+        throw new Error(`${name} timeSeg2 is outside ${cap.tseg2_min}..${cap.tseg2_max}`)
+      }
+      if (timing.sjw < 1 || timing.sjw > cap.sjw_max) {
+        throw new Error(`${name} sjw is outside 1..${cap.sjw_max}`)
+      }
+      if (timing.sjw > timing.timeSeg2) {
+        throw new Error(`${name} sjw must not exceed timeSeg2`)
+      }
+      if (timing.preScaler < cap.brp_min || timing.preScaler > cap.brp_max) {
+        throw new Error(`${name} prescaler is outside ${cap.brp_min}..${cap.brp_max}`)
+      }
+      if ((timing.preScaler - cap.brp_min) % Math.max(1, cap.brp_inc) !== 0) {
+        throw new Error(`${name} prescaler does not match the device increment ${cap.brp_inc}`)
+      }
+    }
+
+    validate('CAN', info.bitrate, capabilities.nominal)
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('CAN FD data timing is required')
+      validate('CAN FD', info.bitratefd, capabilities.data || capabilities.nominal)
+    }
+  }
+
+  private receive(records: VkgsUsbRxRecord[]) {
+    if (this.closed) return
+    for (const record of records) {
+      if (record.kind === 'frame') this.handleFrame(record)
+      else this.handleWireEvent(record)
+    }
+  }
+
+  private relativeTimestamp(deviceTimestampUs: number) {
+    const hostTimestamp = getTsUs() - this.startTime
+    if (!Number.isSafeInteger(deviceTimestampUs) || deviceTimestampUs <= 0) return hostTimestamp
+    if (this.timestampOffset === undefined) {
+      this.timestampOffset = deviceTimestampUs - hostTimestamp
+    }
+    const timestamp = deviceTimestampUs - this.timestampOffset
+    if (timestamp >= 0) return timestamp
+    this.timestampOffset = deviceTimestampUs - hostTimestamp
+    return hostTimestamp
+  }
+
+  private handleFrame(frame: VkgsUsbFrame) {
+    const timestamp = this.relativeTimestamp(frame.timestampUs)
+    if (frame.overflow) {
+      this.log.error(
+        timestamp,
+        `CAN receive overflow reported with frame 0x${frame.id.toString(16)}`
+      )
+    }
+    const msgType: CanMsgType = {
+      idType: frame.extended ? CAN_ID_TYPE.EXTENDED : CAN_ID_TYPE.STANDARD,
+      canfd: frame.fd,
+      brs: frame.brs,
+      remote: frame.remote
+    }
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'IN',
+      id: frame.id,
+      data: frame.remote ? Buffer.alloc(0) : frame.data,
+      ts: timestamp,
+      msgType,
+      database: this.info.database
+    }
+    this.log.canBase(message)
+    this.event.emit(this.getReadBaseId(frame.id, msgType), message)
+  }
+
+  private handleWireEvent(event: Exclude<VkgsUsbRxRecord, VkgsUsbFrame>) {
+    if (event.kind === 'state') {
+      const timestamp = this.relativeTimestamp(event.timestampUs)
+      if (event.state === this.lastState) return
+      this.lastState = event.state
+      if (event.state !== 0) {
+        this.log.error(
+          timestamp,
+          `CAN state ${STATE_NAMES[event.state] || event.state}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}`
+        )
+      }
+      return
+    }
+    if (event.errorCode !== 0) {
+      this.log.error(
+        getTsUs() - this.startTime,
+        `CAN bus error ${ERROR_NAMES[event.errorCode] || event.errorCode}, flags:0x${event.errorFlag.toString(16)}, RX_ERR_CNT:${event.rxErrorCount} TX_ERR_CNT:${event.txErrorCount}, LOG_CNT:${event.errorLoggingCount}`
+      )
+    }
+  }
+
+  private transmitComplete(result: { token: number; ok: boolean; error?: string }) {
+    const pending = this.pendingTransmits.get(result.token)
+    if (!pending) return
+    this.pendingTransmits.delete(result.token)
+    if (!result.ok) {
+      pending.reject(
+        new CanError(CAN_ERROR_ID.CAN_INTERNAL_ERROR, pending.msgType, pending.data, result.error)
+      )
+      return
+    }
+    const timestamp = getTsUs() - this.startTime
+    const message: CanMessage = {
+      device: this.info.name,
+      dir: 'OUT',
+      id: pending.id,
+      data: pending.data,
+      ts: timestamp,
+      msgType: pending.msgType,
+      database: pending.extra?.database,
+      name: pending.extra?.name
+    }
+    this.log.canBase(message)
+    pending.resolve(timestamp)
+  }
+
+  private transportError(error: NativeTransportError) {
+    if (this.closed) return
+    if (!error.fatal) {
+      this.log.error(getTsUs() - this.startTime, error.message)
+      return
+    }
+    this.fatalTransportError = true
+    this.log.error(getTsUs() - this.startTime, error.message)
+    this.rejectAll(CAN_ERROR_ID.CAN_INTERNAL_ERROR, error)
+    setImmediate(() => this.close())
+  }
+
+  private rejectAll(errorId: CAN_ERROR_ID, cause?: unknown) {
+    for (const pending of this.pendingTransmits.values()) {
+      pending.reject(
+        new CanError(
+          errorId,
+          pending.msgType,
+          pending.data,
+          cause instanceof Error ? cause.message : cause === undefined ? undefined : String(cause)
+        )
+      )
+    }
+    this.pendingTransmits.clear()
+    for (const pending of this.pendingReads.values()) {
+      clearTimeout(pending.timer)
+      this.event.off(pending.eventName, pending.listener)
+      pending.reject(new CanError(errorId, pending.msgType))
+    }
+    this.pendingReads.clear()
+  }
+
+  setOption(cmd: string, value: unknown): unknown {
+    return this._setOption(cmd, value)
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    this.rejectAll(CAN_ERROR_ID.CAN_BUS_CLOSED)
+    if (!this.fatalTransportError) {
+      try {
+        this.native.stop()
+      } catch (error) {
+        sysLog.warn(
+          `vkgs_usb stop failed: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    this.native.close()
+    this.detachCanMessage(this.busloadCb)
+    this.log.close()
+    this._close()
+  }
+
+  private validateMessage(id: number, msgType: CanMsgType): string | undefined {
+    if (msgType.idType !== CAN_ID_TYPE.STANDARD && msgType.idType !== CAN_ID_TYPE.EXTENDED) {
+      return 'CAN ID type is invalid'
+    }
+    const maximumId = msgType.idType === CAN_ID_TYPE.EXTENDED ? 0x1fffffff : 0x7ff
+    if (!Number.isInteger(id) || id < 0 || id > maximumId) {
+      return `CAN identifier must be an integer in 0..0x${maximumId.toString(16)}`
+    }
+    if (msgType.canfd && !this.info.canfd) {
+      return 'CAN FD frame requested while the channel is configured for classic CAN'
+    }
+    if (msgType.canfd && msgType.remote) return 'CAN FD does not support remote frames'
+    return undefined
+  }
+
+  writeBase(
+    id: number,
+    msgType: CanMsgType,
+    data: Buffer,
+    extra?: { database?: string; name?: string }
+  ): Promise<number> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType, data))
+    }
+    const parameterError = this.validateMessage(id, msgType)
+    if (parameterError) {
+      return Promise.reject(
+        new CanError(CAN_ERROR_ID.CAN_PARAM_ERROR, msgType, data, parameterError)
+      )
+    }
+    if (this.info.silent) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_DRIVER_SILENT, msgType, data))
+    }
+
+    const effectiveMsgType: CanMsgType = {
+      ...msgType,
+      // Normalize a disabled-but-retained EcuBus BRS value at the driver edge.
+      brs: msgType.canfd && msgType.brs
+    }
+
+    const token = this.nextTransmitToken()
+    let normalized: Buffer | undefined
+    try {
+      normalized = this.native.writeFrame(
+        {
+          id,
+          data,
+          fd: effectiveMsgType.canfd,
+          brs: effectiveMsgType.brs,
+          extended: effectiveMsgType.idType === CAN_ID_TYPE.EXTENDED,
+          remote: effectiveMsgType.remote
+        },
+        token,
+        5,
+        10
+      )
+    } catch (error) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          effectiveMsgType,
+          data,
+          error instanceof Error ? error.message : String(error)
+        )
+      )
+    }
+    if (!normalized) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_INTERNAL_ERROR,
+          effectiveMsgType,
+          data,
+          'VKGS USB transmit queue is full'
+        )
+      )
+    }
+    return new Promise<number>((resolve, reject) => {
+      this.pendingTransmits.set(token, {
+        resolve,
+        reject,
+        id,
+        msgType: effectiveMsgType,
+        data: normalized,
+        extra
+      })
+    })
+  }
+
+  private nextTransmitToken() {
+    while (this.pendingTransmits.has(this.nextToken)) {
+      this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    }
+    const token = this.nextToken
+    this.nextToken = this.nextToken === 0xffffffff ? 1 : this.nextToken + 1
+    return token
+  }
+
+  readBase(
+    id: number,
+    msgType: CanMsgType,
+    timeout: number
+  ): Promise<{ data: Buffer; ts: number }> {
+    if (this.closed) {
+      return Promise.reject(new CanError(CAN_ERROR_ID.CAN_BUS_CLOSED, msgType))
+    }
+    const parameterError = this.validateMessage(id, msgType)
+    if (parameterError || !Number.isFinite(timeout) || timeout < 0) {
+      return Promise.reject(
+        new CanError(
+          CAN_ERROR_ID.CAN_PARAM_ERROR,
+          msgType,
+          undefined,
+          parameterError || 'CAN read timeout must be a non-negative finite number'
+        )
+      )
+    }
+    const eventName = this.getReadBaseId(id, msgType)
+    const readId = this.nextRead++
+    return new Promise((resolve, reject) => {
+      const listener = (value: CanMessage | CanError) => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        clearTimeout(pending.timer)
+        this.pendingReads.delete(readId)
+        if (value instanceof CanError) reject(value)
+        else resolve({ data: value.data, ts: value.ts! })
+      }
+      const timer = setTimeout(() => {
+        const pending = this.pendingReads.get(readId)
+        if (!pending) return
+        this.pendingReads.delete(readId)
+        this.event.off(eventName, listener)
+        reject(new CanError(CAN_ERROR_ID.CAN_READ_TIMEOUT, msgType))
+      }, timeout)
+      this.pendingReads.set(readId, { reject, msgType, eventName, listener, timer })
+      this.event.once(eventName, listener)
+    })
+  }
+
+  getReadBaseId(id: number, msgType: CanMsgType): string {
+    return `${id}-${msgType.canfd ? msgType.brs : false}-${msgType.remote}-${msgType.canfd}-${msgType.idType}`
+  }
+
+  static override getValidDevices(): CanDevice[] {
+    return getVkgsUsbDevices()
+  }
+
+  static override getLibVersion(): string {
+    return '1.0.0 (libusb)'
+  }
+}

--- a/src/main/docan/vkgs_usb/native.ts
+++ b/src/main/docan/vkgs_usb/native.ts
@@ -1,0 +1,249 @@
+import { CanBaseInfo, CandleCapability } from '../../share/can'
+import NativeVkgsUsb from './build/Release/vkgs_usb.node'
+
+export interface NativeUsbInterface {
+  path: string
+  label: string
+  interfaceNumber: number
+  endpointIn: number
+  endpointOut: number
+  busy: boolean
+}
+
+export interface VkgsUsbDeviceInfo {
+  swVersion: number
+  hwVersion: number
+  uid: number[]
+  uuid: number[]
+}
+
+export interface VkgsUsbCapabilities {
+  nominal: CandleCapability
+  data?: CandleCapability
+  fdSupported: boolean
+  listenOnlySupported: boolean
+  terminationSupported: boolean
+}
+
+export interface VkgsUsbAppliedTiming {
+  requestedBitrate: number
+  actualBitrate: number
+  samplePointPermille: number
+  prescaler: number
+  tseg1: number
+  tseg2: number
+  sjw: number
+  wirePrescaler: number
+  wireTseg1: number
+  wireTseg2: number
+  wireSjw: number
+}
+
+export interface VkgsUsbAppliedConfig {
+  nominal: VkgsUsbAppliedTiming
+  data?: VkgsUsbAppliedTiming
+  hardwareTimestamps: boolean
+}
+
+export interface VkgsUsbFrame {
+  kind: 'frame'
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+  timestampUs: number
+  overflow: boolean
+  esi: boolean
+  error: boolean
+}
+
+export interface VkgsUsbStateEvent {
+  kind: 'state'
+  state: number
+  rxErrorCount: number
+  txErrorCount: number
+  timestampUs: number
+}
+
+export interface VkgsUsbBusErrorEvent {
+  kind: 'bus-error'
+  errorFlag: number
+  errorCode: number
+  rxErrorCount: number
+  txErrorCount: number
+  errorLoggingCount: number
+}
+
+export type VkgsUsbRxRecord = VkgsUsbFrame | VkgsUsbStateEvent | VkgsUsbBusErrorEvent
+
+export interface NativeTransportError {
+  operation: string
+  code: number
+  message: string
+  fatal: boolean
+}
+
+interface NativeTxResult {
+  token: number
+  ok: boolean
+  error?: string
+}
+
+interface NativeOpenResult {
+  handle: number
+  interfaceNumber: number
+}
+
+interface NativeTiming {
+  clockHz: number
+  bitrateHz: number
+  prescaler: number
+  tseg1: number
+  tseg2: number
+  sjw: number
+}
+
+interface NativeConfig {
+  nominal: NativeTiming
+  data?: NativeTiming
+  fd: boolean
+  listenOnly: boolean
+  termination: boolean
+}
+
+interface NativeFrame {
+  id: number
+  data: Buffer
+  fd: boolean
+  brs: boolean
+  extended: boolean
+  remote: boolean
+}
+
+interface NativeApi {
+  listDevices(): NativeUsbInterface[]
+  fallbackCapabilities(): VkgsUsbCapabilities
+  open(
+    path: string,
+    onReceive: (records: VkgsUsbRxRecord[]) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): NativeOpenResult
+  startRx(handle: number): void
+  readCapabilities(handle: number): VkgsUsbCapabilities
+  readDeviceInfo(handle: number): VkgsUsbDeviceInfo
+  getTermination(handle: number): boolean
+  configure(handle: number, config: NativeConfig): VkgsUsbAppliedConfig
+  stop(handle: number): void
+  writeFrame(
+    handle: number,
+    frame: NativeFrame,
+    token: number,
+    delayBeforeMs: number,
+    delayAfterMs: number
+  ): Buffer | null
+  close(handle: number): void
+}
+
+const native = NativeVkgsUsb as NativeApi
+
+function toNativeTiming(timing: CanBaseInfo['bitrate']): NativeTiming {
+  return {
+    clockHz: Number(timing.clock) * 1_000_000,
+    bitrateHz: timing.freq,
+    prescaler: timing.preScaler,
+    tseg1: timing.timeSeg1,
+    tseg2: timing.timeSeg2,
+    sjw: timing.sjw
+  }
+}
+
+export class VkgsUsbNative {
+  readonly handle: number
+  readonly interfaceNumber: number
+  private closed = false
+
+  private constructor(result: NativeOpenResult) {
+    this.handle = result.handle
+    this.interfaceNumber = result.interfaceNumber
+  }
+
+  static listDevices(): NativeUsbInterface[] {
+    return native.listDevices()
+  }
+
+  static fallbackCapabilities(): VkgsUsbCapabilities {
+    return native.fallbackCapabilities()
+  }
+
+  static open(
+    path: string,
+    onReceive: (records: VkgsUsbRxRecord[]) => void,
+    onError: (error: NativeTransportError) => void,
+    onTransmit: (result: NativeTxResult) => void
+  ): VkgsUsbNative {
+    return new VkgsUsbNative(native.open(path, onReceive, onError, onTransmit))
+  }
+
+  startReceive() {
+    this.assertOpen()
+    native.startRx(this.handle)
+  }
+
+  readCapabilities(): VkgsUsbCapabilities {
+    this.assertOpen()
+    return native.readCapabilities(this.handle)
+  }
+
+  readDeviceInfo(): VkgsUsbDeviceInfo {
+    this.assertOpen()
+    return native.readDeviceInfo(this.handle)
+  }
+
+  getTermination(): boolean {
+    this.assertOpen()
+    return native.getTermination(this.handle)
+  }
+
+  configure(info: CanBaseInfo, termination: boolean): VkgsUsbAppliedConfig {
+    this.assertOpen()
+    const config: NativeConfig = {
+      nominal: toNativeTiming(info.bitrate),
+      fd: !!info.canfd,
+      listenOnly: !!info.silent,
+      termination
+    }
+    if (info.canfd) {
+      if (!info.bitratefd) throw new Error('VKGS USB CAN FD data timing is required')
+      config.data = toNativeTiming(info.bitratefd)
+    }
+    return native.configure(this.handle, config)
+  }
+
+  stop() {
+    this.assertOpen()
+    native.stop(this.handle)
+  }
+
+  writeFrame(
+    frame: Omit<VkgsUsbFrame, 'kind' | 'timestampUs' | 'overflow' | 'esi' | 'error'>,
+    token: number,
+    delayBeforeMs = 0,
+    delayAfterMs = 0
+  ): Buffer | undefined {
+    this.assertOpen()
+    return native.writeFrame(this.handle, frame, token, delayBeforeMs, delayAfterMs) ?? undefined
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    native.close(this.handle)
+  }
+
+  private assertOpen() {
+    if (this.closed) throw new Error('VKGS USB native driver is closed')
+  }
+}

--- a/src/main/docan/vkgs_usb/native/addon.cpp
+++ b/src/main/docan/vkgs_usb/native/addon.cpp
@@ -1,0 +1,712 @@
+#include <napi.h>
+
+#include "../api/vkgs_usb.h"
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr size_t kTransferSize = 512;
+constexpr size_t kTxQueueLimit = 512;
+constexpr uint32_t kIoTimeoutMs = 2000;
+constexpr uint32_t kRxPollMs = 100;
+
+struct TxJob {
+  uint32_t token = 0;
+  std::vector<uint8_t> bytes;
+  uint32_t delayBeforeMs = 0;
+  uint32_t delayAfterMs = 0;
+};
+
+struct TxResult {
+  uint32_t token = 0;
+  bool ok = false;
+  std::string error;
+};
+
+struct ErrorResult {
+  int32_t code = 0;
+  std::string operation;
+  std::string detail;
+  bool fatal = true;
+};
+
+std::mutex gDevicesMutex;
+std::map<uint32_t, std::shared_ptr<class UsbTransport>> gDevices;
+std::atomic<uint32_t> gNextHandle{1};
+
+std::string ApiErrorMessage(const vkgs_usb_error_t &error) {
+  std::ostringstream output;
+  output << (error.operation[0] != '\0' ? error.operation : "VKGS USB");
+  if (error.message[0] != '\0')
+    output << " failed: " << error.message;
+  if (error.native_code != 0)
+    output << " (code " << error.native_code << ')';
+  return output.str();
+}
+
+int32_t ApiErrorCode(const vkgs_usb_error_t &error) {
+  return error.native_code != 0 ? error.native_code
+                                : static_cast<int32_t>(error.status);
+}
+
+uint32_t ReadUint32Value(const Napi::Value &value, const char *name) {
+  if (!value.IsNumber())
+    throw std::runtime_error(std::string(name) + " must be numeric");
+  const double number = value.As<Napi::Number>().DoubleValue();
+  if (!std::isfinite(number) || number < 0 || number > UINT32_MAX ||
+      std::floor(number) != number)
+    throw std::runtime_error(std::string(name) +
+                             " must be an unsigned 32-bit integer");
+  return static_cast<uint32_t>(number);
+}
+
+uint32_t ReadUint32(const Napi::Object &object, const char *name) {
+  return ReadUint32Value(object.Get(name), name);
+}
+
+bool ReadBoolean(const Napi::Object &object, const char *name) {
+  const Napi::Value value = object.Get(name);
+  if (!value.IsBoolean())
+    throw std::runtime_error(std::string(name) + " must be boolean");
+  return value.As<Napi::Boolean>().Value();
+}
+
+vkgs_usb_timing_t ReadTiming(const Napi::Value &value, const char *name) {
+  if (!value.IsObject())
+    throw std::runtime_error(std::string(name) + " timing is required");
+  const Napi::Object object = value.As<Napi::Object>();
+  return vkgs_usb_timing_t{
+      ReadUint32(object, "clockHz"),   ReadUint32(object, "bitrateHz"),
+      ReadUint32(object, "prescaler"), ReadUint32(object, "tseg1"),
+      ReadUint32(object, "tseg2"),     ReadUint32(object, "sjw")};
+}
+
+Napi::Object TimingLimitsToJs(Napi::Env env,
+                              const vkgs_usb_timing_limits_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("feature", Napi::Number::New(env, value.feature));
+  output.Set("fclk_can", Napi::Number::New(env, value.clock_hz));
+  output.Set("tseg1_min", Napi::Number::New(env, value.tseg1_min));
+  output.Set("tseg1_max", Napi::Number::New(env, value.tseg1_max));
+  output.Set("tseg2_min", Napi::Number::New(env, value.tseg2_min));
+  output.Set("tseg2_max", Napi::Number::New(env, value.tseg2_max));
+  output.Set("sjw_max", Napi::Number::New(env, value.sjw_max));
+  output.Set("brp_min", Napi::Number::New(env, value.brp_min));
+  output.Set("brp_max", Napi::Number::New(env, value.brp_max));
+  output.Set("brp_inc", Napi::Number::New(env, value.brp_inc));
+  return output;
+}
+
+Napi::Object CapabilitiesToJs(Napi::Env env,
+                              const vkgs_usb_capabilities_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("nominal", TimingLimitsToJs(env, value.nominal));
+  if (value.has_data_timing)
+    output.Set("data", TimingLimitsToJs(env, value.data));
+  output.Set("fdSupported", Napi::Boolean::New(env, value.fd_supported));
+  output.Set("listenOnlySupported",
+             Napi::Boolean::New(env, value.listen_only_supported));
+  output.Set("terminationSupported",
+             Napi::Boolean::New(env, value.termination_supported));
+  return output;
+}
+
+Napi::Object AppliedTimingToJs(Napi::Env env,
+                               const vkgs_usb_applied_timing_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("requestedBitrate",
+             Napi::Number::New(env, value.requested_bitrate_hz));
+  output.Set("actualBitrate", Napi::Number::New(env, value.actual_bitrate_hz));
+  output.Set("samplePointPermille",
+             Napi::Number::New(env, value.sample_point_permille));
+  output.Set("prescaler", Napi::Number::New(env, value.prescaler));
+  output.Set("tseg1", Napi::Number::New(env, value.tseg1));
+  output.Set("tseg2", Napi::Number::New(env, value.tseg2));
+  output.Set("sjw", Napi::Number::New(env, value.sjw));
+  output.Set("wirePrescaler", Napi::Number::New(env, value.wire_prescaler));
+  output.Set("wireTseg1", Napi::Number::New(env, value.wire_tseg1));
+  output.Set("wireTseg2", Napi::Number::New(env, value.wire_tseg2));
+  output.Set("wireSjw", Napi::Number::New(env, value.wire_sjw));
+  return output;
+}
+
+Napi::Object DeviceInfoToJs(Napi::Env env,
+                            const vkgs_usb_device_info_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("swVersion", Napi::Number::New(env, value.software_version));
+  output.Set("hwVersion", Napi::Number::New(env, value.hardware_version));
+  Napi::Array uid = Napi::Array::New(env, 4);
+  Napi::Array uuid = Napi::Array::New(env, 4);
+  for (uint32_t index = 0; index < 4; ++index) {
+    uid.Set(index, Napi::Number::New(env, value.uid[index]));
+    uuid.Set(index, Napi::Number::New(env, value.uuid[index]));
+  }
+  output.Set("uid", uid);
+  output.Set("uuid", uuid);
+  return output;
+}
+
+Napi::Object AppliedConfigToJs(Napi::Env env,
+                               const vkgs_usb_applied_config_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  output.Set("nominal", AppliedTimingToJs(env, value.nominal));
+  if (value.has_data_timing)
+    output.Set("data", AppliedTimingToJs(env, value.data));
+  output.Set("hardwareTimestamps",
+             Napi::Boolean::New(env, value.hardware_timestamps));
+  return output;
+}
+
+Napi::Object RxRecordToJs(Napi::Env env, const vkgs_usb_rx_record_t &value) {
+  Napi::Object output = Napi::Object::New(env);
+  if (value.kind == VKGS_USB_RX_FRAME) {
+    output.Set("kind", "frame");
+    output.Set("id", Napi::Number::New(env, value.frame.id));
+    output.Set("data", Napi::Buffer<uint8_t>::Copy(env, value.frame.data,
+                                                   value.frame.length));
+    output.Set("fd", Napi::Boolean::New(env, value.frame.fd));
+    output.Set("brs", Napi::Boolean::New(env, value.frame.brs));
+    output.Set("extended", Napi::Boolean::New(env, value.frame.extended));
+    output.Set("remote", Napi::Boolean::New(env, value.frame.remote));
+    output.Set("overflow", Napi::Boolean::New(env, value.frame.overflow));
+    output.Set("esi", Napi::Boolean::New(env, value.frame.esi));
+    output.Set("error", Napi::Boolean::New(env, value.frame.error));
+    output.Set(
+        "timestampUs",
+        Napi::Number::New(env, static_cast<double>(value.frame.timestamp_us)));
+  } else if (value.kind == VKGS_USB_RX_STATE) {
+    output.Set("kind", "state");
+    output.Set("state", Napi::Number::New(env, value.state));
+    output.Set("rxErrorCount", Napi::Number::New(env, value.rx_error_count));
+    output.Set("txErrorCount", Napi::Number::New(env, value.tx_error_count));
+    output.Set("timestampUs",
+               Napi::Number::New(env, static_cast<double>(value.timestamp_us)));
+  } else {
+    output.Set("kind", "bus-error");
+    output.Set("errorFlag", Napi::Number::New(env, value.error_flag));
+    output.Set("errorCode", Napi::Number::New(env, value.error_code));
+    output.Set("rxErrorCount", Napi::Number::New(env, value.rx_error_count));
+    output.Set("txErrorCount", Napi::Number::New(env, value.tx_error_count));
+    output.Set("errorLoggingCount",
+               Napi::Number::New(env, value.error_logging_count));
+  }
+  return output;
+}
+
+class UsbTransport {
+public:
+  UsbTransport(Napi::Env env, std::string path, Napi::Function rxCallback,
+               Napi::Function errorCallback, Napi::Function txCallback)
+      : path_(std::move(path)), rxTsfn_(Napi::ThreadSafeFunction::New(
+                                    env, rxCallback, "vkgs-usb-rx", 4096, 1)),
+        errorTsfn_(Napi::ThreadSafeFunction::New(env, errorCallback,
+                                                 "vkgs-usb-error", 8, 1)),
+        txTsfn_(Napi::ThreadSafeFunction::New(env, txCallback, "vkgs-usb-tx",
+                                              1024, 1)) {}
+
+  ~UsbTransport() { Close(); }
+
+  void Open() {
+    vkgs_usb_error_t error{};
+    device_ = vkgs_usb_open(path_.c_str(), &error);
+    if (device_ == nullptr)
+      throw std::runtime_error(ApiErrorMessage(error));
+    txThread_ = std::thread(&UsbTransport::TxLoop, this);
+  }
+
+  uint8_t InterfaceNumber() const { return vkgs_usb_interface_number(device_); }
+
+  void StartRx() {
+    EnsureOpen();
+    bool expected = false;
+    if (!rxStarted_.compare_exchange_strong(expected, true))
+      return;
+    rxThread_ = std::thread(&UsbTransport::RxLoop, this);
+  }
+
+  vkgs_usb_capabilities_t Capabilities() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vkgs_usb_capabilities_t result{};
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_get_capabilities(device_, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  vkgs_usb_device_info_t DeviceInfo() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vkgs_usb_device_info_t result{};
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_get_device_info(device_, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  bool Termination() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    bool result = false;
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_get_termination(device_, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  vkgs_usb_applied_config_t Configure(const vkgs_usb_config_t &config) {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vkgs_usb_applied_config_t result{};
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_configure(device_, &config, &result, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    return result;
+  }
+
+  void Stop() {
+    std::lock_guard<std::mutex> lock(controlMutex_);
+    EnsureOpen();
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_stop(device_, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+  }
+
+  bool EnqueueFrame(uint32_t token, const vkgs_usb_frame_t &frame,
+                    uint32_t delayBeforeMs, uint32_t delayAfterMs,
+                    std::vector<uint8_t> *normalized) {
+    EnsureOpen();
+    uint8_t wire[VKGS_USB_MAX_WIRE_FRAME]{};
+    size_t wireLength = 0;
+    uint8_t normalizedLength = 0;
+    vkgs_usb_error_t error{};
+    if (!vkgs_usb_encode_frame(device_, &frame, wire, sizeof(wire), &wireLength,
+                               &normalizedLength, &error))
+      throw std::runtime_error(ApiErrorMessage(error));
+    normalized->assign(frame.data, frame.data + frame.length);
+    normalized->resize(normalizedLength, 0);
+    return Enqueue(token, wire, wireLength, delayBeforeMs, delayAfterMs);
+  }
+
+  bool Enqueue(uint32_t token, const uint8_t *data, size_t length,
+               uint32_t delayBeforeMs, uint32_t delayAfterMs) {
+    if (data == nullptr || length == 0)
+      return false;
+    std::lock_guard<std::mutex> lock(txMutex_);
+    if (closing_ || txQueue_.size() >= kTxQueueLimit)
+      return false;
+    txQueue_.push_back(TxJob{token, std::vector<uint8_t>(data, data + length),
+                             delayBeforeMs, delayAfterMs});
+    txCondition_.notify_one();
+    return true;
+  }
+
+  void Close() {
+    bool expected = false;
+    if (!closing_.compare_exchange_strong(expected, true))
+      return;
+    txCondition_.notify_all();
+    vkgs_usb_cancel(device_);
+    if (rxThread_.joinable())
+      rxThread_.join();
+    if (txThread_.joinable())
+      txThread_.join();
+    vkgs_usb_close(device_);
+    device_ = nullptr;
+    rxTsfn_.Release();
+    errorTsfn_.Release();
+    txTsfn_.Release();
+  }
+
+private:
+  void EnsureOpen() const {
+    if (closing_ || device_ == nullptr) {
+      throw std::runtime_error("VKGS USB transport is closed");
+    }
+  }
+
+  bool WaitDelay(uint32_t delayMs) {
+    if (delayMs == 0)
+      return !closing_;
+    std::unique_lock<std::mutex> lock(txMutex_);
+    return !txCondition_.wait_for(lock, std::chrono::milliseconds(delayMs),
+                                  [&] { return closing_.load(); });
+  }
+
+  void RxLoop() {
+    while (!closing_) {
+      std::vector<uint8_t> bytes(kTransferSize);
+      size_t transferred = 0;
+      vkgs_usb_error_t error{};
+      if (!vkgs_usb_bulk_read(device_, bytes.data(), bytes.size(), &transferred,
+                              kRxPollMs, &error)) {
+        if (!closing_ && error.status != VKGS_USB_STATUS_CANCELLED)
+          ReportError(error);
+        break;
+      }
+      if (transferred == 0)
+        continue;
+      vkgs_usb_rx_batch_t batch{};
+      if (!vkgs_usb_decode(device_, bytes.data(), transferred, &batch,
+                           &error)) {
+        vkgs_usb_decoder_reset(device_);
+        ReportError(error, false);
+        continue;
+      }
+      if (batch.count == 0)
+        continue;
+      auto *payload = new std::vector<vkgs_usb_rx_record_t>(
+          batch.records, batch.records + batch.count);
+      const napi_status status = rxTsfn_.NonBlockingCall(
+          payload, [](Napi::Env env, Napi::Function callback,
+                      std::vector<vkgs_usb_rx_record_t> *value) {
+            Napi::Array records = Napi::Array::New(env, value->size());
+            for (size_t index = 0; index < value->size(); ++index)
+              records.Set(index, RxRecordToJs(env, (*value)[index]));
+            callback.Call({records});
+            delete value;
+          });
+      if (status != napi_ok) {
+        delete payload;
+        if (!closing_ && status != napi_closing) {
+          vkgs_usb_error_t queueError{};
+          queueError.status = VKGS_USB_STATUS_SYSTEM_ERROR;
+          queueError.native_code = 0;
+          std::snprintf(queueError.operation, sizeof(queueError.operation),
+                        "RX callback queue");
+          std::snprintf(queueError.message, sizeof(queueError.message),
+                        "callback queue is full");
+          ReportError(queueError, true);
+          break;
+        }
+      }
+    }
+  }
+
+  void TxLoop() {
+    while (true) {
+      TxJob job;
+      {
+        std::unique_lock<std::mutex> lock(txMutex_);
+        txCondition_.wait(lock, [&] { return closing_ || !txQueue_.empty(); });
+        if (closing_ && txQueue_.empty())
+          break;
+        job = std::move(txQueue_.front());
+        txQueue_.pop_front();
+      }
+
+      bool ok = WaitDelay(job.delayBeforeMs);
+      vkgs_usb_error_t error{};
+      size_t transferred = 0;
+      if (ok) {
+        ok = vkgs_usb_bulk_write(device_, job.bytes.data(), job.bytes.size(),
+                                 &transferred, kIoTimeoutMs, &error);
+      }
+      if (ok)
+        ok = WaitDelay(job.delayAfterMs);
+      std::string detail;
+      if (!ok) {
+        detail = error.status != VKGS_USB_STATUS_OK
+                     ? ApiErrorMessage(error)
+                     : "VKGS USB transport is closed";
+      }
+      PostTxResult(new TxResult{job.token, ok, std::move(detail)});
+    }
+
+    std::deque<TxJob> abandoned;
+    {
+      std::lock_guard<std::mutex> lock(txMutex_);
+      abandoned.swap(txQueue_);
+    }
+    for (const auto &job : abandoned) {
+      PostTxResult(
+          new TxResult{job.token, false, "VKGS USB transport is closed"});
+    }
+  }
+
+  void PostTxResult(TxResult *result) {
+    const napi_status status = txTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, TxResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("token", Napi::Number::New(env, value->token));
+          object.Set("ok", Napi::Boolean::New(env, value->ok));
+          if (!value->ok)
+            object.Set("error", Napi::String::New(env, value->error));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  void ReportError(const vkgs_usb_error_t &error, bool fatal = true) {
+    auto *result = new ErrorResult{ApiErrorCode(error), error.operation,
+                                   ApiErrorMessage(error), fatal};
+    const napi_status status = errorTsfn_.NonBlockingCall(
+        result, [](Napi::Env env, Napi::Function callback, ErrorResult *value) {
+          Napi::Object object = Napi::Object::New(env);
+          object.Set("operation", Napi::String::New(env, value->operation));
+          object.Set("code", Napi::Number::New(env, value->code));
+          object.Set("message", Napi::String::New(env, value->detail));
+          object.Set("fatal", Napi::Boolean::New(env, value->fatal));
+          callback.Call({object});
+          delete value;
+        });
+    if (status != napi_ok)
+      delete result;
+  }
+
+  std::string path_;
+  vkgs_usb_device_t *device_ = nullptr;
+  std::atomic<bool> closing_{false};
+  std::atomic<bool> rxStarted_{false};
+  std::thread rxThread_;
+  std::thread txThread_;
+  std::mutex controlMutex_;
+  std::mutex txMutex_;
+  std::condition_variable txCondition_;
+  std::deque<TxJob> txQueue_;
+  Napi::ThreadSafeFunction rxTsfn_;
+  Napi::ThreadSafeFunction errorTsfn_;
+  Napi::ThreadSafeFunction txTsfn_;
+};
+
+std::shared_ptr<UsbTransport> Lookup(uint32_t handle) {
+  std::lock_guard<std::mutex> lock(gDevicesMutex);
+  const auto found = gDevices.find(handle);
+  if (found == gDevices.end())
+    throw std::runtime_error("invalid VKGS USB transport handle");
+  return found->second;
+}
+
+uint32_t ReadHandle(const Napi::CallbackInfo &info) {
+  if (info.Length() == 0 || !info[0].IsNumber()) {
+    throw Napi::TypeError::New(info.Env(),
+                               "a numeric transport handle is required");
+  }
+  return info[0].As<Napi::Number>().Uint32Value();
+}
+
+Napi::Value ListDevices(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  vkgs_usb_device_list_t list{};
+  vkgs_usb_error_t error{};
+  if (!vkgs_usb_list_scan(&list, &error)) {
+    throw Napi::Error::New(env, ApiErrorMessage(error));
+  }
+  Napi::Array output = Napi::Array::New(env, list.count);
+  for (size_t index = 0; index < list.count; ++index) {
+    const auto &item = list.devices[index];
+    Napi::Object object = Napi::Object::New(env);
+    object.Set("path", Napi::String::New(env, item.path));
+    object.Set("label", Napi::String::New(env, item.label));
+    object.Set("interfaceNumber",
+               Napi::Number::New(env, item.interface_number));
+    object.Set("endpointIn", Napi::Number::New(env, item.endpoint_in));
+    object.Set("endpointOut", Napi::Number::New(env, item.endpoint_out));
+    object.Set("busy", Napi::Boolean::New(env, item.busy));
+    output.Set(index, object);
+  }
+  return output;
+}
+
+Napi::Value Open(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 4 || !info[0].IsString() || !info[1].IsFunction() ||
+      !info[2].IsFunction() || !info[3].IsFunction()) {
+    throw Napi::TypeError::New(
+        env, "open expects path, rx callback, error callback, tx callback");
+  }
+  try {
+    auto device = std::make_shared<UsbTransport>(
+        env, info[0].As<Napi::String>().Utf8Value(),
+        info[1].As<Napi::Function>(), info[2].As<Napi::Function>(),
+        info[3].As<Napi::Function>());
+    device->Open();
+    const uint32_t handle = gNextHandle.fetch_add(1);
+    {
+      std::lock_guard<std::mutex> lock(gDevicesMutex);
+      gDevices.emplace(handle, device);
+    }
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("handle", Napi::Number::New(env, handle));
+    result.Set("interfaceNumber",
+               Napi::Number::New(env, device->InterfaceNumber()));
+    return result;
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value StartRx(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(ReadHandle(info))->StartRx();
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value FallbackCapabilities(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  vkgs_usb_capabilities_t capabilities{};
+  vkgs_usb_fallback_capabilities(&capabilities);
+  return CapabilitiesToJs(env, capabilities);
+}
+
+Napi::Value ReadCapabilities(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    return CapabilitiesToJs(env, Lookup(ReadHandle(info))->Capabilities());
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value ReadDeviceInfo(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    return DeviceInfoToJs(env, Lookup(ReadHandle(info))->DeviceInfo());
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value GetTermination(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    return Napi::Boolean::New(env, Lookup(ReadHandle(info))->Termination());
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Configure(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[1].IsObject())
+    throw Napi::TypeError::New(env, "configure expects handle and config");
+  try {
+    const Napi::Object input = info[1].As<Napi::Object>();
+    vkgs_usb_config_t config{};
+    config.nominal = ReadTiming(input.Get("nominal"), "nominal");
+    config.fd = ReadBoolean(input, "fd");
+    config.listen_only = ReadBoolean(input, "listenOnly");
+    config.termination = ReadBoolean(input, "termination");
+    if (config.fd)
+      config.data = ReadTiming(input.Get("data"), "data");
+    return AppliedConfigToJs(env, Lookup(ReadHandle(info))->Configure(config));
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Stop(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  try {
+    Lookup(ReadHandle(info))->Stop();
+    return env.Undefined();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value WriteFrame(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 5 || !info[1].IsObject()) {
+    throw Napi::TypeError::New(
+        env,
+        "writeFrame expects handle, frame, token, delayBeforeMs, delayAfterMs");
+  }
+  try {
+    const Napi::Object input = info[1].As<Napi::Object>();
+    const Napi::Value dataValue = input.Get("data");
+    if (!dataValue.IsBuffer())
+      throw std::runtime_error("frame data must be a Buffer");
+    const auto data = dataValue.As<Napi::Buffer<uint8_t>>();
+    if (data.Length() > VKGS_USB_MAX_FRAME_DATA)
+      throw std::runtime_error("frame data exceeds 64 bytes");
+    vkgs_usb_frame_t frame{};
+    frame.id = ReadUint32(input, "id");
+    frame.length = static_cast<uint8_t>(data.Length());
+    if (frame.length > 0)
+      std::memcpy(frame.data, data.Data(), frame.length);
+    frame.fd = ReadBoolean(input, "fd");
+    frame.brs = ReadBoolean(input, "brs");
+    frame.extended = ReadBoolean(input, "extended");
+    frame.remote = ReadBoolean(input, "remote");
+    std::vector<uint8_t> normalized;
+    const bool queued =
+        Lookup(ReadHandle(info))
+            ->EnqueueFrame(ReadUint32Value(info[2], "token"), frame,
+                           ReadUint32Value(info[3], "delayBeforeMs"),
+                           ReadUint32Value(info[4], "delayAfterMs"),
+                           &normalized);
+    return queued ? Napi::Buffer<uint8_t>::Copy(env, normalized.data(),
+                                                normalized.size())
+                  : env.Null();
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+Napi::Value Close(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  std::shared_ptr<UsbTransport> device;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    const auto found = gDevices.find(ReadHandle(info));
+    if (found == gDevices.end())
+      return env.Undefined();
+    device = found->second;
+    gDevices.erase(found);
+  }
+  device->Close();
+  return env.Undefined();
+}
+
+void Cleanup(void *) {
+  std::map<uint32_t, std::shared_ptr<UsbTransport>> devices;
+  {
+    std::lock_guard<std::mutex> lock(gDevicesMutex);
+    devices.swap(gDevices);
+  }
+  for (auto &entry : devices)
+    entry.second->Close();
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("listDevices", Napi::Function::New(env, ListDevices));
+  exports.Set("open", Napi::Function::New(env, Open));
+  exports.Set("startRx", Napi::Function::New(env, StartRx));
+  exports.Set("fallbackCapabilities",
+              Napi::Function::New(env, FallbackCapabilities));
+  exports.Set("readCapabilities", Napi::Function::New(env, ReadCapabilities));
+  exports.Set("readDeviceInfo", Napi::Function::New(env, ReadDeviceInfo));
+  exports.Set("getTermination", Napi::Function::New(env, GetTermination));
+  exports.Set("configure", Napi::Function::New(env, Configure));
+  exports.Set("stop", Napi::Function::New(env, Stop));
+  exports.Set("writeFrame", Napi::Function::New(env, WriteFrame));
+  exports.Set("close", Napi::Function::New(env, Close));
+  napi_add_env_cleanup_hook(env, Cleanup, nullptr);
+  return exports;
+}
+
+} // namespace
+
+NODE_API_MODULE(vkgs_usb, Init)

--- a/src/main/share/can.ts
+++ b/src/main/share/can.ts
@@ -23,6 +23,8 @@ export type CanVendor =
   | 'slcan'
   | 'ecubus'
   | 'candle'
+  | 'vcan_usb'
+  | 'vkgs_usb'
 export interface CanBaseInfo {
   id: string
   handle: any
@@ -495,6 +497,8 @@ export interface CanDevice {
       dataCap?: CandleCapability
       fdSupported?: boolean
       Res?: boolean
+      /** Optional vendor hint used only to break equal-sample-point timing ties. */
+      preferredDataTimeQuanta?: number
     }
   }
 }

--- a/src/renderer/src/views/uds/hardware/canNode.vue
+++ b/src/renderer/src/views/uds/hardware/canNode.vue
@@ -69,7 +69,7 @@
       </el-select>
     </el-form-item>
     <el-form-item
-      v-else-if="props.vendor == 'candle' && getSelectedCandleDevice()?.extra?.candle?.Res"
+      v-else-if="isCandleCompatibleVendor() && getSelectedCandleDevice()?.extra?.candle?.Res"
       :label="i18next.t('uds.hardware.canNode.labels.res120Enable')"
       prop="candleRes"
       :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
@@ -91,7 +91,7 @@
       </el-select>
     </el-form-item>
     <el-form-item
-      v-else-if="props.vendor == 'kvaser'"
+      v-else-if="props.vendor == 'kvaser' || isUsbCanVendor()"
       :label="i18next.t('uds.hardware.canNode.labels.silentMode')"
       prop="silent"
       :placeholder="i18next.t('uds.hardware.canNode.options.disable')"
@@ -124,7 +124,7 @@
         </el-form-item>
       </el-col>
       <!-- Non-candle: clock frequency dropdown -->
-      <el-col v-if="props.vendor !== 'candle'" :span="12">
+      <el-col v-if="!isCandleCompatibleVendor()" :span="12">
         <el-form-item
           v-if="vendorConfigLimit.clock"
           :label="i18next.t('uds.hardware.canNode.labels.clockFreq')"
@@ -257,9 +257,9 @@
     v-model="calculatorVisible"
     :height="height - 100"
     :freq="currentRow?.freq || 0"
-    :clock="Number(data.bitrate.clock || 0)"
+    :clock="calculatorClock"
     :vendor="props.vendor"
-    :ability="vendorConfigLimit"
+    :ability="calculatorAbility"
     @result="handleCalculatorResult"
   />
 </template>
@@ -297,6 +297,8 @@ const props = defineProps<{
 }>()
 const height = toRef(props, 'height')
 const ruleFormRef = ref<FormInstance>()
+const calculatorVisible = ref(false)
+const currentRow = ref<CanBitrate | null>(null)
 
 const devices = useDataStore()
 const globalStart = useGlobalStart()
@@ -335,7 +337,16 @@ const clockChange = (value: string) => {
   }
 }
 
-const configInfo: Record<CanVendor, any> = {
+const CANDLE_COMPATIBLE_VENDORS = new Set<CanVendor>(['candle', 'vcan_usb', 'vkgs_usb'])
+
+function isCandleCompatibleVendor(vendor: CanVendor = props.vendor) {
+  return CANDLE_COMPATIBLE_VENDORS.has(vendor)
+}
+
+function isUsbCanVendor() {
+  return props.vendor === 'vcan_usb' || props.vendor === 'vkgs_usb'
+}
+const configInfo = {
   ecubus: {
     clock: false,
     timeSeg1: false,
@@ -710,11 +721,15 @@ const configInfo: Record<CanVendor, any> = {
       }
     }
   }
+} as Record<CanVendor, any>
+
+for (const vendor of ['vcan_usb', 'vkgs_usb'] as const) {
+  configInfo[vendor] = cloneDeep(configInfo.candle)
 }
 
 /** Look up the currently selected candle device from the device list */
 function getSelectedCandleDevice(): CanDevice | undefined {
-  if (props.vendor !== 'candle') return undefined
+  if (!isCandleCompatibleVendor()) return undefined
   // Explicitly check for empty string or null/undefined (handle can be 0!)
   if (data.value.handle === '' || data.value.handle == null) return undefined
   return deviceList.value.find((d) => d.handle === data.value.handle)
@@ -753,17 +768,24 @@ function getCandleDynamicConfig(isFd: boolean) {
 
   if (isFd && dev?.extra?.candle?.dataCap) {
     const dataCap = dev.extra.candle?.dataCap
-    // Only add FD defaults; validation limits stay from bt_const (baseConfig)
-    // so both arb and data rows are validated against arbitration constraints
+    const dataClockStr = isUsbCanVendor()
+      ? String(Math.round(dataCap.fclk_can / 1000000))
+      : clockStr
+    const defaultDataTiming = autoPickCandleTiming(
+      2000000,
+      dataCap,
+      dataCap.fclk_can,
+      dev.extra.candle.preferredDataTimeQuanta
+    )
     return {
       ...baseConfig,
       bitratefd: {
-        sjw: Math.min(1, dataCap.sjw_max),
-        timeSeg1: Math.min(7, dataCap.tseg1_max),
-        timeSeg2: Math.max(2, dataCap.tseg2_min),
-        preScaler: Math.min(4, dataCap.brp_max),
+        sjw: defaultDataTiming?.sjw ?? Math.min(1, dataCap.sjw_max),
+        timeSeg1: defaultDataTiming?.t1 ?? Math.min(7, dataCap.tseg1_max),
+        timeSeg2: defaultDataTiming?.t2 ?? Math.max(2, dataCap.tseg2_min),
+        preScaler: defaultDataTiming?.presc ?? Math.min(4, dataCap.brp_max),
         freq: 2000000,
-        clock: clockStr
+        clock: dataClockStr
       }
     }
   }
@@ -772,31 +794,58 @@ function getCandleDynamicConfig(isFd: boolean) {
 }
 
 const showCandleTimingTable = computed(() => {
-  if (props.vendor !== 'candle') return false
+  if (!isCandleCompatibleVendor()) return false
   if (data.value.handle === '' || data.value.handle == null) return false
   const dev = getSelectedCandleDevice()
   return !!dev?.extra?.candle?.cap
 })
 
 const showCanFdCheckbox = computed(() => {
-  if (props.vendor !== 'candle') return true
+  if (!isCandleCompatibleVendor()) return true
   const dev = getSelectedCandleDevice()
   return !!dev?.extra?.candle?.fdSupported
 })
 
 const selectedCandleClock = computed(() => {
-  if (props.vendor !== 'candle') return null
+  if (!isCandleCompatibleVendor()) return null
   const dev = getSelectedCandleDevice()
   if (!dev?.extra?.candle?.cap || !dev.extra.candle.cap.fclk_can) return null
   return Math.round(dev.extra.candle.cap.fclk_can / 1000000)
 })
 
 const vendorConfigLimit = computed(() => {
-  if (props.vendor === 'candle') {
+  if (isCandleCompatibleVendor()) {
     return getCandleDynamicConfig(data.value.canfd)
   }
   return configInfo[props.vendor][data.value.canfd ? 'canFd' : 'can']
 })
+
+function getUsbDataTimingLimits() {
+  if (!isUsbCanVendor()) return undefined
+  const cap = getSelectedCandleDevice()?.extra?.candle?.dataCap
+  if (!cap) return undefined
+  return {
+    preScaler: { min: cap.brp_min, max: cap.brp_max },
+    tsg1: { min: cap.tseg1_min, max: cap.tseg1_max },
+    tsg2: { min: cap.tseg2_min, max: cap.tseg2_max }
+  }
+}
+
+const calculatorAbility = computed(() => {
+  if (!isUsbCanVendor() || currentRow.value !== data.value.bitratefd) {
+    return vendorConfigLimit.value
+  }
+  const dataLimits = getUsbDataTimingLimits()
+  return dataLimits ? { ...vendorConfigLimit.value, ...dataLimits } : vendorConfigLimit.value
+})
+
+const calculatorClock = computed(() =>
+  Number(
+    (isUsbCanVendor() ? currentRow.value?.clock : data.value.bitrate.clock) ||
+      data.value.bitrate.clock ||
+      0
+  )
+)
 
 const gridOptions = computed(() => {
   const v: VxeGridProps<CanBitrate> = {
@@ -958,10 +1007,10 @@ function getBaudrateSP(speed: CanBitrate, index: number) {
     props.vendor == 'kvaser' ||
     props.vendor == 'toomoss' ||
     props.vendor == 'vector' ||
-    props.vendor == 'candle'
+    isCandleCompatibleVendor()
   ) {
     let f_clock = Number(speed.clock || 80) * 1000000
-    if (index == 1) {
+    if (index == 1 && !isUsbCanVendor()) {
       f_clock = Number(data.value.bitrate.clock || 80) * 1000000
     }
     const nom_brp = speed.preScaler
@@ -1001,9 +1050,17 @@ function autoPickCandleTiming(
     tseg2_max: number
     sjw_max: number
   },
-  clockHz: number
+  clockHz: number,
+  preferredTimeQuanta?: number
 ) {
-  const results: { t1: number; t2: number; sp: number; sjw: number; presc: number }[] = []
+  const results: {
+    t1: number
+    t2: number
+    sp: number
+    sjw: number
+    presc: number
+    totalTq: number
+  }[] = []
   for (let presc = cap.brp_min; presc <= cap.brp_max; presc++) {
     if (clockHz % presc !== 0) continue
     const totalTq = clockHz / (presc * freq)
@@ -1017,7 +1074,8 @@ function autoPickCandleTiming(
         t2,
         sp: Math.round(((t1 + 1) / (t1 + t2 + 1)) * 10000) / 100,
         sjw: Math.min(1, cap.sjw_max),
-        presc
+        presc,
+        totalTq
       })
     }
   }
@@ -1027,13 +1085,22 @@ function autoPickCandleTiming(
   const pool = inRange.length > 0 ? inRange : results
   let best = pool[0]
   for (const r of pool) {
-    if (Math.abs(r.sp - 80) < Math.abs(best.sp - 80)) best = r
+    const sampleError = Math.abs(r.sp - 80)
+    const bestSampleError = Math.abs(best.sp - 80)
+    if (
+      sampleError < bestSampleError ||
+      (preferredTimeQuanta !== undefined &&
+        sampleError === bestSampleError &&
+        Math.abs(r.totalTq - preferredTimeQuanta) < Math.abs(best.totalTq - preferredTimeQuanta))
+    ) {
+      best = r
+    }
   }
   return best
 }
 
 watch([deviceList, () => data.value.handle], () => {
-  if (props.vendor !== 'candle') return
+  if (!isCandleCompatibleVendor()) return
   const dev = getSelectedCandleDevice()
   if (!dev?.extra?.candle?.cap) return
   // Disable CAN FD if the selected device doesn't support it
@@ -1045,21 +1112,29 @@ watch([deviceList, () => data.value.handle], () => {
   const clockChanged = data.value.bitrate.clock !== clockStr
   if (clockChanged) {
     data.value.bitrate.clock = clockStr
-    if (data.value.bitratefd) {
+  }
+  if (data.value.bitratefd) {
+    const dataCap = dev.extra.candle?.dataCap
+    if (isUsbCanVendor() && dataCap?.fclk_can) {
+      data.value.bitratefd.clock = String(Math.round(dataCap.fclk_can / 1000000))
+    } else if (clockChanged) {
       data.value.bitratefd.clock = clockStr
     }
   }
-  // Auto-pick timing params that match the current freq with device's actual clock
-  const best = autoPickCandleTiming(
-    data.value.bitrate.freq,
-    dev.extra.candle.cap,
-    clockMhz * 1000000
-  )
-  if (best) {
-    data.value.bitrate.timeSeg1 = best.t1
-    data.value.bitrate.timeSeg2 = best.t2
-    data.value.bitrate.sjw = best.sjw
-    data.value.bitrate.preScaler = best.presc
+  // Keep user-selected timing for the USB drivers when the async device list refreshes.
+  // Recalculate only if the hardware clock really changed. Candle retains its upstream behavior.
+  if (props.vendor === 'candle' || clockChanged) {
+    const best = autoPickCandleTiming(
+      data.value.bitrate.freq,
+      dev.extra.candle.cap,
+      clockMhz * 1000000
+    )
+    if (best) {
+      data.value.bitrate.timeSeg1 = best.t1
+      data.value.bitrate.timeSeg2 = best.t2
+      data.value.bitrate.sjw = best.sjw
+      data.value.bitrate.preScaler = best.presc
+    }
   }
   nextTick(() => {
     ruleFormRef.value?.validateField('bitrate')
@@ -1073,7 +1148,7 @@ watch([deviceList, () => data.value.handle], () => {
 watch(
   () => [data.value.bitrate.freq, data.value.bitratefd?.freq],
   () => {
-    if (props.vendor !== 'candle') return
+    if (!isCandleCompatibleVendor()) return
     const dev = getSelectedCandleDevice()
     if (!dev?.extra?.candle?.cap) return
     const clockHz = (selectedCandleClock.value ?? 0) * 1000000
@@ -1087,10 +1162,12 @@ watch(
       data.value.bitrate.preScaler = best.presc
     }
     if (data.value.canfd && data.value.bitratefd && dev.extra.candle?.dataCap) {
+      const dataClockHz = isUsbCanVendor() ? dev.extra.candle.dataCap.fclk_can : clockHz
       const bestFd = autoPickCandleTiming(
         data.value.bitratefd.freq,
         dev.extra.candle.dataCap,
-        clockHz
+        dataClockHz,
+        dev.extra.candle.preferredDataTimeQuanta
       )
       if (bestFd) {
         data.value.bitratefd.timeSeg1 = bestFd.t1
@@ -1142,7 +1219,7 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
     props.vendor == 'peak' ||
     props.vendor == 'kvaser' ||
     props.vendor == 'toomoss' ||
-    props.vendor == 'candle'
+    isCandleCompatibleVendor()
   ) {
     if (data.value.bitrate.clock == undefined) {
       callback(new Error(i18next.t('uds.hardware.canNode.validation.selectClock')))
@@ -1211,6 +1288,7 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
     }
 
     if (data.value.canfd && data.value.bitratefd) {
+      const dataTimingLimits = getUsbDataTimingLimits() ?? vendorConfigLimit.value
       if (data.value.bitratefd.timeSeg1 + 1 <= data.value.bitratefd.timeSeg2) {
         error1.value = true
         callback(new Error(i18next.t('uds.hardware.canNode.validation.dataTseg1GreaterThanTseg2')))
@@ -1219,49 +1297,49 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
         error1.value = true
         callback(new Error(i18next.t('uds.hardware.canNode.validation.dataSjwLessThanTseg2')))
       }
-      if (vendorConfigLimit.value.preScaler) {
+      if (dataTimingLimits.preScaler) {
         if (
-          data.value.bitratefd.preScaler < vendorConfigLimit.value.preScaler.min ||
-          data.value.bitratefd.preScaler > vendorConfigLimit.value.preScaler.max
+          data.value.bitratefd.preScaler < dataTimingLimits.preScaler.min ||
+          data.value.bitratefd.preScaler > dataTimingLimits.preScaler.max
         ) {
           error1.value = true
           callback(
             new Error(
               i18next.t('uds.hardware.canNode.validation.dataPrescaleBetween', {
-                min: vendorConfigLimit.value.preScaler.min,
-                max: vendorConfigLimit.value.preScaler.max
+                min: dataTimingLimits.preScaler.min,
+                max: dataTimingLimits.preScaler.max
               })
             )
           )
         }
       }
-      if (vendorConfigLimit.value.tsg1) {
+      if (dataTimingLimits.tsg1) {
         if (
-          data.value.bitratefd.timeSeg1 < vendorConfigLimit.value.tsg1.min ||
-          data.value.bitratefd.timeSeg1 > vendorConfigLimit.value.tsg1.max
+          data.value.bitratefd.timeSeg1 < dataTimingLimits.tsg1.min ||
+          data.value.bitratefd.timeSeg1 > dataTimingLimits.tsg1.max
         ) {
           error1.value = true
           callback(
             new Error(
               i18next.t('uds.hardware.canNode.validation.dataTseg1Between', {
-                min: vendorConfigLimit.value.tsg1.min,
-                max: vendorConfigLimit.value.tsg1.max
+                min: dataTimingLimits.tsg1.min,
+                max: dataTimingLimits.tsg1.max
               })
             )
           )
         }
       }
-      if (vendorConfigLimit.value.tsg2) {
+      if (dataTimingLimits.tsg2) {
         if (
-          data.value.bitratefd.timeSeg2 < vendorConfigLimit.value.tsg2.min ||
-          data.value.bitratefd.timeSeg2 > vendorConfigLimit.value.tsg2.max
+          data.value.bitratefd.timeSeg2 < dataTimingLimits.tsg2.min ||
+          data.value.bitratefd.timeSeg2 > dataTimingLimits.tsg2.max
         ) {
           error1.value = true
           callback(
             new Error(
               i18next.t('uds.hardware.canNode.validation.dataTseg2Between', {
-                min: vendorConfigLimit.value.tsg2.min,
-                max: vendorConfigLimit.value.tsg2.max
+                min: dataTimingLimits.tsg2.min,
+                max: dataTimingLimits.tsg2.max
               })
             )
           )
@@ -1272,7 +1350,7 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
       props.vendor == 'kvaser' ||
       props.vendor == 'toomoss' ||
       props.vendor == 'peak' ||
-      props.vendor == 'candle'
+      isCandleCompatibleVendor()
     ) {
       const calcFreq =
         (Number(data.value.bitrate.clock || 40) * 1000000) /
@@ -1288,7 +1366,10 @@ const bitrateCheck = (rule: any, value: any, callback: any) => {
       }
       if (data.value.canfd && data.value.bitratefd) {
         const calcFreq =
-          (Number(data.value.bitrate.clock || 40) * 1000000) /
+          (Number(
+            (isUsbCanVendor() ? data.value.bitratefd.clock : data.value.bitrate.clock) || 40
+          ) *
+            1000000) /
           (data.value.bitratefd.preScaler *
             (data.value.bitratefd.timeSeg1 + data.value.bitratefd.timeSeg2 + 1))
         if (calcFreq != data.value.bitratefd.freq) {
@@ -1421,9 +1502,6 @@ const showCalculator = (row: CanBitrate) => {
   calculatorVisible.value = true
   currentRow.value = row
 }
-
-const calculatorVisible = ref(false)
-const currentRow = ref<CanBitrate | null>(null)
 
 const handleCalculatorResult = (result: any) => {
   if (currentRow.value) {

--- a/src/renderer/src/views/uds/hardware/index.vue
+++ b/src/renderer/src/views/uds/hardware/index.vue
@@ -566,6 +566,18 @@ async function buildTree() {
     t.push(candle)
     addSubTree('candle', candle, deviceIndexMap)
   }
+  for (const vendor of ['vcan_usb', 'vkgs_usb'] as const) {
+    if (!vendors.includes(vendor)) continue
+    const usbCan: tree = {
+      label: i18next.t(`uds.hardware.vendors.${vendor}`),
+      vendor,
+      append: false,
+      id: vendor.toUpperCase(),
+      children: []
+    }
+    t.push(usbCan)
+    addSubTree(vendor, usbCan, deviceIndexMap)
+  }
 
   tData.value = t
 }

--- a/test/docan/vcan_usb/devicePath.test.ts
+++ b/test/docan/vcan_usb/devicePath.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from 'vitest'
+import { resolveVcanUsbPath } from '../../../src/main/docan/vcan_usb/devicePath'
+
+describe('VCAN USB device path compatibility', () => {
+  test('resolves a stable UUID selector to the current USB topology', () => {
+    const selector = 'vcan-usb://uuid/1234567890abcdef01020304aabbccdd'
+    const currentPath = 'libusb://1d50:6080/4/p3.2/1'
+    expect(
+      resolveVcanUsbPath(selector, 1, () => [
+        {
+          path: currentPath,
+          interfaceNumber: 1,
+          identitySelector: selector
+        }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('rejects duplicate UUID selectors instead of opening an arbitrary adapter', () => {
+    const selector = 'vcan-usb://uuid/1234567890abcdef01020304aabbccdd'
+    expect(() =>
+      resolveVcanUsbPath(selector, 0, () => [
+        {
+          path: 'libusb://1d50:6080/1/p1/0',
+          interfaceNumber: 0,
+          identitySelector: selector
+        },
+        {
+          path: 'libusb://1d50:6080/2/p2/0',
+          interfaceNumber: 0,
+          identitySelector: selector
+        }
+      ])
+    ).toThrow(/Multiple VCAN USB devices/)
+  })
+
+  test('keeps a current libusb path when it is still enumerated', () => {
+    const path = 'libusb://1d50:6080/2/p2.1.3/0'
+    const listDevices = vi.fn(() => [{ path, interfaceNumber: 0 }])
+
+    expect(resolveVcanUsbPath(path, 0, listDevices)).toBe(path)
+    expect(listDevices).toHaveBeenCalledOnce()
+  })
+
+  test('migrates a stale libusb topology path when the channel match is unique', () => {
+    const stalePath = 'libusb://1d50:6080/2/p2.1.3/1'
+    const currentPath = 'libusb://1d50:6080/2/p2.1.4/1'
+
+    expect(
+      resolveVcanUsbPath(stalePath, 1, () => [
+        { path: 'libusb://1d50:6080/2/p2.1.4/0', interfaceNumber: 0 },
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('does not guess a replacement for a stale path with multiple channel matches', () => {
+    const stalePath = 'libusb://1d50:6080/2/p2.1.3/0'
+
+    expect(() =>
+      resolveVcanUsbPath(stalePath, 0, () => [
+        { path: 'libusb://1d50:6080/2/p2.1.4/0', interfaceNumber: 0 },
+        { path: 'libusb://1d50:6080/3/p3.2/0', interfaceNumber: 0 }
+      ])
+    ).toThrow(/multiple channel 0 interfaces/)
+  })
+
+  test('accepts selector and libusb scheme casing from older project files', () => {
+    const selector = 'VCAN-USB://UUID/1234567890ABCDEF01020304AABBCCDD'
+    const currentPath = 'libusb://1d50:6080/4/p3.2/1'
+    expect(
+      resolveVcanUsbPath(selector, 1, () => [
+        { path: currentPath, interfaceNumber: 1, identitySelector: selector.toLowerCase() }
+      ])
+    ).toBe(currentPath)
+    expect(
+      resolveVcanUsbPath(currentPath.toUpperCase(), 1, () => [
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('migrates a legacy WinUSB path when the channel match is unique', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_6080&MI_01#device`
+    const currentPath = 'libusb://1d50:6080/2/p2.1.3/1'
+
+    expect(
+      resolveVcanUsbPath(legacyPath, 1, () => [
+        { path: 'libusb://1d50:6080/2/p2.1.3/0', interfaceNumber: 0 },
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('does not guess when more than one physical device has the channel', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_6080&MI_00#device`
+
+    expect(() =>
+      resolveVcanUsbPath(legacyPath, 0, () => [
+        { path: 'libusb://1d50:6080/1/p1/0', interfaceNumber: 0 },
+        { path: 'libusb://1d50:6080/2/p2/0', interfaceNumber: 0 }
+      ])
+    ).toThrow(/multiple channel 0 interfaces/)
+  })
+})

--- a/test/docan/vcan_usb/identity.test.ts
+++ b/test/docan/vcan_usb/identity.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+import {
+  formatVcanUsbSerialNumber,
+  getVcanUsbIdentity,
+  isVcanUsbIdentitySelector,
+  makeVcanUsbIdentitySelector
+} from '../../../src/main/docan/vcan_usb/identity'
+
+describe('VCAN USB hardware identity', () => {
+  test('prefers the immutable UUID and formats a stable selector', () => {
+    const identity = getVcanUsbIdentity({
+      uid: [1, 2, 3, 4],
+      uuid: [0x12345678, 0x90abcdef, 0x01020304, 0xaabbccdd]
+    })
+
+    expect(identity).toEqual({
+      kind: 'uuid',
+      value: '1234567890abcdef01020304aabbccdd'
+    })
+    expect(makeVcanUsbIdentitySelector(identity!)).toBe(
+      'vcan-usb://uuid/1234567890abcdef01020304aabbccdd'
+    )
+    expect(formatVcanUsbSerialNumber(identity!)).toBe('UUID:1234567890abcdef01020304aabbccdd')
+  })
+
+  test('falls back to UID when UUID is blank', () => {
+    expect(
+      getVcanUsbIdentity({
+        uid: [1, 2, 3, 4],
+        uuid: [0, 0, 0, 0]
+      })
+    ).toEqual({ kind: 'uid', value: '00000001000000020000000300000004' })
+  })
+
+  test('rejects erased or malformed identities', () => {
+    expect(
+      getVcanUsbIdentity({
+        uid: [0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff],
+        uuid: [0, 0, 0, 0]
+      })
+    ).toBeUndefined()
+    expect(isVcanUsbIdentitySelector('vcan-usb://uuid/not-hex')).toBe(false)
+  })
+})

--- a/test/docan/vcan_usb/native.test.ts
+++ b/test/docan/vcan_usb/native.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { VcanUsbNative } from '../../../src/main/docan/vcan_usb/native'
+
+describe('VCAN USB native API contract', () => {
+  test('loads the native module and returns complete fallback capabilities', () => {
+    const capabilities = VcanUsbNative.fallbackCapabilities()
+
+    expect(capabilities.fdSupported).toBe(true)
+    expect(capabilities.listenOnlySupported).toBe(true)
+    expect(capabilities.nominal.fclk_can).toBe(80_000_000)
+    expect(capabilities.nominal.brp_min).toBe(1)
+    expect(capabilities.nominal.brp_max).toBe(256)
+    expect(capabilities.nominal.brp_inc).toBe(1)
+    expect(capabilities.nominal.tseg1_min).toBe(1)
+    expect(capabilities.nominal.tseg1_max).toBe(128)
+    expect(capabilities.nominal.tseg2_min).toBe(2)
+    expect(capabilities.nominal.tseg2_max).toBe(32)
+    expect(capabilities.data).toMatchObject({
+      tseg1_min: 1,
+      tseg1_max: 30,
+      tseg2_min: 1,
+      tseg2_max: 15,
+      sjw_max: 15,
+      brp_min: 1,
+      brp_max: 32,
+      brp_inc: 1
+    })
+  })
+})

--- a/test/docan/vkgs_usb/devicePath.test.ts
+++ b/test/docan/vkgs_usb/devicePath.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from 'vitest'
+import { resolveVkgsUsbPath } from '../../../src/main/docan/vkgs_usb/devicePath'
+
+describe('VKGS USB device path compatibility', () => {
+  test('resolves a stable UUID selector to the current USB topology', () => {
+    const selector = 'vkgs-usb://uuid/1234567890abcdef01020304aabbccdd'
+    const currentPath = 'libusb://1d50:606f/4/p3.2/1'
+    expect(
+      resolveVkgsUsbPath(selector, 1, () => [
+        {
+          path: currentPath,
+          interfaceNumber: 1,
+          identitySelector: selector
+        }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('rejects duplicate UUID selectors instead of opening an arbitrary adapter', () => {
+    const selector = 'vkgs-usb://uuid/1234567890abcdef01020304aabbccdd'
+    expect(() =>
+      resolveVkgsUsbPath(selector, 0, () => [
+        {
+          path: 'libusb://1d50:606f/1/p1/0',
+          interfaceNumber: 0,
+          identitySelector: selector
+        },
+        {
+          path: 'libusb://1d50:606f/2/p2/0',
+          interfaceNumber: 0,
+          identitySelector: selector
+        }
+      ])
+    ).toThrow(/Multiple VKGS USB devices/)
+  })
+
+  test('keeps a current libusb path when it is still enumerated', () => {
+    const path = 'libusb://1d50:606f/2/p2.1.3/0'
+    const listDevices = vi.fn(() => [{ path, interfaceNumber: 0 }])
+
+    expect(resolveVkgsUsbPath(path, 0, listDevices)).toBe(path)
+    expect(listDevices).toHaveBeenCalledOnce()
+  })
+
+  test('migrates a stale libusb topology path when the channel match is unique', () => {
+    const stalePath = 'libusb://1d50:606f/2/p2.1.3/1'
+    const currentPath = 'libusb://1d50:606f/2/p2.1.4/1'
+
+    expect(
+      resolveVkgsUsbPath(stalePath, 1, () => [
+        { path: 'libusb://1d50:606f/2/p2.1.4/0', interfaceNumber: 0 },
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('accepts selector and libusb scheme casing from older project files', () => {
+    const selector = 'VKGS-USB://UUID/1234567890ABCDEF01020304AABBCCDD'
+    const currentPath = 'libusb://1d50:606f/4/p3.2/1'
+    expect(
+      resolveVkgsUsbPath(selector, 1, () => [
+        { path: currentPath, interfaceNumber: 1, identitySelector: selector.toLowerCase() }
+      ])
+    ).toBe(currentPath)
+    expect(
+      resolveVkgsUsbPath(currentPath.toUpperCase(), 1, () => [
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('does not guess a replacement for a stale path with multiple channel matches', () => {
+    const stalePath = 'libusb://1d50:606f/2/p2.1.3/0'
+
+    expect(() =>
+      resolveVkgsUsbPath(stalePath, 0, () => [
+        { path: 'libusb://1d50:606f/2/p2.1.4/0', interfaceNumber: 0 },
+        { path: 'libusb://1d50:606f/3/p3.2/0', interfaceNumber: 0 }
+      ])
+    ).toThrow(/multiple channel 0 interfaces/)
+  })
+
+  test('migrates a legacy WinUSB path when the channel match is unique', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_606F&MI_01#device`
+    const currentPath = 'libusb://1d50:606f/2/p2.1.3/1'
+
+    expect(
+      resolveVkgsUsbPath(legacyPath, 1, () => [
+        { path: 'libusb://1d50:606f/2/p2.1.3/0', interfaceNumber: 0 },
+        { path: currentPath, interfaceNumber: 1 }
+      ])
+    ).toBe(currentPath)
+  })
+
+  test('does not guess when more than one physical device has the channel', () => {
+    const legacyPath = String.raw`\\?\USB#VID_1D50&PID_606F&MI_00#device`
+
+    expect(() =>
+      resolveVkgsUsbPath(legacyPath, 0, () => [
+        { path: 'libusb://1d50:606f/1/p1/0', interfaceNumber: 0 },
+        { path: 'libusb://1d50:606f/2/p2/0', interfaceNumber: 0 }
+      ])
+    ).toThrow(/multiple channel 0 interfaces/)
+  })
+})

--- a/test/docan/vkgs_usb/identity.test.ts
+++ b/test/docan/vkgs_usb/identity.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+import {
+  formatVkgsUsbSerialNumber,
+  getVkgsUsbIdentity,
+  isVkgsUsbIdentitySelector,
+  makeVkgsUsbIdentitySelector
+} from '../../../src/main/docan/vkgs_usb/identity'
+
+describe('VKGS USB hardware identity', () => {
+  test('prefers the immutable UUID and formats a stable selector', () => {
+    const identity = getVkgsUsbIdentity({
+      uid: [1, 2, 3, 4],
+      uuid: [0x12345678, 0x90abcdef, 0x01020304, 0xaabbccdd]
+    })
+
+    expect(identity).toEqual({
+      kind: 'uuid',
+      value: '1234567890abcdef01020304aabbccdd'
+    })
+    expect(makeVkgsUsbIdentitySelector(identity!)).toBe(
+      'vkgs-usb://uuid/1234567890abcdef01020304aabbccdd'
+    )
+    expect(formatVkgsUsbSerialNumber(identity!)).toBe('UUID:1234567890abcdef01020304aabbccdd')
+  })
+
+  test('falls back to UID when UUID is blank', () => {
+    expect(
+      getVkgsUsbIdentity({
+        uid: [1, 2, 3, 4],
+        uuid: [0, 0, 0, 0]
+      })
+    ).toEqual({ kind: 'uid', value: '00000001000000020000000300000004' })
+  })
+
+  test('rejects erased or malformed identities', () => {
+    expect(
+      getVkgsUsbIdentity({
+        uid: [0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff],
+        uuid: [0, 0, 0, 0]
+      })
+    ).toBeUndefined()
+    expect(isVkgsUsbIdentitySelector('vkgs-usb://uuid/not-hex')).toBe(false)
+  })
+})

--- a/test/docan/vkgs_usb/native.test.ts
+++ b/test/docan/vkgs_usb/native.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { VkgsUsbNative } from '../../../src/main/docan/vkgs_usb/native'
+
+describe('VKGS USB native API contract', () => {
+  test('loads the native module and returns complete fallback capabilities', () => {
+    const capabilities = VkgsUsbNative.fallbackCapabilities()
+
+    expect(capabilities.fdSupported).toBe(true)
+    expect(capabilities.listenOnlySupported).toBe(true)
+    expect(capabilities.nominal.fclk_can).toBe(80_000_000)
+    expect(capabilities.nominal.brp_min).toBe(1)
+    expect(capabilities.nominal.brp_max).toBe(256)
+    expect(capabilities.nominal.brp_inc).toBe(1)
+    expect(capabilities.nominal.tseg1_min).toBe(1)
+    expect(capabilities.nominal.tseg1_max).toBe(128)
+    expect(capabilities.nominal.tseg2_min).toBe(2)
+    expect(capabilities.nominal.tseg2_max).toBe(32)
+    expect(capabilities.data).toMatchObject({
+      tseg1_min: 1,
+      tseg1_max: 30,
+      tseg2_min: 1,
+      tseg2_max: 15,
+      sjw_max: 15,
+      brp_min: 1,
+      brp_max: 32,
+      brp_inc: 1
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add independent `src/main/docan/vcan_usb` and `src/main/docan/vkgs_usb` drivers, with each private protocol and libusb transport encapsulated in its own C++ API layer.
- Add stable UUID/UID device selection, dual-channel support, CAN/CAN FD/BRS/RTR/error/timestamp processing, termination/listen-only controls, and strict bit-timing validation.
- Register both vendors through the existing CAN factory, CLI, and hardware UI, using hardware capability data for timing configuration.

## Mainline impact

- Existing CAN backends and Candle protocol code are unchanged.
- Shared and UI changes are guarded by the `vcan_usb` and `vkgs_usb` vendor types.
- libusb is statically linked into each native module; no runtime libusb DLL or JavaScript USB API is required.
- The two drivers intentionally remain independent to prevent protocol and lifecycle coupling.

## Validation

- Hardware validation completed for VCAN USB and VKGS USB on both channels, including Classic CAN and CAN FD/BRS transmit and receive.
- `npm run docan`
- `npm run test -- --run test/docan/vcan_usb test/docan/vkgs_usb` — 24 tests passed.
- `npm run build`

## Related resources

- [VCAN documentation](http://docs.vseasky.com/projects/vcan/index.html)
- Standalone drivers: [GitHub](https://github.com/vseasky/VCANDrive) / [Gitee](https://gitee.com/vseasky/VCANDrive)
- Companion software: [GitHub](https://github.com/vseasky/NexuTrace) / [Gitee](https://gitee.com/vseasky/NexuTrace)